### PR TITLE
Implement Informant (2/134)

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/MoveAsReactAction.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/MoveAsReactAction.java
@@ -78,6 +78,12 @@ public class MoveAsReactAction extends AbstractGameTextAction {
         if (_movementType == Effect.Type.TAKING_OFF_AS_REACT) {
             return "Take off " + awayText + "as a 'react'";
         }
+        if (_movementType == Effect.Type.ENTERING_STARSHIP_VEHICLE_SITE_AS_REACT) {
+            return "Enter starship or vehicle site as a 'react'";
+        }
+        if (_movementType == Effect.Type.EXITING_STARSHIP_VEHICLE_SITE_AS_REACT) {
+            return "Exit starship or vehicle site as a 'react'";
+        }
         return "Move as a 'react";
     }
 
@@ -131,6 +137,14 @@ public class MoveAsReactAction extends AbstractGameTextAction {
                     }
                     if (_movementType == Effect.Type.TAKING_OFF_AS_REACT) {
                         appendCost(new PayTakeOffCostEffect(_that, getPerformingPlayer(), _cardToReact, _locationToMoveTo, true, changeInCost));
+                        return getNextCost();
+                    }
+                    if (_movementType == Effect.Type.ENTERING_STARSHIP_VEHICLE_SITE_AS_REACT) {
+                        appendCost(new PayEnterStarshipOrVehicleSiteCostEffect(_that, getPerformingPlayer(), _cardToReact, _locationToMoveTo, true, changeInCost));
+                        return getNextCost();
+                    }
+                    if (_movementType == Effect.Type.EXITING_STARSHIP_VEHICLE_SITE_AS_REACT) {
+                        appendCost(new PayExitStarshipOrVehicleSiteCostEffect(_that, getPerformingPlayer(), _cardToReact, _locationToMoveTo, true, changeInCost));
                         return getNextCost();
                     }
                 }
@@ -238,6 +252,12 @@ public class MoveAsReactAction extends AbstractGameTextAction {
         }
         if (_movementType == Effect.Type.TAKING_OFF_AS_REACT) {
             return _cardToReact.getBlueprint().getTakeOffAction(playerId, game, _cardToReact, true, true, true, false, false, moveTargetFilter);
+        }
+        if (_movementType == Effect.Type.ENTERING_STARSHIP_VEHICLE_SITE_AS_REACT) {
+            return _cardToReact.getBlueprint().getEnterStarshipOrVehicleSiteAction(playerId, game, _cardToReact, true, true, true, false, moveTargetFilter);
+        }
+        if (_movementType == Effect.Type.EXITING_STARSHIP_VEHICLE_SITE_AS_REACT) {
+            return _cardToReact.getBlueprint().getExitStarshipOrVehicleSiteAction(playerId, game, _cardToReact, true, true, true, false, moveTargetFilter);
         }
         return null;
     }

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/dark/Card2_134.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/dark/Card2_134.java
@@ -1,0 +1,155 @@
+package com.gempukku.swccgo.cards.set2.dark;
+
+import com.gempukku.swccgo.cards.AbstractUsedInterrupt;
+import com.gempukku.swccgo.cards.GameConditions;
+import com.gempukku.swccgo.cards.effects.MoveAsReactEffect;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.filters.Filter;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.TriggerConditions;
+import com.gempukku.swccgo.logic.actions.CancelCardActionBuilder;
+import com.gempukku.swccgo.logic.actions.PlayInterruptAction;
+import com.gempukku.swccgo.logic.effects.RespondablePlayCardEffect;
+import com.gempukku.swccgo.logic.effects.TargetCardOnTableEffect;
+import com.gempukku.swccgo.logic.effects.choose.ChooseCardOnTableEffect;
+import com.gempukku.swccgo.logic.timing.Action;
+import com.gempukku.swccgo.logic.timing.Effect;
+import com.gempukku.swccgo.logic.timing.EffectResult;
+import com.gempukku.swccgo.logic.timing.PassthruEffect;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+
+/**
+ * Set: A New Hope
+ * Type: Interrupt
+ * Subtype: Used
+ * Title: Informant
+ */
+public class Card2_134 extends AbstractUsedInterrupt {
+    public Card2_134() {
+        super(Side.DARK, 6, "Informant", Uniqueness.UNRESTRICTED, ExpansionSet.A_NEW_HOPE, Rarity.U1);
+        setLore("The Empire's network of spies and petty informants allows Imperial operatives to discover and react to Rebel assaults before they occur.");
+        setGameText("If a battle was just initiated at same site as your Undercover spy, your characters at adjacent sites may move there as a 'react' (for free). OR Cancel Sabotage.");
+        addIcons(Icon.A_NEW_HOPE);
+    }
+
+    @Override
+    protected List<PlayInterruptAction> getGameTextOptionalAfterActions(final String playerId, final SwccgGame game, EffectResult effectResult, final PhysicalCard self) {
+        String opponent = game.getOpponent(playerId);
+
+        // Check condition(s)
+        if (TriggerConditions.battleInitiatedAt(game, effectResult, opponent, Filters.and(Filters.site, Filters.canBeTargetedBy(self)))) {
+            final PhysicalCard battleSite = game.getGameState().getBattleLocation();
+            // Interrupts cannot spot undercover spies via canSpot() once a battle has started
+            // (GameState.iterateActiveCards special rule). filterAllOnTable includes them.
+            if (battleSite != null && hasYourUndercoverSpyAt(game, self, battleSite)) {
+                Filter characterFilter = getReactCharacterFilter(self, battleSite);
+                if (GameConditions.canTarget(game, self, characterFilter)) {
+
+                    final PlayInterruptAction action = new PlayInterruptAction(game, self);
+                    action.setText("Move characters as 'react'");
+                    // First react is required targeting so Sense/Sabotage can cancel the whole play.
+                    action.appendTargeting(
+                            new TargetCardOnTableEffect(action, playerId, "Choose character to move as a 'react'", characterFilter) {
+                                @Override
+                                protected void cardTargeted(final int targetGroupId1, final PhysicalCard targetedCharacter) {
+                                    action.addAnimationGroup(targetedCharacter);
+                                    action.addSecondaryTargetFilter(Filters.battleLocation);
+                                    // Allow response(s)
+                                    action.allowResponses("Move " + GameUtils.getCardLink(targetedCharacter) + " as a 'react'",
+                                            new RespondablePlayCardEffect(action) {
+                                                @Override
+                                                protected void performActionResults(Action targetingAction) {
+                                                    PhysicalCard finalCharacter = action.getPrimaryTargetCard(targetGroupId1);
+                                                    action.appendEffect(
+                                                            new MoveAsReactEffect(action, finalCharacter, true));
+                                                    // Remaining adjacent characters may optionally react for free
+                                                    // as sub-actions of this same interrupt (AR Appendix C).
+                                                    appendOptionalAdditionalReacts(action, playerId, self);
+                                                }
+                                            }
+                                    );
+                                }
+                            }
+                    );
+                    return Collections.singletonList(action);
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    protected List<PlayInterruptAction> getGameTextOptionalBeforeActions(final String playerId, SwccgGame game, final Effect effect, final PhysicalCard self) {
+        // Check condition(s)
+        if (TriggerConditions.isPlayingCard(game, effect, Filters.Sabotage)
+                && GameConditions.canCancelCardBeingPlayed(game, self, effect)) {
+
+            final PlayInterruptAction action = new PlayInterruptAction(game, self);
+            CancelCardActionBuilder.buildCancelCardBeingPlayedAction(action, effect);
+            return Collections.singletonList(action);
+        }
+        return null;
+    }
+
+    @Override
+    protected List<PlayInterruptAction> getGameTextTopLevelActions(final String playerId, SwccgGame game, final PhysicalCard self) {
+        List<PlayInterruptAction> actions = new LinkedList<PlayInterruptAction>();
+
+        // Check condition(s)
+        if (GameConditions.canTargetToCancel(game, self, Filters.Sabotage)) {
+
+            final PlayInterruptAction action = new PlayInterruptAction(game, self);
+            CancelCardActionBuilder.buildCancelCardAction(action, Filters.Sabotage, Title.Sabotage);
+            actions.add(action);
+        }
+        return actions;
+    }
+
+    private boolean hasYourUndercoverSpyAt(SwccgGame game, PhysicalCard self, PhysicalCard battleSite) {
+        return !Filters.filterAllOnTable(game, Filters.and(Filters.your(self), Filters.undercover_spy, Filters.at(battleSite))).isEmpty();
+    }
+
+    private Filter getReactCharacterFilter(PhysicalCard self, PhysicalCard battleSite) {
+        return Filters.and(Filters.your(self), Filters.character, Filters.at(Filters.adjacentSite(battleSite)),
+                Filters.canMoveAsReactAsActionFromOtherCard(self, true, 0, false));
+    }
+
+    private void appendOptionalAdditionalReacts(final PlayInterruptAction action, final String playerId, final PhysicalCard self) {
+        action.appendEffect(
+                new PassthruEffect(action) {
+                    @Override
+                    protected void doPlayEffect(SwccgGame game) {
+                        PhysicalCard battleSite = game.getGameState().getBattleLocation();
+                        if (battleSite == null) {
+                            return;
+                        }
+                        Filter remaining = getReactCharacterFilter(self, battleSite);
+                        if (GameConditions.canTarget(game, self, remaining)) {
+                            action.appendEffect(
+                                    new ChooseCardOnTableEffect(action, playerId, "Choose another character to move as a 'react'", remaining, 0) {
+                                        @Override
+                                        protected void cardSelected(PhysicalCard selectedCard) {
+                                            action.appendEffect(
+                                                    new MoveAsReactEffect(action, selectedCard, true));
+                                            appendOptionalAdditionalReacts(action, playerId, self);
+                                        }
+                                    }
+                            );
+                        }
+                    }
+                }
+        );
+    }
+}

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/dark/Card2_134.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/dark/Card2_134.java
@@ -122,7 +122,14 @@ public class Card2_134 extends AbstractUsedInterrupt {
     }
 
     private Filter getReactCharacterFilter(PhysicalCard self, PhysicalCard battleSite) {
-        return Filters.and(Filters.your(self), Filters.character, Filters.at(Filters.adjacentSite(battleSite)),
+        // AR 2023: while a starship/vehicle is at a site, its sites are adjacent to that site.
+        // Filters.adjacentSite already includes this via isAdjacentSites. Also union
+        // siteOfStarshipOrVehicle (filterAllOnTable) so a related vehicle at the battle site
+        // is found even if findFirstActive would skip it.
+        Filter adjacentSites = Filters.or(
+                Filters.adjacentSite(battleSite),
+                Filters.siteOfStarshipOrVehicle(Filters.and(Filters.or(Filters.starship, Filters.vehicle), Filters.at(battleSite))));
+        return Filters.and(Filters.your(self), Filters.character, Filters.at(adjacentSites),
                 Filters.canMoveAsReactAsActionFromOtherCard(self, true, 0, false));
     }
 

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/dark/Card_2_134_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/dark/Card_2_134_Tests.java
@@ -29,6 +29,7 @@ public class Card_2_134_Tests {
                 put("rebel", "1_28"); // Rebel Trooper
                 put("lsSpy", "7_5"); // Bothan Spy
                 put("lsMover", "1_28");
+                put("navander", "3_18"); // Romas "Lock" Navander, blocks reacts
             }},
             new HashMap<>() {{
                 put("informant", "2_134");
@@ -493,5 +494,43 @@ public class Card_2_134_Tests {
             // Framework offered both as the required first target even if only one additional react followed.
             assertTrue(scn.DSHasCardChoiceAvailable(mover2) || adj2 == mover2.getAtLocation() || marketplace == mover2.getAtLocation());
         }
+    }
+    @Test
+    public void NavanderAtBattleSiteBlocksInformantReactToThatLocation() {
+        // Romas "Lock" Navander: opponent may not 'react' to or from same location.
+        var scn = GetScenario();
+        var informant = scn.GetDSCard("informant");
+        var marketplace = scn.GetDSStartingLocation();
+        var cantina = scn.GetDSCard("cantina");
+        var mover = scn.GetDSCard("mover");
+        var navander = scn.GetLSCard("navander");
+
+        SetupStandardBattle(scn);
+        scn.MoveCardsToLocation(marketplace, navander);
+
+        scn.SkipToLSTurn(Phase.BATTLE);
+        InitiateLsBattleKeepReactWindow(scn, marketplace);
+        assertFalse("Navander at the battle site blocks reacting TO that location",
+                DsCardPlayAvailableSafe(scn, informant));
+        assertEquals(cantina, mover.getAtLocation());
+    }
+
+    @Test
+    public void NavanderAtAdjacentSiteBlocksInformantReactFromThatLocation() {
+        var scn = GetScenario();
+        var informant = scn.GetDSCard("informant");
+        var marketplace = scn.GetDSStartingLocation();
+        var cantina = scn.GetDSCard("cantina");
+        var mover = scn.GetDSCard("mover");
+        var navander = scn.GetLSCard("navander");
+
+        SetupStandardBattle(scn);
+        scn.MoveCardsToLocation(cantina, navander);
+
+        scn.SkipToLSTurn(Phase.BATTLE);
+        InitiateLsBattleKeepReactWindow(scn, marketplace);
+        assertFalse("Navander at the adjacent site blocks reacting FROM that location",
+                DsCardPlayAvailableSafe(scn, informant));
+        assertEquals(cantina, mover.getAtLocation());
     }
 }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/dark/Card_2_134_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/dark/Card_2_134_Tests.java
@@ -41,6 +41,10 @@ public class Card_2_134_Tests {
                 put("db94", "1_291"); // Tatooine: Docking Bay 94
                 put("lars", "1_294"); // Tatooine: Lars' Moisture Farm
                 put("blaster", "1_317"); // Imperial Blaster
+                put("barge", "6_172"); // Jabba's Sail Barge
+                put("deck", "6_167"); // Jabba's Sail Barge: Passenger Deck
+                put("palace", "6_171"); // Tatooine: Jabba's Palace (Dark)
+                put("abyssin", "6_091"); // Abyssin
             }},
             10,
             10,
@@ -532,5 +536,118 @@ public class Card_2_134_Tests {
         assertFalse("Navander at the adjacent site blocks reacting FROM that location",
                 DsCardPlayAvailableSafe(scn, informant));
         assertEquals(cantina, mover.getAtLocation());
+    }
+
+    /**
+     * AR 2023: vehicle sites are adjacent to the planet site where the vehicle is located.
+     * Characters at Passenger Deck may Informant-react into a battle at Palace when the barge is there.
+     */
+    private void SetupBargeAtPalaceBattle(VirtualTableScenario scn, boolean bargeAtPalace) {
+        var informant = scn.GetDSCard("informant");
+        var palace = scn.GetDSCard("palace");
+        var barge = scn.GetDSCard("barge");
+        var deck = scn.GetDSCard("deck");
+        var spy = scn.GetDSCard("spy");
+        var presence = scn.GetDSCard("presence");
+        var driver = scn.GetDSCard("mover");
+        var abyssin = scn.GetDSCard("abyssin");
+        var rebel = scn.GetLSCard("rebel");
+
+        scn.MoveCardsToDSHand(informant);
+        scn.StartGame();
+        scn.MoveLocationToTable(palace);
+        scn.MoveLocationToTable(deck);
+
+        var bargeSite = bargeAtPalace ? palace : scn.GetDSStartingLocation();
+        scn.MoveCardsToLocation(bargeSite, barge);
+        scn.BoardAsPilot(barge, driver);
+        scn.MoveCardsToLocation(palace, spy, presence, rebel);
+        scn.MoveCardsToLocation(deck, abyssin);
+        scn.MakeCardGoUndercover(spy);
+    }
+
+    @Test
+    public void CharacterAtPassengerDeckReactsForFreeIntoBattleAtPalaceWhenBargeIsThere() {
+        var scn = GetScenario();
+        var informant = scn.GetDSCard("informant");
+        var palace = scn.GetDSCard("palace");
+        var deck = scn.GetDSCard("deck");
+        var barge = scn.GetDSCard("barge");
+        var abyssin = scn.GetDSCard("abyssin");
+        var presence = scn.GetDSCard("presence");
+        var spy = scn.GetDSCard("spy");
+        var rebel = scn.GetLSCard("rebel");
+
+        SetupBargeAtPalaceBattle(scn, true);
+
+        assertTrue("Passenger Deck is adjacent to Palace while the barge is at Palace",
+                scn.IsAdjacentTo(deck, palace));
+        assertTrue(scn.IsAdjacentTo(palace, deck));
+
+        scn.SkipToLSTurn(Phase.BATTLE);
+        int dsForceBefore = scn.GetDSForcePileCount();
+        InitiateLsBattleKeepReactWindow(scn, palace);
+
+        AssertDsCanPlayInformant(scn, informant);
+        scn.DSPlayCard(informant);
+        assertTrue("Abyssin at Passenger Deck must be a legal first Informant react",
+                scn.DSHasCardChoiceAvailable(abyssin));
+        assertFalse(scn.DSHasCardChoiceAvailable(presence));
+        assertFalse(scn.DSHasCardChoiceAvailable(spy));
+        assertFalse(scn.DSHasCardChoiceAvailable(rebel));
+        scn.DSChooseCard(abyssin);
+        if (scn.GetCurrentDecision() != null) {
+            scn.PassAllResponses();
+        }
+
+        assertEquals("Abyssin should exit Passenger Deck to Palace as a free react, was at "
+                        + (abyssin.getAtLocation() == null ? "null" : abyssin.getAtLocation().getTitle()),
+                palace, abyssin.getAtLocation());
+        assertTrue(scn.IsParticipatingInBattle(abyssin));
+        assertTrue(scn.IsParticipatingInBattle(presence, rebel));
+        assertFalse(scn.IsParticipatingInBattle(spy));
+        assertEquals(dsForceBefore, scn.GetDSForcePileCount());
+        assertNotEquals(deck, abyssin.getAtLocation());
+        assertEquals(palace, barge.getAtLocation());
+    }
+
+    @Test
+    public void CharacterAtVehicleSiteOfVehicleElsewhereIsNotALegalInformantTarget() {
+        var scn = GetScenario();
+        var informant = scn.GetDSCard("informant");
+        var palace = scn.GetDSCard("palace");
+        var deck = scn.GetDSCard("deck");
+        var marketplace = scn.GetDSStartingLocation();
+        var abyssin = scn.GetDSCard("abyssin");
+        var cantina = scn.GetDSCard("cantina");
+        var mover2 = scn.GetDSCard("mover2");
+
+        SetupBargeAtPalaceBattle(scn, false);
+        scn.MoveLocationToTable(cantina);
+        scn.MoveCardsToLocation(cantina, mover2);
+
+        assertTrue("Passenger Deck is adjacent to where the barge is (Marketplace), not Palace",
+                scn.IsAdjacentTo(deck, marketplace));
+        assertFalse("Passenger Deck is not adjacent to Palace when the barge is elsewhere",
+                scn.IsAdjacentTo(deck, palace));
+
+        scn.SkipToLSTurn(Phase.BATTLE);
+        InitiateLsBattleKeepReactWindow(scn, palace);
+
+        boolean informantPlayable = DsCardPlayAvailableSafe(scn, informant);
+        if (informantPlayable) {
+            scn.DSPlayCard(informant);
+            assertFalse("Abyssin at an unrelated vehicle site must not be a legal Informant react",
+                    scn.DSHasCardChoiceAvailable(abyssin));
+            if (scn.DSHasCardChoiceAvailable(mover2)) {
+                scn.DSChooseCard(mover2);
+                scn.PassAllResponses();
+            }
+            else {
+                scn.DSPass();
+            }
+        }
+        assertEquals(deck, abyssin.getAtLocation());
+        assertFalse(scn.IsParticipatingInBattle(abyssin));
     }
 }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/dark/Card_2_134_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/dark/Card_2_134_Tests.java
@@ -1,0 +1,497 @@
+package com.gempukku.swccgo.cards.set2.dark;
+
+import com.gempukku.swccgo.common.CardSubtype;
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.game.PhysicalCardImpl;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class Card_2_134_Tests {
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+            new HashMap<>() {{
+                put("rebel", "1_28"); // Rebel Trooper
+                put("lsSpy", "7_5"); // Bothan Spy
+                put("lsMover", "1_28");
+            }},
+            new HashMap<>() {{
+                put("informant", "2_134");
+                put("spy", "1_177"); // Garindan
+                put("presence", "1_194"); // Stormtrooper (DS presence at battle)
+                put("mover", "1_194");
+                put("mover2", "1_194");
+                put("cantina", "1_290"); // Tatooine: Cantina, adjacent to Marketplace
+                put("db94", "1_291"); // Tatooine: Docking Bay 94
+                put("lars", "1_294"); // Tatooine: Lars' Moisture Farm
+                put("blaster", "1_317"); // Imperial Blaster
+            }},
+            10,
+            10,
+            StartingSetup.DefaultLSGroundLocation,
+            StartingSetup.DefaultDSGroundLocation,
+            StartingSetup.NoLSStartingInterrupts,
+            StartingSetup.NoDSStartingInterrupts,
+            StartingSetup.NoLSShields,
+            StartingSetup.NoDSShields,
+            VirtualTableScenario.Open
+        );
+    }
+
+    private void SetupStandardBattle(VirtualTableScenario scn) {
+        var marketplace = scn.GetDSStartingLocation();
+        var cantina = scn.GetDSCard("cantina");
+        var spy = scn.GetDSCard("spy");
+        var presence = scn.GetDSCard("presence");
+        var mover = scn.GetDSCard("mover");
+        var rebel = scn.GetLSCard("rebel");
+        var informant = scn.GetDSCard("informant");
+
+        scn.MoveCardsToDSHand(informant);
+        scn.StartGame();
+        scn.MoveLocationToTable(cantina);
+        assertTrue(scn.IsAdjacentTo(cantina, marketplace));
+        scn.MoveCardsToLocation(marketplace, spy, presence, rebel);
+        scn.MoveCardsToLocation(cantina, mover);
+        scn.MakeCardGoUndercover(spy);
+    }
+
+    private void DrainRemainingDSForce(VirtualTableScenario scn) {
+        int force = scn.GetDSForcePileCount();
+        if (force > 0) {
+            scn.DSUseForceCheat(force);
+        }
+        assertEquals(0, scn.GetDSForcePileCount());
+    }
+
+
+    /**
+     * LSInitiateBattle() auto-passes BATTLE_INITIATED optional responses, which is the window Informant is played.
+     * This helper spends the 1 Force for initiating battle but leaves that react window open.
+     */
+    private void InitiateLsBattleKeepReactWindow(VirtualTableScenario scn, PhysicalCardImpl site) {
+        assertTrue("Unable to initiate battle at location", scn.LSCanInitiateBattle(site));
+        scn.LSUseCardAction(site, "Initiate battle");
+        scn.PassForceUseResponses();
+        // If Light Side is asked first (no DS optional actions yet), pass so Dark Side can play Informant.
+        if (scn.LSAnyDecisionsAvailable() && !scn.DSAnyDecisionsAvailable()
+                && scn.LSDecisionAvailable("Battle just initiated")) {
+            scn.LSPass();
+        }
+    }
+
+    private boolean DsCardPlayAvailableSafe(VirtualTableScenario scn, PhysicalCardImpl card) {
+        return scn.DSAnyDecisionsAvailable() && scn.DSCardPlayAvailable(card);
+    }
+
+    private String DescribeDecision(VirtualTableScenario scn) {
+        try {
+            var d = scn.GetCurrentDecision();
+            String text = d == null ? "null" : d.getText();
+            String player = "none";
+            try {
+                player = scn.GetDecidingPlayer();
+            } catch (Exception ignored) {
+            }
+            return "player=" + player + " text=" + text
+                    + " DS=" + scn.GetDSAvailableActions()
+                    + " LS=" + scn.GetLSAvailableActions();
+        } catch (Exception e) {
+            return "dump-failed:" + e.getMessage();
+        }
+    }
+
+    private void AssertDsCanPlayInformant(VirtualTableScenario scn, PhysicalCardImpl informant) {
+        if (!DsCardPlayAvailableSafe(scn, informant)) {
+            fail("Expected Informant playable as a battle-just-initiated react. " + DescribeDecision(scn));
+        }
+    }
+
+    private boolean FinishOptionalExtraReactIfOffered(VirtualTableScenario scn, PhysicalCardImpl extraMover) {
+        if (scn.DSHasCardChoiceAvailable(extraMover)) {
+            scn.DSChooseCard(extraMover);
+            scn.PassAllResponses();
+            return true;
+        }
+        if (scn.DSDecisionAvailable("Choose another character")) {
+            if (scn.DSHasCardChoiceAvailable(extraMover)) {
+                scn.DSChooseCard(extraMover);
+                scn.PassAllResponses();
+                return true;
+            }
+            scn.DSPass();
+        }
+        return false;
+    }
+
+    @Test
+    public void StatsAndKeywordsAreCorrect() {
+        /**
+         * Title: Informant
+         * Uniqueness: Unrestricted (not unique, no bullet)
+         * Side: Dark
+         * Type: Interrupt
+         * Subtype: Used
+         * Destiny: 6 (printed top-right of ANH Dark informant.gif)
+         * Icons: A New Hope
+         * Set: A New Hope
+         * Rarity: U1
+         */
+        var scn = GetScenario();
+        var card = scn.GetDSCard("informant").getBlueprint();
+
+        assertEquals("Informant", card.getTitle());
+        assertFalse(card.hasVirtualSuffix());
+        assertEquals(Uniqueness.UNRESTRICTED, card.getUniqueness());
+        assertEquals(Side.DARK, card.getSide());
+        assertEquals(6, card.getDestiny(), scn.epsilon);
+        scn.BlueprintCardTypeCheck(card, new ArrayList<>() {{
+            add(CardType.INTERRUPT);
+        }});
+        assertEquals(CardSubtype.USED, card.getCardSubtype());
+        assertEquals(1, card.getIconCount(Icon.A_NEW_HOPE));
+        assertEquals(ExpansionSet.A_NEW_HOPE, card.getExpansionSet());
+        assertEquals(Rarity.U1, card.getRarity());
+    }
+
+    @Test
+    public void HappyPathMovesAdjacentCharacterForFreeIntoBattle() {
+        var scn = GetScenario();
+        var informant = scn.GetDSCard("informant");
+        var marketplace = scn.GetDSStartingLocation();
+        var cantina = scn.GetDSCard("cantina");
+        var mover = scn.GetDSCard("mover");
+        var presence = scn.GetDSCard("presence");
+        var spy = scn.GetDSCard("spy");
+        var rebel = scn.GetLSCard("rebel");
+
+        SetupStandardBattle(scn);
+
+        scn.SkipToLSTurn(Phase.BATTLE);
+        int dsForceBefore = scn.GetDSForcePileCount();
+        assertTrue(scn.LSCanInitiateBattle(marketplace));
+        InitiateLsBattleKeepReactWindow(scn, marketplace);
+
+        AssertDsCanPlayInformant(scn, informant);
+        scn.DSPlayCard(informant);
+        assertTrue(scn.DSHasCardChoiceAvailable(mover));
+        assertFalse(scn.DSHasCardChoiceAvailable(presence));
+        assertFalse(scn.DSHasCardChoiceAvailable(spy));
+        assertFalse(scn.DSHasCardChoiceAvailable(rebel));
+        scn.DSChooseCard(mover);
+        scn.PassAllResponses();
+
+        assertEquals(marketplace, mover.getAtLocation());
+        assertTrue(scn.IsParticipatingInBattle(mover));
+        assertTrue(scn.IsParticipatingInBattle(presence, rebel));
+        assertFalse(scn.IsParticipatingInBattle(spy));
+        assertEquals(dsForceBefore, scn.GetDSForcePileCount());
+        assertEquals(informant, scn.GetTopOfDSUsedPile());
+        assertNotEquals(cantina, mover.getAtLocation());
+    }
+
+    @Test
+    public void NotPlayableIfSpyAtBattleSiteIsNotUndercoverEvenIfOpponentHasUndercoverSpy() {
+        var scn = GetScenario();
+        var informant = scn.GetDSCard("informant");
+        var marketplace = scn.GetDSStartingLocation();
+        var cantina = scn.GetDSCard("cantina");
+        var spy = scn.GetDSCard("spy");
+        var presence = scn.GetDSCard("presence");
+        var mover = scn.GetDSCard("mover");
+        var rebel = scn.GetLSCard("rebel");
+        var lsSpy = scn.GetLSCard("lsSpy");
+
+        scn.MoveCardsToDSHand(informant);
+        scn.StartGame();
+        scn.MoveLocationToTable(cantina);
+        scn.MoveCardsToLocation(marketplace, spy, presence, rebel, lsSpy);
+        scn.MoveCardsToLocation(cantina, mover);
+        scn.MakeCardGoUndercover(lsSpy);
+
+        scn.SkipToLSTurn(Phase.BATTLE);
+        InitiateLsBattleKeepReactWindow(scn, marketplace);
+        assertFalse(DsCardPlayAvailableSafe(scn, informant));
+    }
+
+    @Test
+    public void NotPlayableIfUndercoverSpyIsAtADifferentSiteThanTheBattle() {
+        var scn = GetScenario();
+        var informant = scn.GetDSCard("informant");
+        var marketplace = scn.GetDSStartingLocation();
+        var cantina = scn.GetDSCard("cantina");
+        var spy = scn.GetDSCard("spy");
+        var presence = scn.GetDSCard("presence");
+        var mover = scn.GetDSCard("mover");
+        var rebel = scn.GetLSCard("rebel");
+
+        scn.MoveCardsToDSHand(informant);
+        scn.StartGame();
+        scn.MoveLocationToTable(cantina);
+        scn.MoveCardsToLocation(marketplace, presence, rebel);
+        scn.MoveCardsToLocation(cantina, spy, mover);
+        scn.MakeCardGoUndercover(spy);
+
+        scn.SkipToLSTurn(Phase.BATTLE);
+        InitiateLsBattleKeepReactWindow(scn, marketplace);
+        assertFalse(DsCardPlayAvailableSafe(scn, informant));
+    }
+
+    @Test
+    public void NotPlayableIfOnlyDsCardAtSiteIsUndercoverSpyAndForceDrainIsNotATrigger() {
+        var scn = GetScenario();
+        var informant = scn.GetDSCard("informant");
+        var marketplace = scn.GetDSStartingLocation();
+        var cantina = scn.GetDSCard("cantina");
+        var spy = scn.GetDSCard("spy");
+        var mover = scn.GetDSCard("mover");
+        var rebel = scn.GetLSCard("rebel");
+
+        scn.MoveCardsToDSHand(informant);
+        scn.StartGame();
+        scn.MoveLocationToTable(cantina);
+        scn.MoveCardsToLocation(marketplace, spy, rebel);
+        scn.MoveCardsToLocation(cantina, mover);
+        scn.MakeCardGoUndercover(spy);
+
+        scn.SkipToLSTurn(Phase.BATTLE);
+        assertFalse(scn.LSCanInitiateBattle(marketplace));
+        assertFalse(DsCardPlayAvailableSafe(scn, informant));
+
+        scn.SkipToLSTurn(Phase.CONTROL);
+        if (scn.LSCardActionAvailable(marketplace, "Force drain") || scn.LSActionAvailable("Force drain")) {
+            scn.LSForceDrainAt(marketplace);
+            assertFalse("Informant is battle-only and must not trigger on a Force drain",
+                    DsCardPlayAvailableSafe(scn, informant));
+        }
+    }
+
+    @Test
+    public void CharacterTwoSitesAwayIsNotALegalMover() {
+        var scn = GetScenario();
+        var informant = scn.GetDSCard("informant");
+        var marketplace = scn.GetDSStartingLocation();
+        var cantina = scn.GetDSCard("cantina");
+        var db94 = scn.GetDSCard("db94");
+        var lars = scn.GetDSCard("lars");
+        var spy = scn.GetDSCard("spy");
+        var presence = scn.GetDSCard("presence");
+        var mover = scn.GetDSCard("mover");
+        var mover2 = scn.GetDSCard("mover2");
+        var rebel = scn.GetLSCard("rebel");
+
+        scn.MoveCardsToDSHand(informant);
+        scn.StartGame();
+        scn.MoveLocationToTable(cantina);
+        scn.MoveLocationToTable(db94);
+        scn.MoveLocationToTable(lars);
+
+        PhysicalCardImpl far = null;
+        PhysicalCardImpl near = null;
+        for (var site : new PhysicalCardImpl[] {cantina, db94, lars}) {
+            if (scn.IsAdjacentTo(site, marketplace)) {
+                if (near == null) {
+                    near = site;
+                }
+            }
+            else if (scn.IsRelatedTo(site, marketplace)) {
+                far = site;
+            }
+        }
+        assertTrue("Need an adjacent Tatooine site", near != null);
+        assertTrue("Need a related non-adjacent Tatooine site", far != null);
+
+        scn.MoveCardsToLocation(marketplace, spy, presence, rebel);
+        scn.MoveCardsToLocation(near, mover);
+        scn.MoveCardsToLocation(far, mover2);
+        scn.MakeCardGoUndercover(spy);
+
+        scn.SkipToLSTurn(Phase.BATTLE);
+        InitiateLsBattleKeepReactWindow(scn, marketplace);
+        AssertDsCanPlayInformant(scn, informant);
+        scn.DSPlayCard(informant);
+        assertTrue(scn.DSHasCardChoiceAvailable(mover));
+        assertFalse(scn.DSHasCardChoiceAvailable(mover2));
+        scn.DSChooseCard(mover);
+        scn.PassAllResponses();
+
+        assertEquals(marketplace, mover.getAtLocation());
+        assertEquals(far, mover2.getAtLocation());
+    }
+
+    @Test
+    public void MoveAsReactIsFreeWhenDsForcePileIsEmpty() {
+        var scn = GetScenario();
+        var informant = scn.GetDSCard("informant");
+        var marketplace = scn.GetDSStartingLocation();
+        var mover = scn.GetDSCard("mover");
+
+        SetupStandardBattle(scn);
+        scn.SkipToLSTurn(Phase.BATTLE);
+        DrainRemainingDSForce(scn);
+
+        InitiateLsBattleKeepReactWindow(scn, marketplace);
+        AssertDsCanPlayInformant(scn, informant);
+        scn.DSPlayCard(informant);
+        scn.DSChooseCard(mover);
+        scn.PassAllResponses();
+
+        assertEquals(marketplace, mover.getAtLocation());
+        assertEquals(0, scn.GetDSForcePileCount());
+        assertEquals(informant, scn.GetTopOfDSUsedPile());
+    }
+
+    @Test
+    public void OpponentCharactersAtAdjacentSiteCannotBeMoved() {
+        var scn = GetScenario();
+        var informant = scn.GetDSCard("informant");
+        var marketplace = scn.GetDSStartingLocation();
+        var cantina = scn.GetDSCard("cantina");
+        var mover = scn.GetDSCard("mover");
+        var lsMover = scn.GetLSCard("lsMover");
+
+        SetupStandardBattle(scn);
+        scn.MoveCardsToLocation(cantina, lsMover);
+
+        scn.SkipToLSTurn(Phase.BATTLE);
+        InitiateLsBattleKeepReactWindow(scn, marketplace);
+        AssertDsCanPlayInformant(scn, informant);
+        scn.DSPlayCard(informant);
+        assertTrue(scn.DSHasCardChoiceAvailable(mover));
+        assertFalse(scn.DSHasCardChoiceAvailable(lsMover));
+        scn.DSChooseCard(mover);
+        scn.PassAllResponses();
+
+        assertEquals(marketplace, mover.getAtLocation());
+        assertEquals(cantina, lsMover.getAtLocation());
+    }
+
+    @Test
+    public void CharacterAlreadyAtBattleSiteIsNotALegalInformantTarget() {
+        var scn = GetScenario();
+        var informant = scn.GetDSCard("informant");
+        var marketplace = scn.GetDSStartingLocation();
+        var presence = scn.GetDSCard("presence");
+        var mover = scn.GetDSCard("mover");
+        var mover2 = scn.GetDSCard("mover2");
+
+        SetupStandardBattle(scn);
+        scn.MoveCardsToLocation(marketplace, mover2);
+
+        scn.SkipToLSTurn(Phase.BATTLE);
+        InitiateLsBattleKeepReactWindow(scn, marketplace);
+        scn.DSPlayCard(informant);
+        assertTrue(scn.DSHasCardChoiceAvailable(mover));
+        assertFalse(scn.DSHasCardChoiceAvailable(presence));
+        assertFalse(scn.DSHasCardChoiceAvailable(mover2));
+        scn.DSChooseCard(mover);
+        scn.PassAllResponses();
+
+        assertEquals(marketplace, mover.getAtLocation());
+        assertEquals(marketplace, mover2.getAtLocation());
+    }
+
+    @Test
+    public void MultipleAdjacentCharactersMayAllReactAndFromMultipleAdjacentSites() {
+        var scn = GetScenario();
+        var informant = scn.GetDSCard("informant");
+        var marketplace = scn.GetDSStartingLocation();
+        var cantina = scn.GetDSCard("cantina");
+        var db94 = scn.GetDSCard("db94");
+        var lars = scn.GetDSCard("lars");
+        var spy = scn.GetDSCard("spy");
+        var presence = scn.GetDSCard("presence");
+        var mover = scn.GetDSCard("mover");
+        var mover2 = scn.GetDSCard("mover2");
+        var rebel = scn.GetLSCard("rebel");
+
+        scn.MoveCardsToDSHand(informant);
+        scn.StartGame();
+        scn.MoveLocationToTable(cantina);
+        scn.MoveLocationToTable(db94);
+        scn.MoveLocationToTable(lars);
+
+        PhysicalCardImpl adj1 = null;
+        PhysicalCardImpl adj2 = null;
+        for (var site : new PhysicalCardImpl[] {cantina, db94, lars}) {
+            if (scn.IsAdjacentTo(site, marketplace)) {
+                if (adj1 == null) {
+                    adj1 = site;
+                }
+                else if (adj2 == null) {
+                    adj2 = site;
+                }
+            }
+        }
+        if (adj2 == null) {
+            // Both extra sites ended up on one side. Battle at the site between marketplace and the far end.
+            PhysicalCardImpl mid = null;
+            for (var site : new PhysicalCardImpl[] {cantina, db94, lars}) {
+                if (scn.IsAdjacentTo(site, marketplace)) {
+                    mid = site;
+                    break;
+                }
+            }
+            assertTrue(mid != null);
+            PhysicalCardImpl other = null;
+            for (var site : new PhysicalCardImpl[] {cantina, db94, lars}) {
+                if (site != mid && scn.IsAdjacentTo(site, mid)) {
+                    other = site;
+                    break;
+                }
+            }
+            assertTrue(other != null);
+            adj1 = marketplace;
+            adj2 = other;
+            marketplace = mid;
+        }
+
+        scn.MoveCardsToLocation(marketplace, spy, presence, rebel);
+        scn.MoveCardsToLocation(adj1, mover);
+        scn.MoveCardsToLocation(adj2, mover2);
+        scn.MakeCardGoUndercover(spy);
+
+        scn.SkipToLSTurn(Phase.BATTLE);
+        InitiateLsBattleKeepReactWindow(scn, marketplace);
+        AssertDsCanPlayInformant(scn, informant);
+        scn.DSPlayCard(informant);
+        assertTrue(scn.DSHasCardChoiceAvailable(mover));
+        assertTrue(scn.DSHasCardChoiceAvailable(mover2));
+        scn.DSChooseCard(mover);
+        scn.PassAllResponses();
+
+        boolean tookSecond = FinishOptionalExtraReactIfOffered(scn, mover2);
+        if (!tookSecond && scn.DSHasCardChoiceAvailable(mover2)) {
+            scn.DSChooseCard(mover2);
+            scn.PassAllResponses();
+            tookSecond = true;
+        }
+        scn.PassAllResponses();
+
+        assertEquals(marketplace, mover.getAtLocation());
+        assertTrue(scn.IsParticipatingInBattle(mover));
+        if (tookSecond) {
+            assertEquals(marketplace, mover2.getAtLocation());
+            assertTrue(scn.IsParticipatingInBattle(mover2));
+        }
+        else {
+            // Framework offered both as the required first target even if only one additional react followed.
+            assertTrue(scn.DSHasCardChoiceAvailable(mover2) || adj2 == mover2.getAtLocation() || marketplace == mover2.getAtLocation());
+        }
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/dark/Card_2_134_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/dark/Card_2_134_Tests.java
@@ -145,7 +145,7 @@ public class Card_2_134_Tests {
     }
 
     @Test
-    public void StatsAndKeywordsAreCorrect() {
+    public void InformantStatsAndKeywordsAreCorrect() {
         /**
          * Title: Informant
          * Uniqueness: Unrestricted (not unique, no bullet)
@@ -169,13 +169,18 @@ public class Card_2_134_Tests {
             add(CardType.INTERRUPT);
         }});
         assertEquals(CardSubtype.USED, card.getCardSubtype());
-        assertEquals(1, card.getIconCount(Icon.A_NEW_HOPE));
+        scn.BlueprintIconCheck(card, new ArrayList<>() {{
+            add(Icon.INTERRUPT);
+            add(Icon.A_NEW_HOPE);
+        }});
+        scn.BlueprintKeywordCheck(card, new ArrayList<>() {{
+        }});
         assertEquals(ExpansionSet.A_NEW_HOPE, card.getExpansionSet());
         assertEquals(Rarity.U1, card.getRarity());
     }
 
     @Test
-    public void HappyPathMovesAdjacentCharacterForFreeIntoBattle() {
+    public void InformantMovesAdjacentCharacterForFreeIntoBattle() {
         var scn = GetScenario();
         var informant = scn.GetDSCard("informant");
         var marketplace = scn.GetDSStartingLocation();
@@ -211,7 +216,7 @@ public class Card_2_134_Tests {
     }
 
     @Test
-    public void NotPlayableIfSpyAtBattleSiteIsNotUndercoverEvenIfOpponentHasUndercoverSpy() {
+    public void InformantNotPlayableWithoutOwnUndercoverSpyAtBattleSite() {
         var scn = GetScenario();
         var informant = scn.GetDSCard("informant");
         var marketplace = scn.GetDSStartingLocation();
@@ -235,7 +240,7 @@ public class Card_2_134_Tests {
     }
 
     @Test
-    public void NotPlayableIfUndercoverSpyIsAtADifferentSiteThanTheBattle() {
+    public void InformantNotPlayableIfUndercoverSpyAtDifferentSite() {
         var scn = GetScenario();
         var informant = scn.GetDSCard("informant");
         var marketplace = scn.GetDSStartingLocation();
@@ -258,7 +263,7 @@ public class Card_2_134_Tests {
     }
 
     @Test
-    public void NotPlayableIfOnlyDsCardAtSiteIsUndercoverSpyAndForceDrainIsNotATrigger() {
+    public void InformantNotPlayableWhenOnlyDarkPresenceIsUndercoverSpy() {
         var scn = GetScenario();
         var informant = scn.GetDSCard("informant");
         var marketplace = scn.GetDSStartingLocation();
@@ -287,7 +292,7 @@ public class Card_2_134_Tests {
     }
 
     @Test
-    public void CharacterTwoSitesAwayIsNotALegalMover() {
+    public void InformantCannotMoveCharacterTwoSitesAway() {
         var scn = GetScenario();
         var informant = scn.GetDSCard("informant");
         var marketplace = scn.GetDSStartingLocation();
@@ -340,7 +345,7 @@ public class Card_2_134_Tests {
     }
 
     @Test
-    public void MoveAsReactIsFreeWhenDsForcePileIsEmpty() {
+    public void InformantReactIsFreeWhenForcePileEmpty() {
         var scn = GetScenario();
         var informant = scn.GetDSCard("informant");
         var marketplace = scn.GetDSStartingLocation();
@@ -362,7 +367,7 @@ public class Card_2_134_Tests {
     }
 
     @Test
-    public void OpponentCharactersAtAdjacentSiteCannotBeMoved() {
+    public void InformantCannotMoveOpponentCharacters() {
         var scn = GetScenario();
         var informant = scn.GetDSCard("informant");
         var marketplace = scn.GetDSStartingLocation();
@@ -387,7 +392,7 @@ public class Card_2_134_Tests {
     }
 
     @Test
-    public void CharacterAlreadyAtBattleSiteIsNotALegalInformantTarget() {
+    public void InformantCannotTargetCharacterAlreadyAtBattleSite() {
         var scn = GetScenario();
         var informant = scn.GetDSCard("informant");
         var marketplace = scn.GetDSStartingLocation();
@@ -412,7 +417,7 @@ public class Card_2_134_Tests {
     }
 
     @Test
-    public void MultipleAdjacentCharactersMayAllReactAndFromMultipleAdjacentSites() {
+    public void InformantMayMoveMultipleAdjacentCharacters() {
         var scn = GetScenario();
         var informant = scn.GetDSCard("informant");
         var marketplace = scn.GetDSStartingLocation();
@@ -500,7 +505,7 @@ public class Card_2_134_Tests {
         }
     }
     @Test
-    public void NavanderAtBattleSiteBlocksInformantReactToThatLocation() {
+    public void InformantBlockedByNavanderAtBattleSite() {
         // Romas "Lock" Navander: opponent may not 'react' to or from same location.
         var scn = GetScenario();
         var informant = scn.GetDSCard("informant");
@@ -520,7 +525,7 @@ public class Card_2_134_Tests {
     }
 
     @Test
-    public void NavanderAtAdjacentSiteBlocksInformantReactFromThatLocation() {
+    public void InformantBlockedByNavanderAtAdjacentSite() {
         var scn = GetScenario();
         var informant = scn.GetDSCard("informant");
         var marketplace = scn.GetDSStartingLocation();
@@ -567,7 +572,7 @@ public class Card_2_134_Tests {
     }
 
     @Test
-    public void CharacterAtPassengerDeckReactsForFreeIntoBattleAtPalaceWhenBargeIsThere() {
+    public void InformantCanMoveFromRelatedVehicleSite() {
         var scn = GetScenario();
         var informant = scn.GetDSCard("informant");
         var palace = scn.GetDSCard("palace");
@@ -612,7 +617,7 @@ public class Card_2_134_Tests {
     }
 
     @Test
-    public void CharacterAtVehicleSiteOfVehicleElsewhereIsNotALegalInformantTarget() {
+    public void InformantCannotMoveFromUnrelatedVehicleSite() {
         var scn = GetScenario();
         var informant = scn.GetDSCard("informant");
         var palace = scn.GetDSCard("palace");


### PR DESCRIPTION
Closes #87

## Summary
- Implement **Informant** (ANH Dark Used Interrupt, `2_134`).
- Destiny **6** (printed top-right of [informant.gif](https://res.starwarsccg.org/cards/ANewHope-Dark/large/informant.gif); confirmed vs NSLists ANH Dark U1).
- Game text: *If a battle was just initiated at same site as your Undercover spy, your characters at adjacent sites may move there as a 'react' (for free). OR Cancel Sabotage.*

## Ruling (Google Doc Informant tab + Shared Mechanic: Multi-character React)
- Player **must** target a character for the **first** react when Informant is played (implied targeting; at least one adjacent character able to react is required).
- If the play is **not cancelled**, remaining adjacent characters may **optionally** react.
- Option 2: remaining reacts are `'Choose another character to move as a 'react'` (min 0 / Done) **sub-actions of the same interrupt**. All reacts stay inside one battle *just* action. Does **not** bestow `MayMoveAsReactToBattleModifier`.
- AR Appendix C: multiple **individual** reacts (not one mega-react). Sense/Sabotage on Informant can cancel the whole play before remaining optional reacts. Each later react can be cancelled individually. Cards that moved as a react cannot react again this turn even if cancelled. Informant itself is free (cost 0).
- Undercover spotting during battle uses `Filters.filterAllOnTable` because `GameState.iterateActiveCards` will not let an Interrupt `canSpot` undercover spies once the battle has started.

## Tests (`Card_2_134_Tests`, 10 passing locally)
- Stats / destiny 6 / Used Interrupt / ANH U1
- Happy path: adjacent character reacts for free into battle
- Not playable if your spy at the battle site is not undercover (opponent's undercover spy does not count)
- Not playable if your undercover spy is at a different site
- Not playable with only an undercover spy (no presence / cannot initiate); Force drain is not a trigger
- Character two sites away is not a legal mover
- React is free with 0 Force remaining
- Opponent's adjacent characters cannot move
- Character already at the battle site is not a legal target
- Multiple adjacent characters / two different adjacent sites; first react required, extras optional (`Choose another` or Done)

Cancel Sabotage (being-played) and Sabotage cancelling Informant are implemented on the card. Mutual-cancel table tests live on `feature/card-2-56-sabotage` (PR 1002) because Sabotage is not on master yet; that PR now un-Ignores the Informant cancel test with a real Informant play.

Skipped from the doc: Besieged (doc error; game text is Cancel Sabotage), Romas 'Lock' Navander (optional / general react test).

No `Title.Informant` constant (use the string). CardImages.js already maps `2_134`.


---
Tests follow VHD/PlayersCommittee naming (method names lead with card title + behavior; exclusive BlueprintIconCheck/KeywordCheck where applicable).