### PR TITLE
Standardization of the "ionization" state on starships & astromech droids that can repair it.

### DIFF
--- a/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/dark/Card2_101.java
+++ b/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/dark/Card2_101.java
@@ -13,7 +13,6 @@ import com.gempukku.swccgo.logic.actions.PlayInterruptAction;
 import com.gempukku.swccgo.logic.actions.TopLevelGameTextAction;
 import com.gempukku.swccgo.logic.conditions.Condition;
 import com.gempukku.swccgo.logic.effects.DeionizeStarshipEffect;
-import com.gempukku.swccgo.logic.effects.RestoreArmorManeuverHyperspeedToNormalEffect;
 import com.gempukku.swccgo.logic.modifiers.*;
 
 import java.util.Collections;

--- a/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/dark/Card2_101.java
+++ b/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/dark/Card2_101.java
@@ -1,0 +1,70 @@
+package com.gempukku.swccgo.cards.set2.dark;
+
+import com.gempukku.swccgo.cards.AbstractDroid;
+import com.gempukku.swccgo.cards.GameConditions;
+import com.gempukku.swccgo.cards.conditions.AboardCondition;
+import com.gempukku.swccgo.cards.effects.usage.OncePerPhaseEffect;
+import com.gempukku.swccgo.common.*;
+import com.gempukku.swccgo.filters.Filter;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.logic.actions.PlayInterruptAction;
+import com.gempukku.swccgo.logic.actions.TopLevelGameTextAction;
+import com.gempukku.swccgo.logic.conditions.Condition;
+import com.gempukku.swccgo.logic.effects.DeionizeStarshipEffect;
+import com.gempukku.swccgo.logic.effects.RestoreArmorManeuverHyperspeedToNormalEffect;
+import com.gempukku.swccgo.logic.modifiers.*;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Set: A New Hope
+ * Type: Character
+ * Subtype: Droid
+ * Title: R5-A2 (Arfive-Aytoo)
+ */
+public class Card2_101 extends AbstractDroid {
+    public Card2_101() {
+        super(Side.DARK, 4, 2, 1, 3, "R5-A2 (Arfive-Aytoo)");
+        setLore("Seldom used for navigation purposes, R5 units are known for their ability to perform hull maintenance and repair damage caused by ionization.");
+        setGameText("While aboard any starship, adds 1 to power and maneuver. During your control phase, if aboard your starship damaged by an Ion cannon, restores armor/maneuver and hyperspeed.");
+        addModelType(ModelType.ASTROMECH);
+        addIcons(Icon.A_NEW_HOPE);
+    }
+
+    @Override
+    protected List<Modifier> getGameTextWhileActiveInPlayModifiers(SwccgGame game, final PhysicalCard self) {
+        Condition aboardStarship = new AboardCondition(self, Filters.starship);
+        Filter starshipAboard = Filters.and(Filters.starship, Filters.hasAboard(self));
+
+        List<Modifier> modifiers = new LinkedList<Modifier>();
+        modifiers.add(new PowerModifier(self, starshipAboard, aboardStarship, 1));
+        modifiers.add(new ManeuverModifier(self, starshipAboard, aboardStarship, 1));
+        return modifiers;
+    }
+
+    @Override
+    protected List<TopLevelGameTextAction> getGameTextTopLevelActions(final String playerId, SwccgGame game, final PhysicalCard self, int gameTextSourceCardId) {
+        List<PlayInterruptAction> actions = new LinkedList<PlayInterruptAction>();
+        // Check condition(s)
+        if (GameConditions.isOnceDuringYourPhase(game, self, playerId, gameTextSourceCardId, Phase.CONTROL)
+                && GameConditions.isAboard(game, self, Filters.and(Filters.or(Filters.starship_defense_ionized,Filters.starship_hyperspeed_ionized), Filters.your(self)))){
+
+            PhysicalCard starship = Filters.findFirstActive(game, self, Filters.and(Filters.or(Filters.starship_defense_ionized,Filters.starship_hyperspeed_ionized), Filters.your(self), Filters.hasAboard(self)));
+            if (starship != null) {
+                final TopLevelGameTextAction action = new TopLevelGameTextAction(self, gameTextSourceCardId);
+                action.setText("Restore armor/maneuver and hyperspeed");
+                // Update usage limit(s)
+                action.appendUsage(
+                        new OncePerPhaseEffect(action));
+                action.appendEffect(
+                        new DeionizeStarshipEffect(action, starship, false, true, true));
+                return Collections.singletonList(action);
+            }
+        }
+        return null;
+    }
+}

--- a/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/dark/Card2_101.java
+++ b/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/dark/Card2_101.java
@@ -9,11 +9,14 @@ import com.gempukku.swccgo.filters.Filter;
 import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.logic.TriggerConditions;
 import com.gempukku.swccgo.logic.actions.PlayInterruptAction;
+import com.gempukku.swccgo.logic.actions.RequiredGameTextTriggerAction;
 import com.gempukku.swccgo.logic.actions.TopLevelGameTextAction;
 import com.gempukku.swccgo.logic.conditions.Condition;
 import com.gempukku.swccgo.logic.effects.DeionizeStarshipEffect;
 import com.gempukku.swccgo.logic.modifiers.*;
+import com.gempukku.swccgo.logic.timing.EffectResult;
 
 import java.util.Collections;
 import java.util.LinkedList;
@@ -46,19 +49,21 @@ public class Card2_101 extends AbstractDroid {
     }
 
     @Override
-    protected List<TopLevelGameTextAction> getGameTextTopLevelActions(final String playerId, SwccgGame game, final PhysicalCard self, int gameTextSourceCardId) {
-        List<PlayInterruptAction> actions = new LinkedList<PlayInterruptAction>();
+    protected List<RequiredGameTextTriggerAction> getGameTextRequiredAfterTriggers(SwccgGame game, EffectResult effectResult, PhysicalCard self, int gameTextSourceCardId) {
+        String playerId = self.getOwner();
+        GameTextActionId gameTextActionId = GameTextActionId.OTHER_CARD_ACTION_2;
         // Check condition(s)
-        if (GameConditions.isOnceDuringYourPhase(game, self, playerId, gameTextSourceCardId, Phase.CONTROL)
-                && GameConditions.isAboard(game, self, Filters.and(Filters.or(Filters.starship_defense_ionized,Filters.starship_hyperspeed_ionized), Filters.your(self)))){
+        // Check if reached end of each control phase and action was not performed yet.
+        // Check if this card is aboard a ship that has been ionized
+        if (TriggerConditions.isEndOfYourPhase(game, effectResult, Phase.CONTROL, playerId)
+                && GameConditions.isOnceDuringYourPhase(game, self, playerId, gameTextSourceCardId, gameTextActionId, Phase.CONTROL)
+                && GameConditions.isAboard(game, self, Filters.and(Filters.or(Filters.starship_defense_ionized,Filters.starship_hyperspeed_ionized), Filters.your(self))) ) {
 
             PhysicalCard starship = Filters.findFirstActive(game, self, Filters.and(Filters.or(Filters.starship_defense_ionized,Filters.starship_hyperspeed_ionized), Filters.your(self), Filters.hasAboard(self)));
             if (starship != null) {
-                final TopLevelGameTextAction action = new TopLevelGameTextAction(self, gameTextSourceCardId);
+                final RequiredGameTextTriggerAction action = new RequiredGameTextTriggerAction(self, gameTextSourceCardId, gameTextActionId);
                 action.setText("Restore armor/maneuver and hyperspeed");
-                // Update usage limit(s)
-                action.appendUsage(
-                        new OncePerPhaseEffect(action));
+                // Perform result(s)
                 action.appendEffect(
                         new DeionizeStarshipEffect(action, starship, false, true, true));
                 return Collections.singletonList(action);

--- a/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/light/Card2_015.java
+++ b/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/light/Card2_015.java
@@ -13,7 +13,6 @@ import com.gempukku.swccgo.logic.actions.PlayInterruptAction;
 import com.gempukku.swccgo.logic.actions.TopLevelGameTextAction;
 import com.gempukku.swccgo.logic.conditions.Condition;
 import com.gempukku.swccgo.logic.effects.DeionizeStarshipEffect;
-import com.gempukku.swccgo.logic.effects.RestoreArmorManeuverHyperspeedToNormalEffect;
 import com.gempukku.swccgo.logic.modifiers.*;
 
 import java.util.Collections;

--- a/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/light/Card2_015.java
+++ b/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/light/Card2_015.java
@@ -1,0 +1,70 @@
+package com.gempukku.swccgo.cards.set2.light;
+
+import com.gempukku.swccgo.cards.AbstractDroid;
+import com.gempukku.swccgo.cards.GameConditions;
+import com.gempukku.swccgo.cards.conditions.AboardCondition;
+import com.gempukku.swccgo.cards.effects.usage.OncePerPhaseEffect;
+import com.gempukku.swccgo.common.*;
+import com.gempukku.swccgo.filters.Filter;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.logic.actions.PlayInterruptAction;
+import com.gempukku.swccgo.logic.actions.TopLevelGameTextAction;
+import com.gempukku.swccgo.logic.conditions.Condition;
+import com.gempukku.swccgo.logic.effects.DeionizeStarshipEffect;
+import com.gempukku.swccgo.logic.effects.RestoreArmorManeuverHyperspeedToNormalEffect;
+import com.gempukku.swccgo.logic.modifiers.*;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Set: A New Hope
+ * Type: Character
+ * Subtype: Droid
+ * Title: R5-D4 (Arfive-Defour)
+ */
+public class Card2_015 extends AbstractDroid {
+    public Card2_015() {
+        super(Side.LIGHT, 4, 2, 1, 3, "R5-D4 (Arfive-Defour)");
+        setLore("Cheap astromech droid commonly referred to as 'Red'. Purposely blew his motivator to prevent splitting up R2-D2 and C-3PO on Tatooine. Poor navigator but skilled mechanic.");
+        setGameText("While aboard any starship, adds 1 to power and maneuver. During your control phase, if aboard your starship damaged by an Ion cannon, restores armor/maneuver and hyperspeed.");
+        addModelType(ModelType.ASTROMECH);
+        addIcons(Icon.A_NEW_HOPE);
+    }
+
+    @Override
+    protected List<Modifier> getGameTextWhileActiveInPlayModifiers(SwccgGame game, final PhysicalCard self) {
+        Condition aboardStarship = new AboardCondition(self, Filters.starship);
+        Filter starshipAboard = Filters.and(Filters.starship, Filters.hasAboard(self));
+
+        List<Modifier> modifiers = new LinkedList<Modifier>();
+        modifiers.add(new PowerModifier(self, starshipAboard, aboardStarship, 1));
+        modifiers.add(new ManeuverModifier(self, starshipAboard, aboardStarship, 1));
+        return modifiers;
+    }
+
+    @Override
+    protected List<TopLevelGameTextAction> getGameTextTopLevelActions(final String playerId, SwccgGame game, final PhysicalCard self, int gameTextSourceCardId) {
+        List<PlayInterruptAction> actions = new LinkedList<PlayInterruptAction>();
+        // Check condition(s)
+        if (GameConditions.isOnceDuringYourPhase(game, self, playerId, gameTextSourceCardId, Phase.CONTROL)
+                && GameConditions.isAboard(game, self, Filters.and(Filters.or(Filters.starship_defense_ionized,Filters.starship_hyperspeed_ionized), Filters.your(self)))){
+
+            PhysicalCard starship = Filters.findFirstActive(game, self, Filters.and(Filters.or(Filters.starship_defense_ionized,Filters.starship_hyperspeed_ionized), Filters.your(self), Filters.hasAboard(self)));
+            if (starship != null) {
+                final TopLevelGameTextAction action = new TopLevelGameTextAction(self, gameTextSourceCardId);
+                action.setText("Restore armor/maneuver and hyperspeed");
+                // Update usage limit(s)
+                action.appendUsage(
+                        new OncePerPhaseEffect(action));
+                action.appendEffect(
+                        new DeionizeStarshipEffect(action, starship, false, true, true));
+                return Collections.singletonList(action);
+            }
+        }
+        return null;
+    }
+}

--- a/gemp-swccg-common/src/main/java/com/gempukku/swccgo/common/IonizationType.java
+++ b/gemp-swccg-common/src/main/java/com/gempukku/swccgo/common/IonizationType.java
@@ -1,0 +1,10 @@
+package com.gempukku.swccgo.common;
+
+/**
+ * Represents the different types of starship ionization that can exist.
+ */
+public enum IonizationType {
+    POWER_IONIZED,
+    DEFENSE_IONIZED,
+    HYPERSPEED_IONIZED
+}

--- a/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
+++ b/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
@@ -10896,6 +10896,22 @@ public class Filters {
     }
 
     /**
+     * Filter that accepts cards that are 'ionized' (hit by an Ion Cannon).
+     */
+    public static final Filter ionized = new Filter() {
+        @Override
+        public boolean accepts(GameState gameState, ModifiersQuerying modifiersQuerying, PhysicalCard physicalCard) {
+            return physicalCard.isIonized();
+        }
+    };
+    /**
+     * Wrapper method to allow other static filters to access the wrapped filter.
+     */
+    private static Filter ionized() {
+        return ionized;
+    }
+
+    /**
      * Filter that accepts cards that are 'collapsed'.
      */
     public static final Filter collapsed = new Filter() {
@@ -17761,6 +17777,7 @@ public class Filters {
     public static final Filter Insignificant_Rebellion = Filters.title(Title.Insignificant_Rebellion);
     public static final Filter ion_cannon = Filters.keyword(Keyword.ION_CANNON);
     public static final Filter Ion_Cannon = Filters.title(Title.Ion_Cannon);
+    public static final Filter ionized_starship = Filters.and(CardCategory.STARSHIP, Filters.ionized());
     public static final Filter inquisitor = Filters.keyword(Keyword.INQUISITOR);
     public static final Filter Irol = Filters.title(Title.Irol);
     public static final Filter ISB_agent = Filters.keyword(Keyword.ISB_AGENT);

--- a/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
+++ b/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
@@ -10896,20 +10896,53 @@ public class Filters {
     }
 
     /**
-     * Filter that accepts cards that are 'ionized' (hit by an Ion Cannon).
+     * Filter that accepts cards whose power is 'ionized' (was hit by an Ion Cannon).
      */
-    public static final Filter ionized = new Filter() {
+    public static final Filter powerIonized = new Filter() {
         @Override
         public boolean accepts(GameState gameState, ModifiersQuerying modifiersQuerying, PhysicalCard physicalCard) {
-            return physicalCard.isIonized();
+            return physicalCard.getIonization().contains(IonizationType.POWER_IONIZED);
         }
     };
     /**
      * Wrapper method to allow other static filters to access the wrapped filter.
      */
-    private static Filter ionized() {
-        return ionized;
+    private static Filter powerIonized() {
+        return powerIonized;
     }
+
+    /**
+     * Filter that accepts cards whose defense is 'ionized' (was hit by an Ion Cannon).
+     */
+    public static final Filter defenseIonized = new Filter() {
+        @Override
+        public boolean accepts(GameState gameState, ModifiersQuerying modifiersQuerying, PhysicalCard physicalCard) {
+            return physicalCard.getIonization().contains(IonizationType.DEFENSE_IONIZED);
+        }
+    };
+    /**
+     * Wrapper method to allow other static filters to access the wrapped filter.
+     */
+    private static Filter defenseIonized() {
+        return defenseIonized;
+    }
+
+    /**
+     * Filter that accepts cards whose hyperspeed is 'ionized' (was hit by an Ion Cannon).
+     */
+    public static final Filter hyperspeedIonized = new Filter() {
+        @Override
+        public boolean accepts(GameState gameState, ModifiersQuerying modifiersQuerying, PhysicalCard physicalCard) {
+            return physicalCard.getIonization().contains(IonizationType.HYPERSPEED_IONIZED);
+        }
+    };
+    /**
+     * Wrapper method to allow other static filters to access the wrapped filter.
+     */
+    private static Filter hyperspeedIonized() {
+        return hyperspeedIonized;
+    }
+
 
     /**
      * Filter that accepts cards that are 'collapsed'.
@@ -17777,7 +17810,7 @@ public class Filters {
     public static final Filter Insignificant_Rebellion = Filters.title(Title.Insignificant_Rebellion);
     public static final Filter ion_cannon = Filters.keyword(Keyword.ION_CANNON);
     public static final Filter Ion_Cannon = Filters.title(Title.Ion_Cannon);
-    public static final Filter ionized_starship = Filters.and(CardCategory.STARSHIP, Filters.ionized());
+
     public static final Filter inquisitor = Filters.keyword(Keyword.INQUISITOR);
     public static final Filter Irol = Filters.title(Title.Irol);
     public static final Filter ISB_agent = Filters.keyword(Keyword.ISB_AGENT);
@@ -18379,6 +18412,9 @@ public class Filters {
     public static final Filter Starkiller_Base_location = Filters.partOfSystem(Title.Starkiller_Base);
     public static final Filter starship = Filters.type(CardType.STARSHIP);
     public static final Filter starship_cannon = Filters.and(CardType.WEAPON, CardSubtype.STARSHIP, Filters.or(Keyword.CANNON, Keyword.ION_CANNON, Keyword.LASER_CANNON));
+    public static final Filter starship_defense_ionized = Filters.and(CardCategory.STARSHIP, Filters.defenseIonized());
+    public static final Filter starship_hyperspeed_ionized = Filters.and(CardCategory.STARSHIP, Filters.hyperspeedIonized());
+    public static final Filter starship_power_ionized = Filters.and(CardCategory.STARSHIP, Filters.powerIonized());
     public static final Filter starship_site = Filters.and(CardSubtype.SITE, Icon.STARSHIP_SITE);
     public static final Filter starship_weapon = Filters.and(CardType.WEAPON, CardSubtype.STARSHIP);
     public static final Filter starship_weapon_that_deploys_on_capitals = Filters.keyword(Keyword.STARSHIP_WEAPON_THAT_DEPLOYS_ON_CAPITALS);

--- a/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/PhysicalCard.java
+++ b/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/PhysicalCard.java
@@ -198,6 +198,9 @@ public interface PhysicalCard extends Filterable, Snapshotable<PhysicalCard> {
     void setCrashed(boolean crashed);
     boolean isCrashed();
 
+    void setIonized(boolean ionized);
+    boolean isIonized();
+
     void setGameTextCanceled(boolean canceled);
     boolean isGameTextCanceled();
     void setLocationGameTextCanceledForPlayer(boolean canceled, String playerId);

--- a/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/PhysicalCard.java
+++ b/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/PhysicalCard.java
@@ -10,6 +10,7 @@ import com.gempukku.swccgo.logic.timing.Snapshotable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 // This interface represents an individual physical card in the game.
 //
@@ -198,8 +199,11 @@ public interface PhysicalCard extends Filterable, Snapshotable<PhysicalCard> {
     void setCrashed(boolean crashed);
     boolean isCrashed();
 
-    void setIonized(boolean ionized);
-    boolean isIonized();
+    Set<IonizationType> getIonization();
+    boolean addIonization(IonizationType newIonization);
+    void setIonization(Set<IonizationType> newIonizationSet);
+    boolean removeIonization(IonizationType cleanIonization);
+    void resetIonization();
 
     void setGameTextCanceled(boolean canceled);
     boolean isGameTextCanceled();

--- a/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/PhysicalCardImpl.java
+++ b/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/PhysicalCardImpl.java
@@ -58,6 +58,7 @@ public class PhysicalCardImpl implements PhysicalCard, Cloneable {
     private boolean _isHit;
     private boolean _damaged;
     private boolean _disarmed;
+    private boolean _ionized;
     private boolean _gameTextCanceled;
     private boolean _suspended;
     private boolean _binaryOff;
@@ -175,6 +176,7 @@ public class PhysicalCardImpl implements PhysicalCard, Cloneable {
         snapshot._isHit = _isHit;
         snapshot._damaged = _damaged;
         snapshot._disarmed = _disarmed;
+        snapshot._ionized = _ionized;
         snapshot._gameTextCanceled = _gameTextCanceled;
         snapshot._suspended = _suspended;
         snapshot._binaryOff = _binaryOff;
@@ -798,6 +800,16 @@ public class PhysicalCardImpl implements PhysicalCard, Cloneable {
     @Override
     public boolean isCrashed() {
         return _isCrashed;
+    }
+
+    @Override
+    public boolean isIonized() {
+        return _ionized;
+    }
+
+    @Override
+    public void setIonized(boolean ionized) {
+        _ionized = ionized;
     }
 
 //    @Override

--- a/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/PhysicalCardImpl.java
+++ b/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/PhysicalCardImpl.java
@@ -58,7 +58,7 @@ public class PhysicalCardImpl implements PhysicalCard, Cloneable {
     private boolean _isHit;
     private boolean _damaged;
     private boolean _disarmed;
-    private boolean _ionized;
+    private Set<IonizationType> _ionization = new HashSet<IonizationType>();
     private boolean _gameTextCanceled;
     private boolean _suspended;
     private boolean _binaryOff;
@@ -176,7 +176,7 @@ public class PhysicalCardImpl implements PhysicalCard, Cloneable {
         snapshot._isHit = _isHit;
         snapshot._damaged = _damaged;
         snapshot._disarmed = _disarmed;
-        snapshot._ionized = _ionized;
+        snapshot._ionization = _ionization;
         snapshot._gameTextCanceled = _gameTextCanceled;
         snapshot._suspended = _suspended;
         snapshot._binaryOff = _binaryOff;
@@ -803,13 +803,28 @@ public class PhysicalCardImpl implements PhysicalCard, Cloneable {
     }
 
     @Override
-    public boolean isIonized() {
-        return _ionized;
+    public Set<IonizationType> getIonization() {
+        return _ionization;
     }
 
     @Override
-    public void setIonized(boolean ionized) {
-        _ionized = ionized;
+    public boolean addIonization(IonizationType newIonization) {
+        return _ionization.add(newIonization);
+    }
+
+    @Override
+    public void setIonization(Set<IonizationType> newIonizationSet) {
+        _ionization = newIonizationSet;
+    }
+
+    @Override
+    public boolean removeIonization(IonizationType cleanIonization) {
+        return _ionization.remove(cleanIonization);
+    }
+
+    @Override
+    public void resetIonization() {
+        _ionization.clear();
     }
 
 //    @Override

--- a/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/GameState.java
+++ b/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/GameState.java
@@ -1433,7 +1433,7 @@ public class GameState implements Snapshotable<GameState> {
         toCard.setConcealed(fromCard.isConcealed());
         toCard.setCollapsed(fromCard.isCollapsed());
         toCard.setCrashed(fromCard.isCrashed());
-        toCard.setIonized(fromCard.isIonized());
+        toCard.setIonization(fromCard.getIonization());
         toCard.setLeavingTable(fromCard.isLeavingTable());
         toCard.setGameTextCanceled(fromCard.isGameTextCanceled());
         toCard.setLocationGameTextCanceledForPlayer(fromCard.isLocationGameTextCanceledForPlayer(_darkSidePlayer), _darkSidePlayer);
@@ -1476,7 +1476,7 @@ public class GameState implements Snapshotable<GameState> {
         card.setConcealed(false);
         card.setCollapsed(false);
         card.setCrashed(false);
-        card.setIonized(false);
+        card.resetIonization();
         card.setLeavingTable(false);
         card.setGameTextCanceled(false);
         card.setLocationGameTextCanceledForPlayer(false, _darkSidePlayer);

--- a/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/GameState.java
+++ b/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/GameState.java
@@ -1433,6 +1433,7 @@ public class GameState implements Snapshotable<GameState> {
         toCard.setConcealed(fromCard.isConcealed());
         toCard.setCollapsed(fromCard.isCollapsed());
         toCard.setCrashed(fromCard.isCrashed());
+        toCard.setIonized(fromCard.isIonized());
         toCard.setLeavingTable(fromCard.isLeavingTable());
         toCard.setGameTextCanceled(fromCard.isGameTextCanceled());
         toCard.setLocationGameTextCanceledForPlayer(fromCard.isLocationGameTextCanceledForPlayer(_darkSidePlayer), _darkSidePlayer);
@@ -1475,6 +1476,7 @@ public class GameState implements Snapshotable<GameState> {
         card.setConcealed(false);
         card.setCollapsed(false);
         card.setCrashed(false);
+        card.setIonized(false);
         card.setLeavingTable(false);
         card.setGameTextCanceled(false);
         card.setLocationGameTextCanceledForPlayer(false, _darkSidePlayer);

--- a/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/actions/FireWeaponActionBuilder.java
+++ b/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/actions/FireWeaponActionBuilder.java
@@ -1876,7 +1876,7 @@ public class FireWeaponActionBuilder {
                                                         if ((totalDestiny + plusOrMinus) > valueToCompare) {
                                                             gameState.sendMessage("Result: Succeeded");
                                                             action.appendEffect(
-                                                                    new ResetArmorManeuverAndHyperspeedEffect(action, cardFiredAt, 0));
+                                                                    new IonizeStarshipEffect(action, cardFiredAt, action.getCardFiringWeapon(), false, true, true));
                                                             Collection<PhysicalCard> starshipWeapons = Filters.filterAllOnTable(game, Filters.and(Filters.starship_weapon, Filters.attachedTo(cardFiredAt)));
                                                             if (!starshipWeapons.isEmpty()) {
                                                                 action.appendEffect(
@@ -5446,7 +5446,7 @@ public class FireWeaponActionBuilder {
                                                         if ((totalDestiny + 3) > valueToCompare) {
                                                             gameState.sendMessage("Result: Succeeded");
                                                             action.appendEffect(
-                                                                    new ResetPowerAndHyperspeedEffect(action, cardFiredAt, 0));
+                                                                   new IonizeStarshipEffect(action, cardFiredAt, action._weaponToFire, true, false, true));
                                                             Collection<PhysicalCard> starshipWeapons = Filters.filterAllOnTable(game, Filters.and(Filters.starship_weapon, Filters.attachedTo(cardFiredAt)));
                                                             if (!starshipWeapons.isEmpty()) {
                                                                 action.appendEffect(

--- a/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DeionizeStarshipEffect.java
+++ b/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DeionizeStarshipEffect.java
@@ -1,11 +1,9 @@
 package com.gempukku.swccgo.logic.effects;
 
 import com.gempukku.swccgo.common.IonizationType;
-import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.game.SwccgGame;
 import com.gempukku.swccgo.game.state.GameState;
-import com.gempukku.swccgo.logic.GameUtils;
 import com.gempukku.swccgo.logic.actions.SubAction;
 
 import com.gempukku.swccgo.logic.timing.AbstractSubActionEffect;

--- a/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DeionizeStarshipEffect.java
+++ b/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DeionizeStarshipEffect.java
@@ -1,0 +1,75 @@
+package com.gempukku.swccgo.logic.effects;
+
+import com.gempukku.swccgo.common.IonizationType;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.game.state.GameState;
+import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.actions.SubAction;
+
+import com.gempukku.swccgo.logic.timing.AbstractSubActionEffect;
+import com.gempukku.swccgo.logic.timing.Action;
+import com.gempukku.swccgo.logic.timing.PassthruEffect;
+
+
+/**
+ * An effect to make a starship no longer Ionized.
+ */
+public class DeionizeStarshipEffect extends AbstractSubActionEffect {
+    private PhysicalCard _cardDeionized;
+    private boolean _deionizePower;
+    private boolean _deionizeDefense;
+    private boolean _deionizeHyperspeed;
+
+    /**
+     * Creates an effect to make a character no longer ionized.
+     * @param action the action performing this effect
+     * @param cardDeionized the card that is deionized
+     */
+    public DeionizeStarshipEffect(Action action, PhysicalCard cardDeionized, boolean deionizePower, boolean deionizeDefense, boolean deionizeHyperspeed) {
+        super(action);
+        _cardDeionized = cardDeionized;
+        _deionizePower = deionizePower;
+        _deionizeDefense = deionizeDefense;
+        _deionizeHyperspeed = deionizeHyperspeed;
+    }
+
+    @Override
+    public boolean isPlayableInFull(SwccgGame game) {
+        return true;
+    }
+
+    @Override
+    protected SubAction getSubAction(SwccgGame game) {
+        final GameState gameState = game.getGameState();
+        final SubAction subAction = new SubAction(_action);
+        subAction.appendEffect(
+                new PassthruEffect(subAction) {
+                    @Override
+                    protected void doPlayEffect(SwccgGame game) {
+                        if (_deionizePower) {
+                            _cardDeionized.removeIonization(IonizationType.POWER_IONIZED);
+                        }
+                        if (_deionizeDefense) {
+                            _cardDeionized.removeIonization(IonizationType.DEFENSE_IONIZED);
+                        }
+                        if (_deionizeHyperspeed) {
+                            _cardDeionized.removeIonization(IonizationType.HYPERSPEED_IONIZED);
+                        }
+                        if (_deionizeDefense && _deionizeHyperspeed) {
+                            subAction.appendEffect(
+                                    new RestoreArmorManeuverHyperspeedToNormalEffect(_action, _cardDeionized));
+                        }
+                    }
+                }
+        );
+
+        return subAction;
+    }
+
+    @Override
+    protected boolean wasActionCarriedOut() {
+        return true;
+    }
+}

--- a/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/IonizeStarshipEffect.java
+++ b/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/IonizeStarshipEffect.java
@@ -1,18 +1,13 @@
 package com.gempukku.swccgo.logic.effects;
 
 import com.gempukku.swccgo.common.IonizationType;
-import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.game.SwccgGame;
-import com.gempukku.swccgo.game.state.GameState;
-import com.gempukku.swccgo.logic.GameUtils;
 import com.gempukku.swccgo.logic.actions.SubAction;
 import com.gempukku.swccgo.logic.timing.AbstractSubActionEffect;
 import com.gempukku.swccgo.logic.timing.Action;
 import com.gempukku.swccgo.logic.timing.PassthruEffect;
 import com.gempukku.swccgo.logic.timing.results.IonizedResult;
-
-import java.util.Collection;
 
 /**
  * An effect to make a starship ionized.

--- a/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/IonizeStarshipEffect.java
+++ b/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/IonizeStarshipEffect.java
@@ -1,0 +1,82 @@
+package com.gempukku.swccgo.logic.effects;
+
+import com.gempukku.swccgo.common.IonizationType;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.game.state.GameState;
+import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.actions.SubAction;
+import com.gempukku.swccgo.logic.timing.AbstractSubActionEffect;
+import com.gempukku.swccgo.logic.timing.Action;
+import com.gempukku.swccgo.logic.timing.PassthruEffect;
+import com.gempukku.swccgo.logic.timing.results.IonizedResult;
+
+import java.util.Collection;
+
+/**
+ * An effect to make a starship ionized.
+ */
+public class IonizeStarshipEffect extends AbstractSubActionEffect {
+    private PhysicalCard _cardIonized;
+    private PhysicalCard _ionizedByCard;
+    private boolean _ionizePower;
+    private boolean _ionizeDefense;
+    private boolean _ionizeHyperspeed;
+
+    /**
+     * Creates an effect to make a starship Ionized.
+     * @param action the action performing this effect
+     * @param cardIonized the card that is "Ionized"
+     * @param ionizedByCard the card the card was "Ionized" by
+     * @param ionizePower whether or not the Power of this card should be Ionized
+     * @param ionizeDefense whether or not the Armor/Maneuver of this card should be Ionized
+     * @param ionizeHyperspeed whether or not the Hyperspeed of this card should be Ionized
+     */
+    public IonizeStarshipEffect(Action action, PhysicalCard cardIonized, PhysicalCard ionizedByCard, boolean ionizePower, boolean ionizeDefense, boolean ionizeHyperspeed) {
+        super(action);
+        _cardIonized = cardIonized;
+        _ionizedByCard = ionizedByCard;
+        _ionizePower = ionizePower;
+        _ionizeDefense = ionizeDefense;
+        _ionizeHyperspeed = ionizeHyperspeed;
+    }
+
+    @Override
+    public boolean isPlayableInFull(SwccgGame game) {
+        return true;
+    }
+
+    @Override
+    protected SubAction getSubAction(SwccgGame game) {
+        //final GameState gameState = game.getGameState();
+        final SubAction subAction = new SubAction(_action);
+        subAction.appendEffect(
+                new PassthruEffect(subAction) {
+                    @Override
+                    protected void doPlayEffect(SwccgGame game) {
+                        if (_ionizePower)
+                            _cardIonized.addIonization(IonizationType.POWER_IONIZED);
+                        if (_ionizeDefense)
+                            _cardIonized.addIonization(IonizationType.DEFENSE_IONIZED);
+                        if (_ionizeHyperspeed)
+                            _cardIonized.addIonization(IonizationType.HYPERSPEED_IONIZED);
+                        if (_ionizePower && _ionizeHyperspeed) { // Currently just from Planetary Ion Cannon
+                            subAction.appendEffect(new ResetPowerAndHyperspeedEffect(subAction, _cardIonized, 0));
+                        }
+                        else if (_ionizeDefense && _ionizeHyperspeed) { // Other Ion Cannons
+                            subAction.appendEffect(new ResetArmorManeuverAndHyperspeedEffect(subAction, _cardIonized, 0));
+                        }
+                        subAction.appendEffect(
+                                new TriggeringResultEffect(subAction, new IonizedResult(_ionizedByCard.getOwner(), _cardIonized)));
+                    }
+                });
+
+        return subAction;
+    }
+
+    @Override
+    protected boolean wasActionCarriedOut() {
+        return true;
+    }
+}

--- a/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/RestoreArmorManeuverHyperspeedToNormalEffect.java
+++ b/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/RestoreArmorManeuverHyperspeedToNormalEffect.java
@@ -1,0 +1,62 @@
+package com.gempukku.swccgo.logic.effects;
+
+import com.gempukku.swccgo.common.Keyword;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.game.state.GameState;
+import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.modifiers.KeywordAffectingModifier;
+import com.gempukku.swccgo.logic.modifiers.Modifier;
+import com.gempukku.swccgo.logic.modifiers.ModifierType;
+import com.gempukku.swccgo.logic.modifiers.ModifiersQuerying;
+import com.gempukku.swccgo.logic.timing.AbstractSuccessfulEffect;
+import com.gempukku.swccgo.logic.timing.Action;
+import com.gempukku.swccgo.logic.timing.results.ResetOrModifyCardAttributeResult;
+
+import java.util.List;
+
+
+/**
+ * An effect to restore a card's Armor, Maneuver & Hyperspeed to normal.
+ */
+public class RestoreArmorManeuverHyperspeedToNormalEffect extends AbstractSuccessfulEffect {
+    private PhysicalCard _cardToRestore;
+
+    /**
+     * Creates an effect that restores a card's forfeit to normal.
+     * @param action the action performing this effect
+     * @param cardToRestore the card to restore
+     */
+    public RestoreArmorManeuverHyperspeedToNormalEffect(Action action, PhysicalCard cardToRestore) {
+        super(action);
+        _cardToRestore = cardToRestore;
+    }
+
+    @Override
+    protected void doPlayEffect(SwccgGame game) {
+        GameState gameState = game.getGameState();
+        ModifiersQuerying modifiersQuerying = game.getModifiersQuerying();
+
+        gameState.sendMessage(GameUtils.getCardLink(_cardToRestore) + "'s armor/maneuver, and hyperspeed are set to normal by " + GameUtils.getCardLink(_action.getActionSource()));
+        game.getGameState().cardAffectsCard(_action.getActionSource().getOwner(), _action.getActionSource(), _cardToRestore);
+
+        // Get all the persistent modifiers that can affect the card's armor, maneuver, and hyperspeed and exclude this card from those modifiers.
+        List<Modifier> modifiers = modifiersQuerying.getPersistentModifiersAffectingCard(gameState, _cardToRestore);
+
+        // Only clean modifiers that are originating specifically from an ion cannon weapon
+        for (Modifier modifier : modifiers) {
+            PhysicalCard affectingCard = modifier.getSource(gameState);
+            if (modifiersQuerying.hasKeyword(gameState, affectingCard, Keyword.ION_CANNON)) {
+                if ((modifier.getModifierType() == ModifierType.ARMOR || modifier.getModifierType() == ModifierType.UNMODIFIABLE_ARMOR) ||
+                        (modifier.getModifierType() == ModifierType.MANEUVER || modifier.getModifierType() == ModifierType.UNMODIFIABLE_MANEUVER) ||
+                        (modifier.getModifierType() == ModifierType.HYPERSPEED || modifier.getModifierType() == ModifierType.UNMODIFIABLE_HYPERSPEED)) {
+                    if (!modifier.isNotRemovedOnRestoreToNormal()) {
+                        modifiersQuerying.excludeFromBeingAffected(modifier, _cardToRestore);
+                    }
+                }
+            }
+        }
+
+        game.getActionsEnvironment().emitEffectResult(new ResetOrModifyCardAttributeResult(_action.getPerformingPlayer(), _cardToRestore));
+    }
+}

--- a/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/EffectResult.java
+++ b/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/EffectResult.java
@@ -213,6 +213,9 @@ public abstract class EffectResult implements Snapshotable<EffectResult> {
         // Disarmed
         DISARMED,
 
+        // Ionized
+        IONIZED,
+
         // Excluded from battle
         ABOUT_TO_HIDE_FROM_BATTLE,
         ABOUT_TO_BE_EXCLUDED_FROM_BATTLE,

--- a/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/results/IonizedResult.java
+++ b/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/results/IonizedResult.java
@@ -6,7 +6,7 @@ import com.gempukku.swccgo.logic.GameUtils;
 import com.gempukku.swccgo.logic.timing.EffectResult;
 
 /**
- * An effect result that is emitted when a card is Disarmed.
+ * An effect result that is emitted when a card is Ionized.
  */
 public class IonizedResult extends EffectResult {
     private PhysicalCard _cardIonized;

--- a/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/results/IonizedResult.java
+++ b/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/results/IonizedResult.java
@@ -1,0 +1,42 @@
+package com.gempukku.swccgo.logic.timing.results;
+
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.timing.EffectResult;
+
+/**
+ * An effect result that is emitted when a card is Disarmed.
+ */
+public class IonizedResult extends EffectResult {
+    private PhysicalCard _cardIonized;
+
+    /**
+     * Creates an effect result that is emitted when a card is Ionized.
+     * @param performingPlayerId the player performing the action
+     * @param cardIonized the card that was Ionized
+     */
+    public IonizedResult(String performingPlayerId, PhysicalCard cardIonized) {
+        super(Type.IONIZED, performingPlayerId);
+        _cardIonized = cardIonized;
+    }
+
+    /**
+     * Gets the card that was Ionized.
+     * @return the card
+     */
+    public PhysicalCard getCardIonized() {
+        return _cardIonized;
+    }
+
+
+    /**
+     * Gets the text to show to describe the effect result.
+     * @param game the game
+     * @return the text
+     */
+    @Override
+    public String getText(SwccgGame game) {
+        return "Ionized " + GameUtils.getCardLink(_cardIonized);
+    }
+}


### PR DESCRIPTION
Standardizes the negative status effect applied by the Ion Cannon, SW4-Ion Cannon and Planet Defender Ion Cannon weapons as "ionization" and now, the three types of starship ionization can individually be applied and removed. Also implements the astromech droids R5-A2 and R5-D4 from the A New Hope set that can correctly remove these ionization states. "Ionization" was chosen as it accurately reflects the type of the effect and is also directly referenced by R5-A2's lore text.

Closes #77
Closes #82 