### PR TITLE
Bug fix: Han Solo

### DIFF
--- a/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_011.java
+++ b/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_011.java
@@ -59,7 +59,7 @@ public class Card1_011 extends AbstractRebel {
 
         // Check condition(s)
         if (TriggerConditions.isDestinyJustDrawnBy(game, effectResult, playerId)
-                && GameConditions.isOncePerBattle(game, self, playerId, gameTextSourceCardId)
+                && GameConditions.isOncePerBattle(game, self, playerId, gameTextSourceCardId, gameTextActionId)
                 && GameConditions.isInBattle(game, self)
                 && GameConditions.canUseForce(game, playerId, 1)
                 && GameConditions.canCancelDestinyAndCauseRedraw(game, playerId)) {


### PR DESCRIPTION
His once per battle redraw ability was highlighting multiple times after being used even though the action would fail if you attempted it more than once
Closes #274 