### PR TITLE
Blown away location titles

### DIFF
--- a/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
+++ b/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
@@ -761,7 +761,7 @@ public class Filters {
             @Override
             public boolean accepts(GameState gameState, ModifiersQuerying modifiersQuerying, PhysicalCard physicalCard) {
                 for (String cardTitle : physicalCard.getTitles()) {
-                    if (cardTitle.equalsIgnoreCase(title)) {
+                    if (cardTitle.equalsIgnoreCase(title) && !physicalCard.isBlownAway()) {
                         return true;
                     }
                 }


### PR DESCRIPTION
The AR says a blown away location "is considered an unnamed location (i.e. a blown away Alderaan cannot have Haven deployed on it)". This PR changes the title filter to ignore titles from blown away locations. This corrects a few things, including the bug reported where you can use Target The Main Generator on a blown away Main Power Generators.
Closes #272