### PR TITLE
Bug fix - He's All Yours, Bounty Hunter non-V cannot transfer

### DIFF
--- a/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
+++ b/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
@@ -11311,14 +11311,14 @@ public class Filters {
                 PhysicalCard source = gameState.findCardByPermanentId(permSourceCardId);
 
                 // New escort needs to be able to move to transfer captive
-                if (!modifiersQuerying.mayNotBeTransferred(gameState, physicalCard)) {
+                if (!modifiersQuerying.mayNotMove(gameState, physicalCard)) {
                     for (PhysicalCard escort : Filters.filterActive(gameState.getGame(), source, Filters.escort())) {
                         // Old escort needs to be able to move to transfer captive
                         if (!modifiersQuerying.mayNotMove(gameState, escort)) {
                             Collection<PhysicalCard> captives = gameState.getCaptivesOfEscort(escort);
                             for (PhysicalCard captive : captives) {
                                 // Captive needs to be able to move to transfer
-                                if (!modifiersQuerying.mayNotMove(gameState, captive)) {
+                                if (!modifiersQuerying.mayNotMove(gameState, captive)&&!modifiersQuerying.mayNotBeTransferred(gameState, captive)) {
                                     if (Filters.and(Filters.canEscortCaptive(captive), Filters.presentWith(escort)).accepts(gameState, modifiersQuerying, physicalCard)) {
                                         return true;
                                     }


### PR DESCRIPTION
The filter this uses was checking if the potential escort couldn't be transferred, not if it couldn't move