### PR TITLE
Fix fresh dev env stand up

### DIFF
--- a/vagrant-build/bootstrap.sh
+++ b/vagrant-build/bootstrap.sh
@@ -4,7 +4,7 @@
 #   Install dependencies
 # -----------------------------------------
 
-sudo yum -y install unzip vim dos2unix git
+sudo yum -y install unzip vim dos2unix git wget
 sudo yum -y install mysql mariadb-server
 sudo yum -y install java-1.8.0-openjdk-devel
 


### PR DESCRIPTION
Fixes #195 

Ensure the `wget` command is available in the `bento/centos-7` box, as it's used to download maven later in the provision flow.