### PR TITLE
Add decktypes to game_history table

### DIFF
--- a/database_script.sql
+++ b/database_script.sql
@@ -55,6 +55,9 @@ CREATE  TABLE IF NOT EXISTS `gemp-swccg`.`game_history` (
   `winner_deck_name` VARCHAR(255) CHARACTER SET 'utf8' COLLATE 'utf8_bin' NULL DEFAULT NULL ,
   `loser_deck_name` VARCHAR(255) CHARACTER SET 'utf8' COLLATE 'utf8_bin' NULL DEFAULT NULL ,
   `tournament` VARCHAR(255) CHARACTER SET 'utf8' COLLATE 'utf8_bin' NULL DEFAULT NULL ,
+  `winner_deck_archetype` VARCHAR(255) CHARACTER SET 'utf8' COLLATE 'utf8_bin' NULL DEFAULT NULL ,
+  `loser_deck_archetype` VARCHAR(255) CHARACTER SET 'utf8' COLLATE 'utf8_bin' NULL DEFAULT NULL ,
+  `winner_side` VARCHAR(45) CHARACTER SET 'utf8' COLLATE 'utf8_bin' NULL DEFAULT NULL ,
   PRIMARY KEY (`id`) )
 ENGINE = InnoDB
 AUTO_INCREMENT = 71300

--- a/gemp-swccg-server/src/main/java/com/gempukku/swccgo/db/DbGameHistoryDAO.java
+++ b/gemp-swccg-server/src/main/java/com/gempukku/swccgo/db/DbGameHistoryDAO.java
@@ -16,11 +16,11 @@ public class DbGameHistoryDAO implements GameHistoryDAO {
         _dbAccess = dbAccess;
     }
 
-    public void addGameHistory(String winner, String loser, String winReason, String loseReason, String winRecordingId, String loseRecordingId, String formatName, String tournament, String winnerDeckName, String loserDeckName, Date startDate, Date endDate) {
+    public void addGameHistory(String winner, String loser, String winReason, String loseReason, String winRecordingId, String loseRecordingId, String formatName, String tournament, String winnerDeckName, String loserDeckName, String winnerDeckArchetype, String loserDeckArchetype, String winnerSide, Date startDate, Date endDate) {
         try {
             Connection connection = _dbAccess.getDataSource().getConnection();
             try {
-                PreparedStatement statement = connection.prepareStatement("insert into game_history (winner, loser, win_reason, lose_reason, win_recording_id, lose_recording_id, format_name, tournament, winner_deck_name, loser_deck_name, start_date, end_date) values (?,?,?,?,?,?,?,?,?,?,?,?)");
+                PreparedStatement statement = connection.prepareStatement("insert into game_history (winner, loser, win_reason, lose_reason, win_recording_id, lose_recording_id, format_name, tournament, winner_deck_name, loser_deck_name, winner_deck_archetype, loser_deck_archetype, winner_side, start_date, end_date) values (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)");
                 try {
                     statement.setString(1, winner);
                     statement.setString(2, loser);
@@ -32,8 +32,11 @@ public class DbGameHistoryDAO implements GameHistoryDAO {
                     statement.setString(8, tournament);
                     statement.setString(9, winnerDeckName);
                     statement.setString(10, loserDeckName);
-                    statement.setLong(11, startDate.getTime());
-                    statement.setLong(12, endDate.getTime());
+                    statement.setString(11, winnerDeckArchetype);
+                    statement.setString(12, loserDeckArchetype);
+                    statement.setString(13, winnerSide);
+                    statement.setLong(14, startDate.getTime());
+                    statement.setLong(15, endDate.getTime());
 
                     statement.execute();
                 } finally {

--- a/gemp-swccg-server/src/main/java/com/gempukku/swccgo/db/DbGameHistoryDAO.java
+++ b/gemp-swccg-server/src/main/java/com/gempukku/swccgo/db/DbGameHistoryDAO.java
@@ -32,8 +32,8 @@ public class DbGameHistoryDAO implements GameHistoryDAO {
                     statement.setString(8, tournament);
                     statement.setString(9, winnerDeckName);
                     statement.setString(10, loserDeckName);
-                    statement.setString(11, winnerDeckArchetype);
-                    statement.setString(12, loserDeckArchetype);
+                    statement.setString(11, (winnerDeckArchetype==null?"":winnerDeckArchetype));
+                    statement.setString(12, (loserDeckArchetype==null?"":loserDeckArchetype));
                     statement.setString(13, winnerSide);
                     statement.setLong(14, startDate.getTime());
                     statement.setLong(15, endDate.getTime());

--- a/gemp-swccg-server/src/main/java/com/gempukku/swccgo/db/GameHistoryDAO.java
+++ b/gemp-swccg-server/src/main/java/com/gempukku/swccgo/db/GameHistoryDAO.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Map;
 
 public interface GameHistoryDAO {
-    public void addGameHistory(String winner, String loser, String winReason, String loseReason, String winRecordingId, String loseRecordingId, String formatName, String tournament, String winnerDeckName, String loserDeckName, Date startDate, Date endDate);
+    public void addGameHistory(String winner, String loser, String winReason, String loseReason, String winRecordingId, String loseRecordingId, String formatName, String tournament, String winnerDeckName, String loserDeckName, String winnerDeckArchetype, String loserDeckArchetype, String winningSide, Date startDate, Date endDate);
 
     public List<GameHistoryEntry> getGameHistoryForPlayer(Player player, int start, int count);
 

--- a/gemp-swccg-server/src/main/java/com/gempukku/swccgo/game/GameHistoryService.java
+++ b/gemp-swccg-server/src/main/java/com/gempukku/swccgo/game/GameHistoryService.java
@@ -17,8 +17,8 @@ public class GameHistoryService {
         _gameHistoryDAO = gameHistoryDAO;
     }
 
-    public void addGameHistory(String winner, String loser, String winReason, String loseReason, String winRecordingId, String loseRecordingId, String formatName, String tournament, String winnerDeckName, String loserDeckName, Date startDate, Date endDate) {
-        _gameHistoryDAO.addGameHistory(winner, loser, winReason, loseReason, winRecordingId, loseRecordingId, formatName, tournament, winnerDeckName, loserDeckName, startDate, endDate);
+    public void addGameHistory(String winner, String loser, String winReason, String loseReason, String winRecordingId, String loseRecordingId, String formatName, String tournament, String winnerDeckName, String loserDeckName, String winnerDeckArchetype, String loserDeckArchetype, String winningSide, Date startDate, Date endDate) {
+        _gameHistoryDAO.addGameHistory(winner, loser, winReason, loseReason, winRecordingId, loseRecordingId, formatName, tournament, winnerDeckName, loserDeckName, winnerDeckArchetype, loserDeckArchetype, winningSide, startDate, endDate);
         Integer winnerCount = _playerGameCount.get(winner);
         Integer loserCount = _playerGameCount.get(loser);
         if (winnerCount != null)

--- a/gemp-swccg-server/src/main/java/com/gempukku/swccgo/game/GameRecorder.java
+++ b/gemp-swccg-server/src/main/java/com/gempukku/swccgo/game/GameRecorder.java
@@ -62,7 +62,7 @@ public class GameRecorder {
             @Override
             public void finishRecording(String winner, String winReason, String loser, String loseReason) {
                 Map<String, String> playerRecordingId = saveRecordedChannels(recordingChannels);
-                _gameHistoryService.addGameHistory(winner, loser, winReason, loseReason, playerRecordingId.get(winner), playerRecordingId.get(loser), formatName, tournament, deckNames.get(winner), deckNames.get(loser), startData, new Date());
+                _gameHistoryService.addGameHistory(winner, loser, winReason, loseReason, playerRecordingId.get(winner), playerRecordingId.get(loser), formatName, tournament, deckNames.get(winner), deckNames.get(loser), swccgo.getDeckArchetypeLabel(winner), swccgo.getDeckArchetypeLabel(loser), **WINNINGSIDE**, startData, new Date());
             }
         };
     }

--- a/gemp-swccg-server/src/main/java/com/gempukku/swccgo/game/GameRecorder.java
+++ b/gemp-swccg-server/src/main/java/com/gempukku/swccgo/game/GameRecorder.java
@@ -62,7 +62,7 @@ public class GameRecorder {
             @Override
             public void finishRecording(String winner, String winReason, String loser, String loseReason) {
                 Map<String, String> playerRecordingId = saveRecordedChannels(recordingChannels);
-                _gameHistoryService.addGameHistory(winner, loser, winReason, loseReason, playerRecordingId.get(winner), playerRecordingId.get(loser), formatName, tournament, deckNames.get(winner), deckNames.get(loser), swccgo.getDeckArchetypeLabel(winner), swccgo.getDeckArchetypeLabel(loser), **WINNINGSIDE**, startData, new Date());
+                _gameHistoryService.addGameHistory(winner, loser, winReason, loseReason, playerRecordingId.get(winner), playerRecordingId.get(loser), formatName, tournament, deckNames.get(winner), deckNames.get(loser), swccgo.getDeckArchetypeLabel(winner), swccgo.getDeckArchetypeLabel(loser), swccg.getWinningSide().getHumanReadable(), startData, new Date());
             }
         };
     }

--- a/gemp-swccg-server/src/main/java/com/gempukku/swccgo/game/GameRecorder.java
+++ b/gemp-swccg-server/src/main/java/com/gempukku/swccgo/game/GameRecorder.java
@@ -1,6 +1,7 @@
 package com.gempukku.swccgo.game;
 
 import com.gempukku.swccgo.common.ApplicationConfiguration;
+import com.gempukku.swccgo.common.Side;
 import com.gempukku.swccgo.game.state.EventSerializer;
 import com.gempukku.swccgo.game.state.GameCommunicationChannel;
 import com.gempukku.swccgo.game.state.GameEvent;

--- a/gemp-swccg-server/src/main/java/com/gempukku/swccgo/game/GameRecorder.java
+++ b/gemp-swccg-server/src/main/java/com/gempukku/swccgo/game/GameRecorder.java
@@ -62,7 +62,7 @@ public class GameRecorder {
             @Override
             public void finishRecording(String winner, String winReason, String loser, String loseReason) {
                 Map<String, String> playerRecordingId = saveRecordedChannels(recordingChannels);
-                _gameHistoryService.addGameHistory(winner, loser, winReason, loseReason, playerRecordingId.get(winner), playerRecordingId.get(loser), formatName, tournament, deckNames.get(winner), deckNames.get(loser), swccgo.getDeckArchetypeLabel(winner), swccgo.getDeckArchetypeLabel(loser), swccg.getWinningSide().getHumanReadable(), startData, new Date());
+                _gameHistoryService.addGameHistory(winner, loser, winReason, loseReason, playerRecordingId.get(winner), playerRecordingId.get(loser), formatName, tournament, deckNames.get(winner), deckNames.get(loser), swccgo.getDeckArchetypeLabel(winner), swccgo.getDeckArchetypeLabel(loser), swccgo.getWinningSide().getHumanReadable(), startData, new Date());
             }
         };
     }

--- a/gemp-swccg-server/src/main/java/com/gempukku/swccgo/game/SwccgGameMediator.java
+++ b/gemp-swccg-server/src/main/java/com/gempukku/swccgo/game/SwccgGameMediator.java
@@ -125,6 +125,10 @@ public class SwccgGameMediator {
     public String getWinner() {
         return _swccgoGame.getWinner();
     }
+    
+    public Side getWinningSide() {
+        return _swccgoGame.getSide(_swccgoGame.getWinner());
+    }
 
     public List<SwccgGameParticipant> getPlayersPlaying() {
         return new LinkedList<SwccgGameParticipant>(_playersPlaying);


### PR DESCRIPTION
Since the table already exists, the three columns probably need to be added manually in the database. Something like

ALTER TABLE `gemp-swccg`.`game_history`
ADD  `winner_deck_archetype` VARCHAR(255) CHARACTER SET 'utf8' COLLATE 'utf8_bin' NULL DEFAULT NULL ,
  `loser_deck_archetype` VARCHAR(255) CHARACTER SET 'utf8' COLLATE 'utf8_bin' NULL DEFAULT NULL ,
  `winner_side` VARCHAR(45) CHARACTER SET 'utf8' COLLATE 'utf8_bin' NULL DEFAULT NULL;
