### PR TITLE
Update actions/checkout version to 3 for nodejs16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: apt-get install OpenJDK
         run:  |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@master
 
       - name: apt-get install OpenJDK
         run:  |


### PR DESCRIPTION
All the auto-sync actions from the private repo are failing due to github deprecating nodejs12.  Apparently, the actions/checkout@v2 action uses nodejs12 but the newer v3 uses nodejs16 so we should update.