### PR TITLE
Fix for HCF/HCFv and Protector

### DIFF
--- a/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set13/light/Card13_021.java
+++ b/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set13/light/Card13_021.java
@@ -28,7 +28,7 @@ public class Card13_021 extends AbstractStarfighter {
         setComboCard(true);
         setLore("Although temperamental, this trusty hunk of junk always seems to perform for its proud owner and his Wookiee co-pilot when needed the most.");
         setGameText("Permanent pilots are •Han and •Chewie: provide ability of 5, add one battle destiny, and add 5 to power. Immune to attrition < 6, Come With Me, and Lateral Damage. End of your turn: Use 3 Force to maintain OR Place out of play.");
-        addPersona(Persona.FALCON);
+        addPersonas(Persona.FALCON,Persona.HAN,Persona.CHEWIE);
         addIcons(Icon.REFLECTIONS_III, Icon.NAV_COMPUTER, Icon.SCOMP_LINK, Icon.MAINTENANCE);
         addIcon(Icon.PILOT, 2);
         addModelType(ModelType.HEAVILY_MODIFIED_LIGHT_FREIGHTER);

--- a/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set205/light/Card205_007.java
+++ b/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set205/light/Card205_007.java
@@ -29,7 +29,7 @@ public class Card205_007 extends AbstractStarfighter {
         setComboCard(true);
         setLore("Although temperamental, this trusty hunk of junk always seems to perform for its proud owner and his Wookiee co-pilot when needed the most.");
         setGameText("May add 2 passengers. Permanent pilots are •Han and •Chewie, who provide ability of 5. If in battle, add one destiny to total power. Immune to Come With Me, Life Debt and attrition < 5.");
-        addPersona(Persona.FALCON);
+        addPersonas(Persona.FALCON, Persona.HAN,Persona.CHEWIE);
         addIcons(Icon.REFLECTIONS_III, Icon.NAV_COMPUTER, Icon.SCOMP_LINK, Icon.VIRTUAL_SET_5);
         addIcon(Icon.PILOT, 2);
         setPassengerCapacity(2);


### PR DESCRIPTION
Adds Han and Chewie personas to HCF/HCFv while card is in hand so that Protector can be used with HCF/HCFv