### PR TITLE
Fixing Issue#38 - 'Concentrate All Fire' & 'Fighter Cover' Now only apply the +3 power bonus to a ship that's fired a weapon once per battle

### DIFF
--- a/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set9/dark/Card9_093.java
+++ b/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set9/dark/Card9_093.java
@@ -23,6 +23,7 @@ import com.gempukku.swccgo.logic.timing.EffectResult;
 import com.gempukku.swccgo.logic.timing.results.FiredWeaponResult;
 
 import java.util.Collections;
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -45,6 +46,14 @@ public class Card9_093 extends AbstractAdmiralsOrder {
         // Check condition(s)
         if (TriggerConditions.weaponJustFiredBy(game, effectResult, Filters.weapon, Filters.and(Filters.starfighter, Filters.participatingInBattle))) {
             final PhysicalCard cardFiringWeapon = ((FiredWeaponResult) effectResult).getCardFiringWeapon();
+
+            // We only apply this effect if it hasn't already happened for this ship this battle
+            for (Modifier modifier: game.getModifiersQuerying().getModifiersAffecting(game.getGameState(), cardFiringWeapon)) {
+                PhysicalCard thisCard = modifier.getSource(game.getGameState());
+                if (thisCard == self) {
+                    return null;
+                }
+            }
 
             final RequiredGameTextTriggerAction action = new RequiredGameTextTriggerAction(self, gameTextSourceCardId, gameTextActionId);
             action.setText("Add 3 to power of " + GameUtils.getFullName(cardFiringWeapon));

--- a/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set9/dark/Card9_093.java
+++ b/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set9/dark/Card9_093.java
@@ -48,8 +48,7 @@ public class Card9_093 extends AbstractAdmiralsOrder {
 
             // We only apply this effect if it hasn't already happened for this ship this battle
             for (Modifier modifier: game.getModifiersQuerying().getModifiersAffecting(game.getGameState(), cardFiringWeapon)) {
-                PhysicalCard thisCard = modifier.getSource(game.getGameState());
-                if (thisCard == self) {
+                if (modifier.getSource(game.getGameState()) == self) {
                     return null;
                 }
             }

--- a/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set9/dark/Card9_093.java
+++ b/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set9/dark/Card9_093.java
@@ -23,7 +23,6 @@ import com.gempukku.swccgo.logic.timing.EffectResult;
 import com.gempukku.swccgo.logic.timing.results.FiredWeaponResult;
 
 import java.util.Collections;
-import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 

--- a/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set9/light/Card9_003.java
+++ b/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set9/light/Card9_003.java
@@ -46,6 +46,14 @@ public class Card9_003 extends AbstractAdmiralsOrder {
         if (TriggerConditions.weaponJustFiredBy(game, effectResult, Filters.weapon, Filters.and(Filters.starfighter, Filters.participatingInBattle))) {
             final PhysicalCard cardFiringWeapon = ((FiredWeaponResult) effectResult).getCardFiringWeapon();
 
+            // We only apply this effect if it hasn't already happened for this ship this battle
+            for (Modifier modifier: game.getModifiersQuerying().getModifiersAffecting(game.getGameState(), cardFiringWeapon)) {
+                PhysicalCard thisCard = modifier.getSource(game.getGameState());
+                if (thisCard == self) {
+                    return null;
+                }
+            }
+
             final RequiredGameTextTriggerAction action = new RequiredGameTextTriggerAction(self, gameTextSourceCardId, gameTextActionId);
             action.setText("Add 3 to power of " + GameUtils.getFullName(cardFiringWeapon));
             action.setActionMsg("Add 3 to power of " + GameUtils.getCardLink(cardFiringWeapon));

--- a/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set9/light/Card9_003.java
+++ b/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set9/light/Card9_003.java
@@ -48,8 +48,7 @@ public class Card9_003 extends AbstractAdmiralsOrder {
 
             // We only apply this effect if it hasn't already happened for this ship this battle
             for (Modifier modifier: game.getModifiersQuerying().getModifiersAffecting(game.getGameState(), cardFiringWeapon)) {
-                PhysicalCard thisCard = modifier.getSource(game.getGameState());
-                if (thisCard == self) {
+               if (modifier.getSource(game.getGameState()) == self) {
                     return null;
                 }
             }


### PR DESCRIPTION
Raised in Issue #38 , corrected for both 'Concentrate All Fire' & 'Fighter Cover'. Both cards now check if the ship firing the weapon already has power modifier supplied by the Admiral's Order, and does not trigger if said modifier exists.
Closes #38 
Closes #46 