### PR TITLE
Docker Volume Bind for Web Application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ RUN mkdir -p /opt/gemp-swccg/web && \
 ## a small quality of life addition for those times when entering the container
 RUN echo 'export PS1="\u@\h:\w\$ "' > /etc/profile.d/ps1.sh && chmod +x /etc/profile.d/ps1.sh
 
+COPY gemp-swccg-async/src/main/web \
+     /opt/gemp-swccg/web
+
 COPY gemp-swccg-async/target/web.jar \
      /opt/gemp-swccg/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,6 @@ RUN mkdir -p /opt/gemp-swccg/web && \
 ## a small quality of life addition for those times when entering the container
 RUN echo 'export PS1="\u@\h:\w\$ "' > /etc/profile.d/ps1.sh && chmod +x /etc/profile.d/ps1.sh
 
-## copy artifacts in to the container
-COPY gemp-swccg-async/src/main/web \
-     /opt/gemp-swccg/web
-
 COPY gemp-swccg-async/target/web.jar \
      /opt/gemp-swccg/
 
@@ -46,6 +42,7 @@ USER gemp
 WORKDIR /opt/gemp-swccg
 
 ## default parameters representing a test, non-prod, setup
+ENV "environment" "test"
 ENV "application_root" "/opt/gemp-swccg"
 ENV "db_hostname"      "gempdb"
 ENV "db_dbname"        "gemp-swccg"

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,6 @@ USER gemp
 WORKDIR /opt/gemp-swccg
 
 ## default parameters representing a test, non-prod, setup
-ENV "environment" "test"
 ENV "application_root" "/opt/gemp-swccg"
 ENV "db_hostname"      "gempdb"
 ENV "db_dbname"        "gemp-swccg"

--- a/README.md
+++ b/README.md
@@ -30,14 +30,11 @@ GEMP-SWCCG - server/client for playing Star Wars CCG using a web browser. The pr
 
 
 ### Docker-Compose
-
-* `docker-compose.yml` can be used, _instead of the utility scripts below,_ to create a development/test environment.
-* Docker compose will build the container images.
-* Before bringing up the test environment using `docker-compose`, compile gemp.
+_Instead of the utility scripts below,_ to create a development/test environment you can run the following commands. The first command will compile the Java Server, and the second command will build and then apply the local developer settings from `docker-compose.dev.yml` on top on the base Docker image.
 
 ```bash
 mvn clean install
-docker-compose up
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml up
 ```
 
 
@@ -52,7 +49,7 @@ docker-compose up
 ### Connecting to the local dev/test gemp server
 
 
-* After starting the server, point your browser of choice to: http://0.0.0.0:8080/gemp-swccg/
+* After starting the server, point your browser of choice to: http://0.0.0.0:8080/gemp-swccg/ (or localhost:8080/gemp-swccg depending on your system)
 
 
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,5 +8,8 @@ services:
        - type: bind
          source: ./gemp-swccg-async/src/main/web/
          target: /opt/gemp-swccg/web
+       - type: bind
+         source: ./gemp-swccg-async/target/web.jar
+         target: /opt/gemp-swccg/web.jar
     environment:
       - "environment=test"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,12 @@
+---
+
+version: "3"
+
+services:
+ gemp:
+    volumes:
+       - type: bind
+         source: ./gemp-swccg-async/src/main/web/
+         target: /opt/gemp-swccg/web
+    environment:
+      - "environment=test"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,10 @@ services:
     tty: true
     depends_on:
       - gempdb
+    volumes:
+       - type: bind
+         source: ./gemp-swccg-async/src/main/web/
+         target: /opt/gemp-swccg/web
     environment:
       - "db_hostname=gempdb"
     command: ["/usr/bin/wait-for-it.sh", "gempdb:3306", "--",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,12 +44,9 @@ services:
     tty: true
     depends_on:
       - gempdb
-    volumes:
-       - type: bind
-         source: ./gemp-swccg-async/src/main/web/
-         target: /opt/gemp-swccg/web
     environment:
       - "db_hostname=gempdb"
+      - "environment=production"
     command: ["/usr/bin/wait-for-it.sh", "gempdb:3306", "--",
               "/usr/bin/java",
               "-Xmx4g",

--- a/gemp-swccg-async/src/main/java/com/gempukku/swccgo/async/SwccgoHttpRequestHandler.java
+++ b/gemp-swccg-async/src/main/java/com/gempukku/swccgo/async/SwccgoHttpRequestHandler.java
@@ -139,11 +139,9 @@ public class SwccgoHttpRequestHandler extends SimpleChannelUpstreamHandler {
                 } finally {
                     IOUtils.closeQuietly(fis);
                 }
-            } else {
-                _log.debug("File " + canonicalPath + " served from cache");
             }
 
-                writeHttpByteResponse(request, fileBytes, getHeadersForFile(headers, file), e);
+            writeHttpByteResponse(request, fileBytes, getHeadersForFile(headers, file), e);
         } catch (IOException exp) {
             writeHttpErrorResponse(request, 500, null, e);
         }

--- a/gemp-swccg-async/src/main/java/com/gempukku/swccgo/async/SwccgoHttpRequestHandler.java
+++ b/gemp-swccg-async/src/main/java/com/gempukku/swccgo/async/SwccgoHttpRequestHandler.java
@@ -1,6 +1,8 @@
 package com.gempukku.swccgo.async;
 
 import com.gempukku.swccgo.async.handler.UriRequestHandler;
+import com.gempukku.swccgo.common.ApplicationConfiguration;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 import org.jboss.netty.buffer.ChannelBuffers;
@@ -36,8 +38,10 @@ public class SwccgoHttpRequestHandler extends SimpleChannelUpstreamHandler {
 
     private Map<Type, Object> _objects;
     private UriRequestHandler _uriRequestHandler;
+    private boolean _isLocalHost = false;
 
     public SwccgoHttpRequestHandler(Map<Type, Object> objects, UriRequestHandler uriRequestHandler) {
+        _isLocalHost = ApplicationConfiguration.getProperty("environment").equals("test");
         _objects = objects;
         _uriRequestHandler = uriRequestHandler;
     }
@@ -120,7 +124,7 @@ public class SwccgoHttpRequestHandler extends SimpleChannelUpstreamHandler {
         try {
             String canonicalPath = file.getCanonicalPath();
             byte[] fileBytes = _fileCache.get(canonicalPath);
-            if (fileBytes == null) {
+            if (fileBytes == null || _isLocalHost) {
                 if (!file.exists() || !file.isFile()) {
                     writeHttpErrorResponse(request, 404, null, e);
                     return;
@@ -135,6 +139,8 @@ public class SwccgoHttpRequestHandler extends SimpleChannelUpstreamHandler {
                 } finally {
                     IOUtils.closeQuietly(fis);
                 }
+            } else {
+                _log.debug("File " + canonicalPath + " served from cache");
             }
 
                 writeHttpByteResponse(request, fileBytes, getHeadersForFile(headers, file), e);

--- a/gemp-swccg-async/src/main/java/com/gempukku/swccgo/async/handler/WebRequestHandler.java
+++ b/gemp-swccg-async/src/main/java/com/gempukku/swccgo/async/handler/WebRequestHandler.java
@@ -1,6 +1,9 @@
 package com.gempukku.swccgo.async.handler;
 
 import com.gempukku.swccgo.async.ResponseWriter;
+import com.gempukku.swccgo.common.ApplicationConfiguration;
+
+import org.apache.log4j.Logger;
 import org.jboss.netty.channel.MessageEvent;
 import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.jboss.netty.handler.codec.http.HttpRequest;
@@ -15,15 +18,17 @@ import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.IF_NONE_MATCH
 public class WebRequestHandler implements UriRequestHandler {
     private String _root;
     private String _uniqueEtag;
+    private boolean _isLocalHost = false;
 
     public WebRequestHandler(String root) {
+        _isLocalHost = ApplicationConfiguration.getProperty("environment").equals("test");
         _root = root;
         _uniqueEtag = "\"" + String.valueOf(System.currentTimeMillis()) + "\"";
     }
 
     @Override
     public void handleRequest(String uri, HttpRequest request, Map<Type, Object> context, ResponseWriter responseWriter, MessageEvent e) throws Exception {
-        if (clientHasCurrentVersion(request)) {
+        if (clientHasCurrentVersion(request) && !_isLocalHost) {
             responseWriter.writeError(304);
             return;
         }

--- a/gemp-swccg-common/src/main/resources/gemp-swccg.properties
+++ b/gemp-swccg-common/src/main/resources/gemp-swccg.properties
@@ -1,6 +1,7 @@
 ## Application root, used swccg for example for storing replay files
 #application.root=/etc/gemp-swccg
 application.root=${application_root:-/etc/gemp-swccg}
+environment=${environment:-production}
 
 ## DB connection
 db.connection.class=org.gjt.mm.mysql.Driver

--- a/run-gemp.sh
+++ b/run-gemp.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 rm -rf /env/gemp-swccg/web/Build
-unzip -o gemp-swccg-async/target/web.zip -d /env/gemp-swccg/web/
 if [ -f gemp-swccg-async/target/web.jar ]; then
   cp gemp-swccg-async/target/web.jar /env/gemp-swccg/
 else

--- a/run-gemp.sh
+++ b/run-gemp.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 rm -rf /env/gemp-swccg/web/Build
+unzip -o gemp-swccg-async/target/web.zip -d /env/gemp-swccg/web/
 if [ -f gemp-swccg-async/target/web.jar ]; then
   cp gemp-swccg-async/target/web.jar /env/gemp-swccg/
 else


### PR DESCRIPTION
Minimal changes required to bind the host `gemp-swccg-async/src/web/` folder to the correct location in the docker container. This makes modifications to the web app easier to develop and test by removing the manual steps required to rebuild the application with maven, zip and replace the folder in the container and refresh. 

### Implementation Steps
* A new environment variable defines if it is a prod or test build 
  * This defaults to prod to mimic previous behavior. Since there was no flag everything was a "prod" build
  * The `Dockerfile` where "default parameters" for a "test" environment is updated
* The two HTTP handlers both have a property that indicates if the app is local or prod
  * I don't know enough about Java or the app to find a way to inject this configuration. I do hate logic in constructors... but this seems reasonable
* Updated `Dockerfile` to no longer copy the web folder manually
* Updated the `docker-compose.yml` file to bind the host web folder into the container

### Testing
* I validated the current behavior for making any changes in an HTML or JS file were as follows:
  *  Make change
  * Refresh page in UI
    * See the changes are not represented
  * Stop the docker containers
    * Following a restart the the changes are still not represented
  * Delete the docker image
    * Following a deletion of the container and then the image, `docker-compose up` and the changes are not represented
  * Run `mvn clean install`
    * After deleting the container, the image and then rebuilding the changes are finally represented

* The current flow is now:

* With a `local` build
  * Make a change in any HTML or JS file
  * Refresh the page in the browser
  * See changes are represented

* With a `production` build
  * Make a change in any HTML or JS file
  * Refresh the page in the browser
    * See no changes are visible
    * See the requests all return `304` (not modified)