### PR TITLE
update vbox static ip address

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ From the SSH login direcory on the VM (`/vagrant`) run:
 ./run-gemp.sh
 ```
 
-You can now access GEMP by visiting `http://192.168.50.94:8080/gemp-swccg/` in your browser.
+You can now access GEMP by visiting `http://192.168.60.94:8080/gemp-swccg/` in your browser.
 
-The bootstrap script automatically creates 2 test admin accounts, `test1` and `test2`, with the password "test". When the server first starts, it is in non-operational standby mode which does not allow games to be started. To enable operational mode, when logged in visit `http://192.168.50.94:8080/gemp-swccg/admin.html` in your browser and click the "Startup" link.
+The bootstrap script automatically creates 2 test admin accounts, `test1` and `test2`, with the password "test". When the server first starts, it is in non-operational standby mode which does not allow games to be started. To enable operational mode, when logged in visit `http://192.168.60.94:8080/gemp-swccg/admin.html` in your browser and click the "Startup" link.
 
 ### Other VM Commands
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     # Create a private network, which allows host-only 
     # access to the machine using a specific IP.
-    d.vm.network "private_network", ip: "192.168.50.94"
+    d.vm.network "private_network", ip: "192.168.60.94"
 
     config.vm.provider "virtualbox" do |vb|
       vb.name = VAGRANT_INSTANCE_NAME


### PR DESCRIPTION
Newer versions of VirtualBox restrict the static ip range for hostonly networks to between 192.168.56.1 and 192.168.63.254.  This picks a nice static ip in the middle.