### PR TITLE
Implement Targeting Computer (1_39)

### DIFF
--- a/src/gemp-swccg-async/src/main/web/js/gemp-016/gameUi.js
+++ b/src/gemp-swccg-async/src/main/web/js/gemp-016/gameUi.js
@@ -2405,12 +2405,13 @@ var GempSwccgGameUI = Class.extend({
         var text = decision.getAttribute("text");
         var results = this.getDecisionParameters(decision, "results");
         var defaultIndex = this.getDecisionParameter(decision, "defaultIndex");
+        var asButtons = this.getDecisionParameter(decision, "asButtons") == "true";
 
         var that = this;
         this.smallDialog
             .html(text);
 
-        if (results.length > 2 || this.settingsAlwaysDropDown || defaultIndex >= 0) {
+        if (!asButtons && (results.length > 2 || this.settingsAlwaysDropDown || defaultIndex >= 0)) {
             var html = "<br /><select id='multipleChoiceDecision'>";
             for (var i = 0; i < results.length; i++) {
                 html += "<option " + (i == defaultIndex ? "selected='selected' " : "") + "value='" + i + "'>" + results[i] + "</option>";

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
@@ -215,7 +215,7 @@ public class Card1_039 extends AbstractDevice {
                 game.getGameState(), soc.getCardFiringWeapon(), weapon, null,
                 Collections.singletonList(target), combined);
         soc.markResolved();
-        game.getGameState().sendMessage("Combined total weapon destiny (completed firings only): " + GuiUtils.formatAsString(totalDestiny));
+        game.getGameState().sendMessage(soc.getCombinedTotalDestinyMessage(GuiUtils.formatAsString(totalDestiny)));
         float defenseValue = game.getModifiersQuerying().getDefenseValue(game.getGameState(), target);
         game.getGameState().sendMessage("Defense value: " + GuiUtils.formatAsString(defenseValue));
         if (totalDestiny > defenseValue) {

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
@@ -287,7 +287,7 @@ public class Card1_039 extends AbstractDevice {
         @Override
         protected FullEffectResult playEffectReturningResult(SwccgGame game) {
             game.getUserFeedback().sendAwaitingDecision(_playerId,
-                    new MultipleChoiceAwaitingDecision("Fire a weapon twice", new String[]{"Separately", "Combined", "Don't Fire (Cancel)"}) {
+                    new MultipleChoiceAwaitingDecision("Fire a weapon twice", new String[]{"Separately", "Combined", "Don't Fire (Cancel)"}, true) {
                         @Override
                         protected void validDecisionMade(int index, String result) {
                             modeChosen(result);

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
@@ -139,6 +139,17 @@ public class Card1_039 extends AbstractDevice {
                                             action.appendUsage(
                                                     new UseDeviceEffect(action, self));
                                             game.getGameState().beginSeparatelyOrCombinedFiring(self, weapon, combined);
+                                            // Always clear separately-or-combined firing when this action leaves the stack.
+                                            // Nested finish after shot 2 can be skipped if a required response (Defiance)
+                                            // completes the nested fire without running remaining parent effects.
+                                            action.appendAfterEffect(
+                                                    new PassthruEffect(action) {
+                                                        @Override
+                                                        protected void doPlayEffect(SwccgGame game) {
+                                                            game.getGameState().finishSeparatelyOrCombinedFiring();
+                                                        }
+                                                    }
+                                            );
                                             final String mode = result.toLowerCase();
                                             action.appendEffect(
                                                     new PassthruEffect(action) {

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
@@ -3,8 +3,8 @@ package com.gempukku.swccgo.cards.set1.light;
 import com.gempukku.swccgo.cards.AbstractDevice;
 import com.gempukku.swccgo.cards.GameConditions;
 import com.gempukku.swccgo.cards.effects.UseDeviceEffect;
-import com.gempukku.swccgo.cards.effects.usage.OncePerBattleEffect;
 import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.GameTextActionId;
 import com.gempukku.swccgo.common.PlayCardOptionId;
 import com.gempukku.swccgo.common.PlayCardZoneOption;
 import com.gempukku.swccgo.common.Rarity;
@@ -109,9 +109,12 @@ public class Card1_039 extends AbstractDevice {
                 Filters.attachedTo(Filters.and(Filters.hasAttached(self), Filters.participatingInBattle)),
                 Filters.canBeFired(self, 0, Filters.canBeTargetedBy(self)));
 
-        // Only usable during battle (forum p=1195641). Each copy is limited to one usage per battle (forum p=961994).
+        // Only usable during battle (forum p=1195641). Each copy is limited to one usage per turn
+        // (One Rule / Targeting Computer game text). OncePerBattle alone would re-offer the same copy
+        // in a later battle the same turn.
         if (GameConditions.isDuringBattle(game)
-                && GameConditions.isOncePerBattle(game, self, gameTextSourceCardId)
+                && GameConditions.isOncePerTurn(game, self, playerId, gameTextSourceCardId)
+                && GameConditions.isOncePerBattle(game, self, playerId, gameTextSourceCardId)
                 && GameConditions.canUseDevice(game, self)
                 && GameConditions.isDuringBattleWithParticipant(game, Filters.hasAttached(self))
                 && GameConditions.canSpot(game, self, weaponFilter)) {
@@ -119,7 +122,7 @@ public class Card1_039 extends AbstractDevice {
             final TopLevelGameTextAction action = new TopLevelGameTextAction(self, gameTextSourceCardId);
             action.setText("Fire a weapon twice");
             action.setActionMsg("use " + GameUtils.getCardLink(self) + " to fire a weapon twice");
-            // OncePerBattle / UseDevice wait until Separately or Combined so Don't Fire can abort unused.
+            // OncePerTurn / OncePerBattle / UseDevice wait until Separately or Combined so Don't Fire can abort unused.
             action.appendTargeting(
                     new ChooseCardOnTableEffect(action, playerId, "Choose weapon to fire twice", weaponFilter) {
                         @Override
@@ -139,9 +142,12 @@ public class Card1_039 extends AbstractDevice {
                                                 return;
                                             }
                                             final boolean combined = "Combined".equals(result);
-                                            action.appendUsage(
-                                                    new OncePerBattleEffect(action));
-                                            action.appendUsage(
+                                            // Increment here (not appendUsage): targeting has already started, so a
+                                            // usage-phase queue would never run OncePerTurn/OncePerBattle. Don't Fire
+                                            // returns before this, so cancel still leaves the copy unused.
+                                            game.getModifiersQuerying().getUntilEndOfTurnLimitCounter(self, playerId, gameTextSourceCardId, GameTextActionId.OTHER_CARD_ACTION_DEFAULT).incrementToLimit(1, 1);
+                                            game.getModifiersQuerying().getUntilEndOfBattleLimitCounter(self, playerId, gameTextSourceCardId, GameTextActionId.OTHER_CARD_ACTION_DEFAULT).incrementToLimit(1, 1);
+                                            action.appendEffect(
                                                     new UseDeviceEffect(action, self));
                                             game.getGameState().beginSeparatelyOrCombinedFiring(self, weapon, combined);
                                             // Clear separately-or-combined firing after shots, not at targeting-complete.

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
@@ -89,7 +89,12 @@ public class Card1_039 extends AbstractDevice {
             @Override
             public boolean isFulfilled(GameState gameState, ModifiersQuerying modifiersQuerying) {
                 SeparatelyOrCombinedFiringState soc = gameState.getSeparatelyOrCombinedFiringState();
-                return soc != null && soc.getDevice() != null && soc.getDevice().getCardId() == self.getCardId();
+                if (soc != null && soc.getDevice() != null && soc.getDevice().getCardId() == self.getCardId()) {
+                    return true;
+                }
+                // Fire-twice action can still be resolving if separately-or-combined state was cleared
+                // as soon as targeting completed. Keep -1 on both draws in that case.
+                return gameState.isDuringGameTextActionFrom(self);
             }
         };
         modifiers.add(new EachWeaponDestinyModifier(self, Filters.any, usingThisDeviceToFire, hasAttached, -1));
@@ -139,14 +144,19 @@ public class Card1_039 extends AbstractDevice {
                                             action.appendUsage(
                                                     new UseDeviceEffect(action, self));
                                             game.getGameState().beginSeparatelyOrCombinedFiring(self, weapon, combined);
-                                            // Always clear separately-or-combined firing when this action leaves the stack.
+                                            // Clear separately-or-combined firing after shots, not at targeting-complete.
                                             // Nested finish after shot 2 can be skipped if a required response (Defiance)
                                             // completes the nested fire without running remaining parent effects.
                                             action.appendAfterEffect(
                                                     new PassthruEffect(action) {
                                                         @Override
                                                         protected void doPlayEffect(SwccgGame game) {
-                                                            game.getGameState().finishSeparatelyOrCombinedFiring();
+                                                            // Do not clear at targeting-complete: destinies still need this state for -1.
+                                                            SeparatelyOrCombinedFiringState soc = game.getGameState().getSeparatelyOrCombinedFiringState();
+                                                            if (soc != null && soc.getCurrentFiringNumber() > 0
+                                                                    && !game.getGameState().isDuringWeaponFiring()) {
+                                                                game.getGameState().finishSeparatelyOrCombinedFiring();
+                                                            }
                                                         }
                                                     }
                                             );

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
@@ -11,16 +11,19 @@ import com.gempukku.swccgo.common.Rarity;
 import com.gempukku.swccgo.common.Side;
 import com.gempukku.swccgo.common.Title;
 import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.common.Keyword;
 import com.gempukku.swccgo.filters.Filter;
 import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.game.SwccgGame;
 import com.gempukku.swccgo.game.state.SeparatelyOrCombinedFiringState;
 import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.actions.FireWeaponAction;
 import com.gempukku.swccgo.logic.actions.TopLevelGameTextAction;
 import com.gempukku.swccgo.logic.decisions.MultipleChoiceAwaitingDecision;
 import com.gempukku.swccgo.logic.effects.FireWeaponEffect;
 import com.gempukku.swccgo.logic.effects.HitCardEffect;
+import com.gempukku.swccgo.logic.effects.IonizeStarshipEffect;
 import com.gempukku.swccgo.logic.effects.PlayoutDecisionEffect;
 import com.gempukku.swccgo.logic.effects.choose.ChooseCardOnTableEffect;
 import com.gempukku.swccgo.logic.modifiers.DefinedByGameTextDeployCostModifier;
@@ -131,8 +134,11 @@ public class Card1_039 extends AbstractDevice {
 
     /**
      * Fires the chosen weapon twice as sub-actions of this device action (no top-level action between shots).
-     * Pending rules: pay each firing's Force when that shot initiates. If the second shot cannot pay, the first
-     * still resolved when separately; when combined, completed firings still combine.
+     * Appendix B option A: Force is used for BOTH firings, but costs are paid as EACH shot initiates
+     * (not all upfront). After shot 1 completes, attempt shot 2; if the fire action cannot be built
+     * (typically remaining Force cannot pay that shot's cost), skip shot 2. Do not rewind shot 1 and
+     * do not fail the overall action. Combined: destinies from completed firings still combine, with
+     * total-modifiers applied once vs the single target.
      */
     private void appendFireTwice(final TopLevelGameTextAction action, final SwccgGame game, final PhysicalCard self,
                                  final PhysicalCard weapon, final boolean combined) {
@@ -145,6 +151,15 @@ public class Card1_039 extends AbstractDevice {
                         SeparatelyOrCombinedFiringState soc = game.getGameState().getSeparatelyOrCombinedFiringState();
                         if (combined && soc != null && soc.getCombinedTarget() != null) {
                             secondTargetFilter = Filters.sameCardId(soc.getCombinedTarget());
+                        }
+                        // Same check FireWeaponEffect uses: builder returns null when this shot cannot initiate.
+                        // Nested FireWeaponEffect already no-ops in that case (does not abort the parent);
+                        // skip appending shot 2 so combined can resolve from completed firings only.
+                        if (!canInitiateSocShot(game, self, weapon, secondTargetFilter)) {
+                            game.getGameState().sendMessage("Second firing does not initiate (cannot pay fire cost). Completed firings still count.");
+                            resolveCombinedIfStillPending(action, game, weapon);
+                            game.getGameState().finishSeparatelyOrCombinedFiring();
+                            return;
                         }
                         action.appendEffect(createFireTwiceShotEffect(action, weapon, secondTargetFilter));
                         action.appendEffect(
@@ -159,6 +174,17 @@ public class Card1_039 extends AbstractDevice {
                     }
                 }
         );
+    }
+
+    /**
+     * True if the weapon can currently begin a fire-weapon action for this SOC shot
+     * (Force remaining, legal target, per-battle limit ignored).
+     */
+    private boolean canInitiateSocShot(SwccgGame game, PhysicalCard self, PhysicalCard weapon, Filter fireAtTargetFilter) {
+        FireWeaponAction fireWeaponAction = weapon.getBlueprint().getFireWeaponAction(
+                weapon.getOwner(), game, weapon, false, 0, self, false,
+                Filters.none, null, fireAtTargetFilter, true);
+        return fireWeaponAction != null;
     }
 
     private FireWeaponEffect createFireTwiceShotEffect(Action action, PhysicalCard weapon, Filter fireAtTargetFilter) {
@@ -194,7 +220,13 @@ public class Card1_039 extends AbstractDevice {
         game.getGameState().sendMessage("Defense value: " + GuiUtils.formatAsString(defenseValue));
         if (totalDestiny > defenseValue) {
             game.getGameState().sendMessage("Result: Succeeded");
-            action.appendEffect(new HitCardEffect(action, target, weapon));
+            // Apply the weapon's actual result (Ion Cannon ionizes; most starship weapons hit).
+            if (weapon.getBlueprint().hasKeyword(Keyword.ION_CANNON)) {
+                action.appendEffect(new IonizeStarshipEffect(action, target, weapon, false, true, true));
+            }
+            else {
+                action.appendEffect(new HitCardEffect(action, target, weapon));
+            }
         }
         else {
             game.getGameState().sendMessage("Result: Failed");

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
@@ -24,15 +24,16 @@ import com.gempukku.swccgo.logic.decisions.MultipleChoiceAwaitingDecision;
 import com.gempukku.swccgo.logic.effects.FireWeaponEffect;
 import com.gempukku.swccgo.logic.effects.HitCardEffect;
 import com.gempukku.swccgo.logic.effects.IonizeStarshipEffect;
-import com.gempukku.swccgo.logic.effects.PlayoutDecisionEffect;
 import com.gempukku.swccgo.logic.effects.choose.ChooseCardOnTableEffect;
 import com.gempukku.swccgo.logic.modifiers.DefinedByGameTextDeployCostModifier;
 import com.gempukku.swccgo.logic.modifiers.EachWeaponDestinyModifier;
 import com.gempukku.swccgo.logic.modifiers.ManeuverModifier;
 import com.gempukku.swccgo.logic.modifiers.Modifier;
+import com.gempukku.swccgo.logic.timing.AbstractStandardEffect;
 import com.gempukku.swccgo.logic.timing.Action;
 import com.gempukku.swccgo.logic.timing.GuiUtils;
 import com.gempukku.swccgo.logic.timing.PassthruEffect;
+import com.gempukku.swccgo.logic.timing.TargetingEffect;
 
 import java.util.Collections;
 import java.util.LinkedList;
@@ -101,28 +102,45 @@ public class Card1_039 extends AbstractDevice {
 
             final TopLevelGameTextAction action = new TopLevelGameTextAction(self, gameTextSourceCardId);
             action.setText("Fire a weapon twice");
-            action.setActionMsg("Use " + GameUtils.getCardLink(self) + " to fire a weapon twice, separately or combined");
-            action.appendUsage(
-                    new OncePerBattleEffect(action));
-            action.appendUsage(
-                    new UseDeviceEffect(action, self));
-            action.appendEffect(
+            action.setActionMsg("use " + GameUtils.getCardLink(self) + " to fire a weapon twice");
+            // OncePerBattle / UseDevice wait until Separately or Combined so Don't Fire can abort unused.
+            action.appendTargeting(
                     new ChooseCardOnTableEffect(action, playerId, "Choose weapon to fire twice", weaponFilter) {
                         @Override
+                        protected boolean getUseShortcut() {
+                            // Auto-select the only legal weapon even though top-level actions allow abort.
+                            return true;
+                        }
+                        @Override
                         protected void cardSelected(final PhysicalCard weapon) {
-                            action.appendEffect(
-                                    new PlayoutDecisionEffect(action, playerId,
-                                            new MultipleChoiceAwaitingDecision("Fire twice separately or combined?", new String[]{"Separately", "Combined"}) {
-                                                @Override
-                                                protected void validDecisionMade(int index, String result) {
-                                                    final boolean combined = "Combined".equals(result);
-                                                    game.getGameState().beginSeparatelyOrCombinedFiring(self, weapon, combined);
-                                                    game.getGameState().sendMessage(playerId + " uses " + GameUtils.getCardLink(self)
-                                                            + " to fire " + GameUtils.getCardLink(weapon) + " twice " + result);
-                                                    appendFireTwice(action, game, self, weapon, combined);
-                                                }
+                            action.appendTargeting(
+                                    new FireTwiceModeEffect(action, playerId) {
+                                        @Override
+                                        protected void modeChosen(String result) {
+                                            if (result != null && result.startsWith("Don't Fire")) {
+                                                action.setActionMsg(null);
+                                                cancel();
+                                                return;
                                             }
-                                    )
+                                            final boolean combined = "Combined".equals(result);
+                                            action.appendUsage(
+                                                    new OncePerBattleEffect(action));
+                                            action.appendUsage(
+                                                    new UseDeviceEffect(action, self));
+                                            game.getGameState().beginSeparatelyOrCombinedFiring(self, weapon, combined);
+                                            final String mode = result.toLowerCase();
+                                            action.appendEffect(
+                                                    new PassthruEffect(action) {
+                                                        @Override
+                                                        protected void doPlayEffect(SwccgGame game) {
+                                                            game.getGameState().sendMessage(playerId + " uses " + GameUtils.getCardLink(self)
+                                                                    + " to fire " + GameUtils.getCardLink(weapon) + " twice: " + mode);
+                                                        }
+                                                    }
+                                            );
+                                            appendFireTwice(action, game, self, weapon, combined);
+                                        }
+                                    }
                             );
                         }
                     }
@@ -234,6 +252,48 @@ public class Card1_039 extends AbstractDevice {
         }
         else {
             game.getGameState().sendMessage("Result: Failed");
+        }
+    }
+
+    /**
+     * Targeting decision for Separately / Combined / Don't Fire.
+     * Don't Fire fails this cost so the parent action aborts unused (same as clicking Done).
+     */
+    private abstract static class FireTwiceModeEffect extends AbstractStandardEffect implements TargetingEffect {
+        private final String _playerId;
+        private boolean _cancelled;
+
+        private FireTwiceModeEffect(Action action, String playerId) {
+            super(action);
+            _playerId = playerId;
+        }
+
+        protected void cancel() {
+            _cancelled = true;
+        }
+
+        protected abstract void modeChosen(String result);
+
+        @Override
+        public boolean isPlayableInFull(SwccgGame game) {
+            return true;
+        }
+
+        @Override
+        public boolean wasCarriedOut() {
+            return super.wasCarriedOut() && !_cancelled;
+        }
+
+        @Override
+        protected FullEffectResult playEffectReturningResult(SwccgGame game) {
+            game.getUserFeedback().sendAwaitingDecision(_playerId,
+                    new MultipleChoiceAwaitingDecision("Fire a weapon twice", new String[]{"Separately", "Combined", "Don't Fire (Cancel)"}) {
+                        @Override
+                        protected void validDecisionMade(int index, String result) {
+                            modeChosen(result);
+                        }
+                    });
+            return new FullEffectResult(true);
         }
     }
 }

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
@@ -16,7 +16,10 @@ import com.gempukku.swccgo.filters.Filter;
 import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.game.state.GameState;
 import com.gempukku.swccgo.game.state.SeparatelyOrCombinedFiringState;
+import com.gempukku.swccgo.logic.conditions.Condition;
+import com.gempukku.swccgo.logic.modifiers.querying.ModifiersQuerying;
 import com.gempukku.swccgo.logic.GameUtils;
 import com.gempukku.swccgo.logic.actions.FireWeaponAction;
 import com.gempukku.swccgo.logic.actions.TopLevelGameTextAction;
@@ -80,8 +83,16 @@ public class Card1_039 extends AbstractDevice {
 
         List<Modifier> modifiers = new LinkedList<Modifier>();
         modifiers.add(new ManeuverModifier(self, hasAttached, 1));
-        // Continuous: -1 from each destiny draw when this starship fires, including fire-twice usage.
-        modifiers.add(new EachWeaponDestinyModifier(self, Filters.any, hasAttached, -1));
+        // Subtract 1 from each destiny draw only while this copy is used to fire a weapon twice.
+        // Attached but unused Targeting Computer does not modify ordinary weapon fire.
+        Condition usingThisDeviceToFire = new Condition() {
+            @Override
+            public boolean isFulfilled(GameState gameState, ModifiersQuerying modifiersQuerying) {
+                SeparatelyOrCombinedFiringState soc = gameState.getSeparatelyOrCombinedFiringState();
+                return soc != null && soc.getDevice() != null && soc.getDevice().getCardId() == self.getCardId();
+            }
+        };
+        modifiers.add(new EachWeaponDestinyModifier(self, Filters.any, usingThisDeviceToFire, hasAttached, -1));
         return modifiers;
     }
 

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
@@ -118,7 +118,7 @@ public class Card1_039 extends AbstractDevice {
                                                     final boolean combined = "Combined".equals(result);
                                                     game.getGameState().beginSeparatelyOrCombinedFiring(self, weapon, combined);
                                                     game.getGameState().sendMessage(playerId + " uses " + GameUtils.getCardLink(self)
-                                                            + " to fire " + GameUtils.getCardLink(weapon) + " twice " + result.toLowerCase());
+                                                            + " to fire " + GameUtils.getCardLink(weapon) + " twice " + result);
                                                     appendFireTwice(action, game, self, weapon, combined);
                                                 }
                                             }
@@ -215,12 +215,16 @@ public class Card1_039 extends AbstractDevice {
                 game.getGameState(), soc.getCardFiringWeapon(), weapon, null,
                 Collections.singletonList(target), combined);
         soc.markResolved();
-        game.getGameState().sendMessage(soc.getCombinedTotalDestinyMessage(GuiUtils.formatAsString(totalDestiny)));
         float defenseValue = game.getModifiersQuerying().getDefenseValue(game.getGameState(), target);
-        game.getGameState().sendMessage("Defense value: " + GuiUtils.formatAsString(defenseValue));
-        if (totalDestiny > defenseValue) {
+        game.getGameState().sendMessage(soc.getCombinedDestiniesMathMessage(
+                GuiUtils.formatAsString(combined), GuiUtils.formatAsString(totalDestiny),
+                GuiUtils.formatAsString(defenseValue)));
+        if (soc.getDrawDestinyEffect() != null) {
+            soc.getDrawDestinyEffect().applyDeferredWeaponResult(game, action, weapon,
+                    soc.getCardFiringWeapon(), null, target, soc.getVariableXSnapshot(), totalDestiny);
+        }
+        else if (totalDestiny > defenseValue) {
             game.getGameState().sendMessage("Result: Succeeded");
-            // Apply the weapon's actual result (Ion Cannon ionizes; most starship weapons hit).
             if (weapon.getBlueprint().hasKeyword(Keyword.ION_CANNON)) {
                 action.appendEffect(new IonizeStarshipEffect(action, target, weapon, false, true, true));
             }

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
@@ -1,0 +1,203 @@
+package com.gempukku.swccgo.cards.set1.light;
+
+import com.gempukku.swccgo.cards.AbstractDevice;
+import com.gempukku.swccgo.cards.GameConditions;
+import com.gempukku.swccgo.cards.effects.UseDeviceEffect;
+import com.gempukku.swccgo.cards.effects.usage.OncePerBattleEffect;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.PlayCardOptionId;
+import com.gempukku.swccgo.common.PlayCardZoneOption;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.filters.Filter;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.game.state.SeparatelyOrCombinedFiringState;
+import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.actions.TopLevelGameTextAction;
+import com.gempukku.swccgo.logic.decisions.MultipleChoiceAwaitingDecision;
+import com.gempukku.swccgo.logic.effects.FireWeaponEffect;
+import com.gempukku.swccgo.logic.effects.HitCardEffect;
+import com.gempukku.swccgo.logic.effects.PlayoutDecisionEffect;
+import com.gempukku.swccgo.logic.effects.choose.ChooseCardOnTableEffect;
+import com.gempukku.swccgo.logic.modifiers.DefinedByGameTextDeployCostModifier;
+import com.gempukku.swccgo.logic.modifiers.EachWeaponDestinyModifier;
+import com.gempukku.swccgo.logic.modifiers.ManeuverModifier;
+import com.gempukku.swccgo.logic.modifiers.Modifier;
+import com.gempukku.swccgo.logic.timing.Action;
+import com.gempukku.swccgo.logic.timing.GuiUtils;
+import com.gempukku.swccgo.logic.timing.PassthruEffect;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Set: Premiere
+ * Type: Device
+ * Title: Targeting Computer
+ */
+public class Card1_039 extends AbstractDevice {
+    public Card1_039() {
+        super(Side.LIGHT, 3, PlayCardZoneOption.ATTACHED, Title.Targeting_Computer, Uniqueness.UNRESTRICTED, ExpansionSet.PREMIERE, Rarity.U1);
+        setLore("Specially designed for use on Rebel starfighters. Assists pilots on torpedo runs. Automatically locks on pre-programmed target points.");
+        setGameText("Use 2 Force to deploy on any starship. Adds 1 to starship's maneuver. If this starship is using a weapon during a battle, you may fire that weapon twice, separately or combined. Subtract 1 from each destiny draw when firing.");
+    }
+
+    @Override
+    protected List<Modifier> getGameTextAlwaysOnModifiers(SwccgGame game, final PhysicalCard self) {
+        List<Modifier> modifiers = new LinkedList<Modifier>();
+        modifiers.add(new DefinedByGameTextDeployCostModifier(self, 2));
+        return modifiers;
+    }
+
+    @Override
+    protected Filter getGameTextValidDeployTargetFilter(SwccgGame game, PhysicalCard self, PlayCardOptionId playCardOptionId, boolean asReact) {
+        // "any starship" = any of your starships (fighter or capital), not opponent's
+        return Filters.and(Filters.your(self), Filters.starship);
+    }
+
+    @Override
+    protected Filter getGameTextValidToUseDeviceFilter(final SwccgGame game, final PhysicalCard self) {
+        return Filters.starship;
+    }
+
+    @Override
+    protected Filter getGameTextValidTargetFilterToRemainAttachedTo(final SwccgGame game, final PhysicalCard self) {
+        return Filters.starship;
+    }
+
+    @Override
+    protected List<Modifier> getGameTextWhileActiveInPlayModifiers(SwccgGame game, final PhysicalCard self) {
+        Filter hasAttached = Filters.hasAttached(self);
+
+        List<Modifier> modifiers = new LinkedList<Modifier>();
+        modifiers.add(new ManeuverModifier(self, hasAttached, 1));
+        // Continuous: -1 from each destiny draw when this starship fires, including fire-twice usage.
+        modifiers.add(new EachWeaponDestinyModifier(self, Filters.any, hasAttached, -1));
+        return modifiers;
+    }
+
+    @Override
+    protected List<TopLevelGameTextAction> getGameTextTopLevelActions(final String playerId, final SwccgGame game, final PhysicalCard self, int gameTextSourceCardId) {
+        final Filter weaponFilter = Filters.and(
+                Filters.your(self),
+                Filters.weapon,
+                Filters.attachedTo(Filters.and(Filters.hasAttached(self), Filters.participatingInBattle)),
+                Filters.canBeFired(self, 0, Filters.canBeTargetedBy(self)));
+
+        // Only usable during battle (forum p=1195641). Each copy is limited to one usage per battle (forum p=961994).
+        if (GameConditions.isDuringBattle(game)
+                && GameConditions.isOncePerBattle(game, self, gameTextSourceCardId)
+                && GameConditions.canUseDevice(game, self)
+                && GameConditions.isDuringBattleWithParticipant(game, Filters.hasAttached(self))
+                && GameConditions.canSpot(game, self, weaponFilter)) {
+
+            final TopLevelGameTextAction action = new TopLevelGameTextAction(self, gameTextSourceCardId);
+            action.setText("Fire a weapon twice");
+            action.setActionMsg("Use " + GameUtils.getCardLink(self) + " to fire a weapon twice, separately or combined");
+            action.appendUsage(
+                    new OncePerBattleEffect(action));
+            action.appendUsage(
+                    new UseDeviceEffect(action, self));
+            action.appendEffect(
+                    new ChooseCardOnTableEffect(action, playerId, "Choose weapon to fire twice", weaponFilter) {
+                        @Override
+                        protected void cardSelected(final PhysicalCard weapon) {
+                            action.appendEffect(
+                                    new PlayoutDecisionEffect(action, playerId,
+                                            new MultipleChoiceAwaitingDecision("Fire twice separately or combined?", new String[]{"Separately", "Combined"}) {
+                                                @Override
+                                                protected void validDecisionMade(int index, String result) {
+                                                    final boolean combined = "Combined".equals(result);
+                                                    game.getGameState().beginSeparatelyOrCombinedFiring(self, weapon, combined);
+                                                    game.getGameState().sendMessage(playerId + " uses " + GameUtils.getCardLink(self)
+                                                            + " to fire " + GameUtils.getCardLink(weapon) + " twice " + result.toLowerCase());
+                                                    appendFireTwice(action, game, self, weapon, combined);
+                                                }
+                                            }
+                                    )
+                            );
+                        }
+                    }
+            );
+            return Collections.singletonList(action);
+        }
+        return null;
+    }
+
+    /**
+     * Fires the chosen weapon twice as sub-actions of this device action (no top-level action between shots).
+     * Pending rules: pay each firing's Force when that shot initiates. If the second shot cannot pay, the first
+     * still resolved when separately; when combined, completed firings still combine.
+     */
+    private void appendFireTwice(final TopLevelGameTextAction action, final SwccgGame game, final PhysicalCard self,
+                                 final PhysicalCard weapon, final boolean combined) {
+        action.appendEffect(createFireTwiceShotEffect(action, weapon, Filters.any));
+        action.appendEffect(
+                new PassthruEffect(action) {
+                    @Override
+                    protected void doPlayEffect(SwccgGame game) {
+                        Filter secondTargetFilter = Filters.any;
+                        SeparatelyOrCombinedFiringState soc = game.getGameState().getSeparatelyOrCombinedFiringState();
+                        if (combined && soc != null && soc.getCombinedTarget() != null) {
+                            secondTargetFilter = Filters.sameCardId(soc.getCombinedTarget());
+                        }
+                        action.appendEffect(createFireTwiceShotEffect(action, weapon, secondTargetFilter));
+                        action.appendEffect(
+                                new PassthruEffect(action) {
+                                    @Override
+                                    protected void doPlayEffect(SwccgGame game) {
+                                        resolveCombinedIfStillPending(action, game, weapon);
+                                        game.getGameState().finishSeparatelyOrCombinedFiring();
+                                    }
+                                }
+                        );
+                    }
+                }
+        );
+    }
+
+    private FireWeaponEffect createFireTwiceShotEffect(Action action, PhysicalCard weapon, Filter fireAtTargetFilter) {
+        return new FireWeaponEffect(action, weapon, false, fireAtTargetFilter) {
+            @Override
+            protected boolean isignorePerAttackOrBattleLimit() {
+                // Second shot of the same overall action must ignore the weapon's once-per-battle firing.
+                return true;
+            }
+        };
+    }
+
+    /**
+     * If combined firing stored destinies but never resolved (second shot unpaid/canceled), apply total modifiers
+     * once to the completed firings and resolve against the stored target.
+     */
+    private void resolveCombinedIfStillPending(Action action, SwccgGame game, PhysicalCard weapon) {
+        SeparatelyOrCombinedFiringState soc = game.getGameState().getSeparatelyOrCombinedFiringState();
+        if (soc == null || !soc.isCombined() || soc.isResolved() || soc.getCompletedFiringCount() == 0) {
+            return;
+        }
+        PhysicalCard target = soc.getCombinedTarget();
+        if (target == null) {
+            return;
+        }
+        float combined = soc.getCombinedFiringDestinySum();
+        float totalDestiny = game.getModifiersQuerying().getTotalWeaponDestiny(
+                game.getGameState(), soc.getCardFiringWeapon(), weapon, null,
+                Collections.singletonList(target), combined);
+        soc.markResolved();
+        game.getGameState().sendMessage("Combined total weapon destiny (completed firings only): " + GuiUtils.formatAsString(totalDestiny));
+        float defenseValue = game.getModifiersQuerying().getDefenseValue(game.getGameState(), target);
+        game.getGameState().sendMessage("Defense value: " + GuiUtils.formatAsString(defenseValue));
+        if (totalDestiny > defenseValue) {
+            game.getGameState().sendMessage("Result: Succeeded");
+            action.appendEffect(new HitCardEffect(action, target, weapon));
+        }
+        else {
+            game.getGameState().sendMessage("Result: Failed");
+        }
+    }
+}

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/GameState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/GameState.java
@@ -96,6 +96,7 @@ public class GameState implements Snapshotable<GameState> {
     private SabaccState _sabaccState;
     private SearchPartyState _searchPartyState;
     private WeaponFiringState _weaponFiringState;
+    private SeparatelyOrCombinedFiringState _separatelyOrCombinedFiringState;
     private UsingTractorBeamState _usingTractorBeamState;
     private Stack<ForceLossState> _forceLossState = new Stack<ForceLossState>();
     private Stack<ForceRetrievalState> _forceRetrievalState = new Stack<ForceRetrievalState>();
@@ -297,6 +298,9 @@ public class GameState implements Snapshotable<GameState> {
         }
         if (_weaponFiringState != null) {
             throw new UnsupportedOperationException("Cannot generate snapshot of " + getClass().getSimpleName() + " with WeaponFiringState");
+        }
+        if (_separatelyOrCombinedFiringState != null) {
+            throw new UnsupportedOperationException("Cannot generate snapshot of " + getClass().getSimpleName() + " with SeparatelyOrCombinedFiringState");
         }
         if (!_forceLossState.isEmpty()) {
             throw new UnsupportedOperationException("Cannot generate snapshot of " + getClass().getSimpleName() + " with ForceLossState");
@@ -4362,6 +4366,22 @@ public class GameState implements Snapshotable<GameState> {
             _game.getActionsEnvironment().removeEndOfWeaponFiringActionProxies();
             _weaponFiringState = null;
         }
+    }
+
+    /**
+     * Begins a Targeting Computer-style fire-twice separately-or-combined action.
+     * Both shots are one overall action (no top-level actions between shots).
+     */
+    public void beginSeparatelyOrCombinedFiring(PhysicalCard device, PhysicalCard weapon, boolean combined) {
+        _separatelyOrCombinedFiringState = new SeparatelyOrCombinedFiringState(device, weapon, combined);
+    }
+
+    public SeparatelyOrCombinedFiringState getSeparatelyOrCombinedFiringState() {
+        return _separatelyOrCombinedFiringState;
+    }
+
+    public void finishSeparatelyOrCombinedFiring() {
+        _separatelyOrCombinedFiringState = null;
     }
 
     //

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/GameState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/GameState.java
@@ -4346,6 +4346,9 @@ public class GameState implements Snapshotable<GameState> {
     //
     public void beginWeaponFiring(PhysicalCard weaponFiring, SwccgBuiltInCardBlueprint permanentWeapon) {
         _weaponFiringState = new WeaponFiringState(_game, weaponFiring, permanentWeapon);
+        if (_separatelyOrCombinedFiringState != null) {
+            _separatelyOrCombinedFiringState.markFiringInitiated();
+        }
     }
 
     public void beginCombinedWeaponFiring() {

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/GameState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/GameState.java
@@ -4062,6 +4062,24 @@ public class GameState implements Snapshotable<GameState> {
     }
 
     /**
+     * True if a game-text action from this card is still on the stack.
+     * Targeting Computer uses this so -1 still applies if separately-or-combined state was cleared too soon.
+     */
+    public boolean isDuringGameTextActionFrom(PhysicalCard card) {
+        if (card == null) {
+            return false;
+        }
+        for (GameTextActionState state : _gameTextActionState) {
+            GameTextAction action = state.getGameTextAction();
+            if (action != null && action.getActionSource() != null
+                    && action.getActionSource().getCardId() == card.getCardId()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Gets the game text action state for the specific game text action.
      * @return the current game text action state, or null
      */

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/GameState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/GameState.java
@@ -626,6 +626,10 @@ public class GameState implements Snapshotable<GameState> {
             listener.sendMessage(message);
     }
 
+    public java.util.List<String> getLastMessages() {
+        return java.util.Collections.unmodifiableList(_lastMessages);
+    }
+
     public void playerDecisionStarted(String playerId, AwaitingDecision awaitingDecision) {
         _playerDecisions.put(playerId, awaitingDecision);
         for (GameStateListener listener : getAllGameStateListeners())

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/SeparatelyOrCombinedFiringState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/SeparatelyOrCombinedFiringState.java
@@ -130,7 +130,10 @@ public class SeparatelyOrCombinedFiringState {
     }
 
     public String getFiringLabel() {
-        return "Firing " + _firingsInitiated;
+        String deviceTitle = _device != null ? _device.getTitle() : "Targeting Computer";
+        String mode = _combined ? "Combined" : "Separately";
+        String weaponText = _weapon != null ? GameUtils.getCardLink(_weapon) : "weapon";
+        return deviceTitle + " " + mode + " firing " + _firingsInitiated + " (" + weaponText + ")";
     }
 
     public String getCombinedDrawModifiersOnlyMessage(PhysicalCard weapon, float firingDestiny) {

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/SeparatelyOrCombinedFiringState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/SeparatelyOrCombinedFiringState.java
@@ -1,6 +1,9 @@
 package com.gempukku.swccgo.game.state;
 
 import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.effects.DrawDestinyEffect;
+import com.gempukku.swccgo.logic.timing.GuiUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +31,8 @@ public class SeparatelyOrCombinedFiringState {
     private final List<Float> _firingDestinies = new ArrayList<Float>();
     private boolean _resolved;
     private int _firingsInitiated;
+    private DrawDestinyEffect _drawDestinyEffect;
+    private float _variableXSnapshot;
 
     public SeparatelyOrCombinedFiringState(PhysicalCard device, PhysicalCard weapon, boolean combined) {
         _device = device;
@@ -90,6 +95,24 @@ public class SeparatelyOrCombinedFiringState {
         return total;
     }
 
+    public void setDrawDestinyEffect(DrawDestinyEffect drawDestinyEffect) {
+        if (drawDestinyEffect != null) {
+            _drawDestinyEffect = drawDestinyEffect;
+        }
+    }
+
+    public DrawDestinyEffect getDrawDestinyEffect() {
+        return _drawDestinyEffect;
+    }
+
+    public void setVariableXSnapshot(float variableXSnapshot) {
+        _variableXSnapshot = variableXSnapshot;
+    }
+
+    public float getVariableXSnapshot() {
+        return _variableXSnapshot;
+    }
+
     public void markResolved() {
         _resolved = true;
     }
@@ -108,6 +131,34 @@ public class SeparatelyOrCombinedFiringState {
 
     public String getFiringLabel() {
         return "Firing " + _firingsInitiated;
+    }
+
+    public String getCombinedDrawModifiersOnlyMessage(PhysicalCard weapon, float firingDestiny) {
+        String weaponLink = weapon != null ? GameUtils.getCardLink(weapon) : "weapon";
+        return "Combined firing " + getCompletedFiringCount() + ": " + weaponLink
+                + " destiny " + GuiUtils.formatAsString(firingDestiny) + " (draw modifiers only)";
+    }
+
+    public String getCombinedDestiniesMathMessage(String drawSumFormatted, String totalFormatted, String defenseFormatted) {
+        String addends = formatAddends(_firingDestinies);
+        String deviceTitle = _device != null ? _device.getTitle() : "Targeting Computer";
+        return deviceTitle + " combined destinies: " + addends + " = " + drawSumFormatted
+                + ". Total weapon destiny " + totalFormatted + " vs defense value " + defenseFormatted;
+    }
+
+    private static String formatAddends(List<Float> values) {
+        if (values == null || values.isEmpty()) {
+            return "0";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < values.size(); i++) {
+            if (i > 0) {
+                sb.append(" + ");
+            }
+            Float value = values.get(i);
+            sb.append(GuiUtils.formatAsString(value != null ? value : 0f));
+        }
+        return sb.toString();
     }
 
     public String getCombinedTotalDestinyMessage(String totalFormatted) {

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/SeparatelyOrCombinedFiringState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/SeparatelyOrCombinedFiringState.java
@@ -13,9 +13,10 @@ import java.util.List;
  * Combined: treat each firing as a single weapon destiny (draw modifiers only, even if
  * multiple draws), add them, then apply total weapon destiny modifiers once and resolve.
  *
- * Pending rules (sensible AR reading, coded here): Force for each shot is paid when that
- * shot initiates, not all upfront. If the second shot cannot pay, the first still resolved
- * when firing separately; when combined, completed firings still combine.
+ * Appendix B option A (coded here): Force is used for BOTH firings, but each shot's cost
+ * is paid when THAT shot initiates (not all upfront). If the second shot cannot pay, skip
+ * it; do not rewind the first shot and do not fail the overall action. Combined: destinies
+ * from completed firings still combine (total-modifiers applied once) vs the single target.
  */
 public class SeparatelyOrCombinedFiringState {
     private final PhysicalCard _device;

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/SeparatelyOrCombinedFiringState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/SeparatelyOrCombinedFiringState.java
@@ -1,0 +1,98 @@
+package com.gempukku.swccgo.game.state;
+
+import com.gempukku.swccgo.game.PhysicalCard;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tracks a "fire twice, separately or combined" action such as Targeting Computer (1_39).
+ * This is NOT Maul-style repeated firing and is NOT Combined/Precise Attack.
+ *
+ * AR (Weapons - Firing Separately Or Combined): both shots are one overall action.
+ * Combined: treat each firing as a single weapon destiny (draw modifiers only, even if
+ * multiple draws), add them, then apply total weapon destiny modifiers once and resolve.
+ *
+ * Pending rules (sensible AR reading, coded here): Force for each shot is paid when that
+ * shot initiates, not all upfront. If the second shot cannot pay, the first still resolved
+ * when firing separately; when combined, completed firings still combine.
+ */
+public class SeparatelyOrCombinedFiringState {
+    private final PhysicalCard _device;
+    private final PhysicalCard _weapon;
+    private final boolean _combined;
+    private final int _expectedFirings;
+    private PhysicalCard _cardFiringWeapon;
+    private PhysicalCard _combinedTarget;
+    private final List<Float> _firingDestinies = new ArrayList<Float>();
+    private boolean _resolved;
+
+    public SeparatelyOrCombinedFiringState(PhysicalCard device, PhysicalCard weapon, boolean combined) {
+        _device = device;
+        _weapon = weapon;
+        _combined = combined;
+        _expectedFirings = 2;
+    }
+
+    public PhysicalCard getDevice() {
+        return _device;
+    }
+
+    public PhysicalCard getWeapon() {
+        return _weapon;
+    }
+
+    public boolean isCombined() {
+        return _combined;
+    }
+
+    public void setCardFiringWeapon(PhysicalCard cardFiringWeapon) {
+        if (cardFiringWeapon != null) {
+            _cardFiringWeapon = cardFiringWeapon;
+        }
+    }
+
+    public PhysicalCard getCardFiringWeapon() {
+        return _cardFiringWeapon;
+    }
+
+    public void setCombinedTarget(PhysicalCard target) {
+        if (_combinedTarget == null && target != null) {
+            _combinedTarget = target;
+        }
+    }
+
+    public PhysicalCard getCombinedTarget() {
+        return _combinedTarget;
+    }
+
+    public void addFiringDestiny(float firingDestiny) {
+        _firingDestinies.add(firingDestiny);
+    }
+
+    public int getCompletedFiringCount() {
+        return _firingDestinies.size();
+    }
+
+    public boolean hasCompletedExpectedFirings() {
+        return _firingDestinies.size() >= _expectedFirings;
+    }
+
+    public float getCombinedFiringDestinySum() {
+        float total = 0f;
+        for (Float value : _firingDestinies) {
+            if (value != null) {
+                total += value;
+            }
+        }
+        return total;
+    }
+
+    public void markResolved() {
+        _resolved = true;
+    }
+
+    public boolean isResolved() {
+        return _resolved;
+    }
+}

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/SeparatelyOrCombinedFiringState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/SeparatelyOrCombinedFiringState.java
@@ -133,7 +133,7 @@ public class SeparatelyOrCombinedFiringState {
         String deviceTitle = _device != null ? _device.getTitle() : "Targeting Computer";
         String mode = _combined ? "Combined" : "Separately";
         String weaponText = _weapon != null ? GameUtils.getCardLink(_weapon) : "weapon";
-        return deviceTitle + " " + mode + " firing " + _firingsInitiated + " (" + weaponText + ")";
+        return deviceTitle + " " + mode + " firing " + _firingsInitiated + " " + weaponText;
     }
 
     public String getCombinedDrawModifiersOnlyMessage(PhysicalCard weapon, float firingDestiny) {

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/SeparatelyOrCombinedFiringState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/SeparatelyOrCombinedFiringState.java
@@ -27,6 +27,7 @@ public class SeparatelyOrCombinedFiringState {
     private PhysicalCard _combinedTarget;
     private final List<Float> _firingDestinies = new ArrayList<Float>();
     private boolean _resolved;
+    private int _firingsInitiated;
 
     public SeparatelyOrCombinedFiringState(PhysicalCard device, PhysicalCard weapon, boolean combined) {
         _device = device;
@@ -95,5 +96,24 @@ public class SeparatelyOrCombinedFiringState {
 
     public boolean isResolved() {
         return _resolved;
+    }
+
+    public void markFiringInitiated() {
+        _firingsInitiated++;
+    }
+
+    public int getCurrentFiringNumber() {
+        return _firingsInitiated;
+    }
+
+    public String getFiringLabel() {
+        return "Firing " + _firingsInitiated;
+    }
+
+    public String getCombinedTotalDestinyMessage(String totalFormatted) {
+        if (getCompletedFiringCount() <= 1) {
+            return "Combined total weapon destiny (firing 1 only): " + totalFormatted;
+        }
+        return "Combined total weapon destiny (firing 1 + firing 2): " + totalFormatted;
     }
 }

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/WeaponFiringState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/WeaponFiringState.java
@@ -58,6 +58,11 @@ public class WeaponFiringState {
             else
                 _game.getModifiersQuerying().targetedByWeapon(target, _weaponFiring);
         }
+        SeparatelyOrCombinedFiringState soc = _game.getGameState().getSeparatelyOrCombinedFiringState();
+        if (soc != null && soc.isCombined() && !targets.isEmpty()) {
+            soc.setCombinedTarget(targets.iterator().next());
+            soc.setCardFiringWeapon(_cardFiringWeapon);
+        }
     }
 
     public Collection<PhysicalCard> getTargets() {

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/actions/AbstractAction.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/actions/AbstractAction.java
@@ -333,6 +333,17 @@ public abstract class AbstractAction implements Action {
     }
 
     /**
+     * Removes and returns effects queued on this action that have not started yet.
+     * Used so Combined Attack / TC-combined can run a weapon's destinyDraws later and
+     * execute the resulting hit/lost/ionize effects on a different parent action.
+     */
+    public List<StandardEffect> drainPendingEffects() {
+        List<StandardEffect> drained = new ArrayList<StandardEffect>(_effects);
+        _effects.clear();
+        return drained;
+    }
+
+    /**
      * Inserts the specified effects as the next after effects to be executed.  It will be executed after all the other
      * effects currently in the queue. These effects do not need to be successful for the action to be considered carried out.
      *
@@ -577,7 +588,11 @@ public abstract class AbstractAction implements Action {
      */
     @Override
     public final Collection<PhysicalCard> getPrimaryTargetCards(int targetGroupId) {
-        return _targetGroupMap.get(targetGroupId).keySet();
+        Map<PhysicalCard, Set<TargetingReason>> map = _targetGroupMap.get(targetGroupId);
+        if (map == null) {
+            return Collections.emptyList();
+        }
+        return new ArrayList<PhysicalCard>(map.keySet());
     }
 
     /**

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/actions/AbstractRespondableAction.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/actions/AbstractRespondableAction.java
@@ -3,6 +3,7 @@ package com.gempukku.swccgo.logic.actions;
 import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.game.SwccgGame;
 import com.gempukku.swccgo.game.state.GameState;
+import com.gempukku.swccgo.game.state.SeparatelyOrCombinedFiringState;
 import com.gempukku.swccgo.logic.GameUtils;
 import com.gempukku.swccgo.logic.effects.RespondableEffect;
 import com.gempukku.swccgo.logic.timing.Action;
@@ -193,7 +194,12 @@ public abstract class AbstractRespondableAction extends AbstractAction {
 
                 // Send message and show animation of targets now that action initiation is complete
                 if (_actionMessage != null) {
-                    gameState.sendMessage(_actionMessage);
+                    String actionMsg = _actionMessage;
+                    SeparatelyOrCombinedFiringState soc = gameState.getSeparatelyOrCombinedFiringState();
+                    if (soc != null && soc.getCurrentFiringNumber() > 0 && this instanceof AbstractFireWeaponAction) {
+                        actionMsg = soc.getFiringLabel() + ": " + actionMsg;
+                    }
+                    gameState.sendMessage(actionMsg);
                 }
 
                 // Assert that RespondableEffect is set (which is required if any cards were targeted and this is not a sub-action)

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/actions/FireSingleWeaponAction.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/actions/FireSingleWeaponAction.java
@@ -111,6 +111,9 @@ public class FireSingleWeaponAction extends AbstractFireWeaponAction {
                     !_weaponToFire.getBlueprint().isFiredByCharacterPresentOrHere() && !Filters.artillery_weapon.accepts(game, _weaponToFire)) {
                 setCardFiringWeapon(_weaponToFire.getAttachedTo());
             }
+            if (getCardFiringWeapon() != null && game.getGameState().getWeaponFiringState() != null) {
+                game.getGameState().getWeaponFiringState().setCardFiringWeapon(getCardFiringWeapon());
+            }
         }
 
         // Add any extra cost to fire the weapon

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/decisions/MultipleChoiceAwaitingDecision.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/decisions/MultipleChoiceAwaitingDecision.java
@@ -20,6 +20,19 @@ public abstract class MultipleChoiceAwaitingDecision extends AbstractAwaitingDec
     /**
      * Creates a decision that involves choosing from a choice of string values on the User Interface.
      * @param text the text to show the player making the decision
+     * @param possibleResults the strings to choose from
+     * @param asButtons true to show the choices as buttons instead of a dropdown
+     */
+    public MultipleChoiceAwaitingDecision(String text, String[] possibleResults, boolean asButtons) {
+        this(text, possibleResults, -1);
+        if (asButtons) {
+            setParam("asButtons", "true");
+        }
+    }
+
+    /**
+     * Creates a decision that involves choosing from a choice of string values on the User Interface.
+     * @param text the text to show the player making the decision
      * @param possibleResults the strings to choose from, as ArrayList
      */
     public MultipleChoiceAwaitingDecision(String text, ArrayList<String> possibleResults) {

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
@@ -9,6 +9,7 @@ import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.game.SwccgGame;
 import com.gempukku.swccgo.game.state.DrawDestinyState;
 import com.gempukku.swccgo.game.state.GameState;
+import com.gempukku.swccgo.game.state.SeparatelyOrCombinedFiringState;
 import com.gempukku.swccgo.logic.GameUtils;
 import com.gempukku.swccgo.logic.actions.OptionalGameTextTriggerAction;
 import com.gempukku.swccgo.logic.actions.SubAction;
@@ -503,7 +504,11 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
 
         // Add modifiers to total weapon destiny (unless this is combined firing)
         if (_destinyType==DestinyType.WEAPON_DESTINY || _destinyType==DestinyType.EPIC_EVENT_AND_WEAPON_DESTINY) {
-            totalDestiny = game.getModifiersQuerying().getTotalWeaponDestiny(gameState, _performingPlayerId, totalDestiny);
+            SeparatelyOrCombinedFiringState soc = gameState.getSeparatelyOrCombinedFiringState();
+            // Combined: each firing is a single weapon destiny (draw modifiers only), not a weapon destiny total.
+            if (soc == null || !soc.isCombined()) {
+                totalDestiny = game.getModifiersQuerying().getTotalWeaponDestiny(gameState, _performingPlayerId, totalDestiny);
+            }
         }
         else if (_destinyType==DestinyType.BATTLE_DESTINY) {
             totalDestiny = game.getModifiersQuerying().getTotalBattleDestiny(gameState, _performingPlayerId, totalDestiny);
@@ -694,6 +699,33 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
                         Float totalDestiny = getTotalDestiny(game);
 
                         gameState.endDrawDestiny();
+
+                        SeparatelyOrCombinedFiringState soc = gameState.getSeparatelyOrCombinedFiringState();
+                        if (soc != null && soc.isCombined()
+                                && (_destinyType == DestinyType.WEAPON_DESTINY || _destinyType == DestinyType.EPIC_EVENT_AND_WEAPON_DESTINY)) {
+                            float firingDestiny = 0f;
+                            for (Float value : _destinyDrawValues) {
+                                if (value != null) {
+                                    firingDestiny += value;
+                                }
+                            }
+                            soc.addFiringDestiny(firingDestiny);
+                            if (gameState.getWeaponFiringState() != null) {
+                                soc.setCardFiringWeapon(gameState.getWeaponFiringState().getCardFiringWeapon());
+                            }
+                            gameState.sendMessage("Combined firing weapon destiny (draw modifiers only): " + GuiUtils.formatAsString(firingDestiny));
+
+                            if (!soc.hasCompletedExpectedFirings()) {
+                                // Defer hit resolution until remaining combined firings complete.
+                                // Pending rules: costs paid as each shot initiates; completed firings still combine.
+                                return;
+                            }
+
+                            float combined = soc.getCombinedFiringDestinySum();
+                            totalDestiny = game.getModifiersQuerying().getTotalWeaponDestiny(gameState, _performingPlayerId, combined);
+                            soc.markResolved();
+                            gameState.sendMessage("Combined total weapon destiny: " + GuiUtils.formatAsString(totalDestiny));
+                        }
 
                         // Callback
                         destinyDraws(game, _destinyCardDraws, _destinyDrawValues, totalDestiny);

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
@@ -713,7 +713,7 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
                             if (gameState.getWeaponFiringState() != null) {
                                 soc.setCardFiringWeapon(gameState.getWeaponFiringState().getCardFiringWeapon());
                             }
-                            gameState.sendMessage("Combined firing weapon destiny (draw modifiers only): " + GuiUtils.formatAsString(firingDestiny));
+                            gameState.sendMessage("Combined " + soc.getFiringLabel().toLowerCase() + " weapon destiny (draw modifiers only): " + GuiUtils.formatAsString(firingDestiny));
 
                             if (!soc.hasCompletedExpectedFirings()) {
                                 // Defer hit resolution until remaining combined firings complete.
@@ -725,7 +725,7 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
                             float combined = soc.getCombinedFiringDestinySum();
                             totalDestiny = game.getModifiersQuerying().getTotalWeaponDestiny(gameState, _performingPlayerId, combined);
                             soc.markResolved();
-                            gameState.sendMessage("Combined total weapon destiny: " + GuiUtils.formatAsString(totalDestiny));
+                            gameState.sendMessage(soc.getCombinedTotalDestinyMessage(GuiUtils.formatAsString(totalDestiny)));
                         }
 
                         // Callback
@@ -1447,7 +1447,13 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
                                 return;
 
                             if (_destinyType != DestinyType.RACE_DESTINY) {
-                                game.getGameState().sendMessage(_performingPlayerId + "'s total " + _destinyType.getHumanReadable() + " is " + GuiUtils.formatAsString(totalDestiny));
+                                String totalMsg = _performingPlayerId + "'s total " + _destinyType.getHumanReadable() + " is " + GuiUtils.formatAsString(totalDestiny);
+                                SeparatelyOrCombinedFiringState soc = game.getGameState().getSeparatelyOrCombinedFiringState();
+                                if (soc != null && soc.getCurrentFiringNumber() > 0
+                                        && (_destinyType == DestinyType.WEAPON_DESTINY || _destinyType == DestinyType.EPIC_EVENT_AND_WEAPON_DESTINY)) {
+                                    totalMsg = soc.getFiringLabel() + ": " + totalMsg;
+                                }
+                                game.getGameState().sendMessage(totalMsg);
                             }
 
                             actionsEnvironment.emitEffectResult(

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
@@ -717,7 +717,8 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
 
                             if (!soc.hasCompletedExpectedFirings()) {
                                 // Defer hit resolution until remaining combined firings complete.
-                                // Pending rules: costs paid as each shot initiates; completed firings still combine.
+                                // Appendix B option A: if a later shot cannot initiate, completed firings still combine
+                                // (Card1_039 skips unpaid shot 2 and resolves combined from completed firings only).
                                 return;
                             }
 

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
@@ -724,7 +724,6 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
                             if (gameState.getWeaponFiringState() != null) {
                                 soc.setCardFiringWeapon(gameState.getWeaponFiringState().getCardFiringWeapon());
                             }
-                            gameState.sendMessage(soc.getCombinedDrawModifiersOnlyMessage(socWeapon, firingDestiny));
 
                             if (!soc.hasCompletedExpectedFirings()) {
                                 // Defer hit resolution until remaining combined firings complete.
@@ -1525,18 +1524,12 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
                             if (_destinyType != DestinyType.RACE_DESTINY) {
                                 GameState gameState = game.getGameState();
                                 SeparatelyOrCombinedFiringState soc = gameState.getSeparatelyOrCombinedFiringState();
-                                boolean combinedDrawModsOnly = (soc != null && soc.isCombined());
-                                // TC-combined: do not print a finished-looking "total weapon destiny"
-                                // per shot. Draw-modifiers-only lines plus the combined math block
-                                // are the resolve log.
-                                if (!combinedDrawModsOnly) {
-                                    String totalMsg = _performingPlayerId + "'s total " + _destinyType.getHumanReadable() + " is " + GuiUtils.formatAsString(totalDestiny);
-                                    if (soc != null && soc.getCurrentFiringNumber() > 0
-                                            && (_destinyType == DestinyType.WEAPON_DESTINY || _destinyType == DestinyType.EPIC_EVENT_AND_WEAPON_DESTINY)) {
-                                        totalMsg = soc.getFiringLabel() + ": " + totalMsg;
-                                    }
-                                    gameState.sendMessage(totalMsg);
+                                String totalMsg = _performingPlayerId + "'s total " + _destinyType.getHumanReadable() + " is " + GuiUtils.formatAsString(totalDestiny);
+                                if (soc != null && soc.getCurrentFiringNumber() > 0
+                                        && (_destinyType == DestinyType.WEAPON_DESTINY || _destinyType == DestinyType.EPIC_EVENT_AND_WEAPON_DESTINY)) {
+                                    totalMsg = soc.getFiringLabel() + ": " + totalMsg;
                                 }
+                                gameState.sendMessage(totalMsg);
                             }
 
                             actionsEnvironment.emitEffectResult(

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
@@ -797,7 +797,10 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
                                           PhysicalCard target, float variableX, Float combinedTotal) {
         GameState gameState = game.getGameState();
         boolean beganFiring = false;
-        if (gameState.getWeaponFiringState() == null && weapon != null) {
+        if (gameState.getWeaponFiringState() != null) {
+            gameState.finishWeaponFiring();
+        }
+        if (weapon != null) {
             gameState.beginWeaponFiring(weapon, permanentWeapon);
             beganFiring = true;
             WeaponFiringState wfs = gameState.getWeaponFiringState();

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
@@ -2,15 +2,18 @@ package com.gempukku.swccgo.logic.effects;
 
 import com.gempukku.swccgo.common.DestinyType;
 import com.gempukku.swccgo.common.GameTextActionId;
+import com.gempukku.swccgo.common.Variable;
 import com.gempukku.swccgo.common.Zone;
 import com.gempukku.swccgo.game.ActionProxy;
 import com.gempukku.swccgo.game.ActionsEnvironment;
 import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgBuiltInCardBlueprint;
 import com.gempukku.swccgo.game.SwccgGame;
 import com.gempukku.swccgo.game.state.DrawDestinyState;
 import com.gempukku.swccgo.game.state.GameState;
 import com.gempukku.swccgo.game.state.SeparatelyOrCombinedFiringState;
 import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.actions.AbstractAction;
 import com.gempukku.swccgo.logic.actions.OptionalGameTextTriggerAction;
 import com.gempukku.swccgo.logic.actions.SubAction;
 import com.gempukku.swccgo.logic.actions.TriggerAction;
@@ -19,6 +22,7 @@ import com.gempukku.swccgo.logic.decisions.DecisionResultInvalidException;
 import com.gempukku.swccgo.logic.decisions.YesNoDecision;
 import com.gempukku.swccgo.logic.modifiers.Modifier;
 import com.gempukku.swccgo.logic.modifiers.ModifierFlag;
+import com.gempukku.swccgo.logic.modifiers.SetInitialCalculationVariableModifier;
 import com.gempukku.swccgo.logic.modifiers.querying.ModifiersEnvironment;
 import com.gempukku.swccgo.logic.modifiers.querying.ModifiersQuerying;
 import com.gempukku.swccgo.logic.modifiers.TotalBattleDestinyModifier;
@@ -27,6 +31,8 @@ import com.gempukku.swccgo.logic.timing.Action;
 import com.gempukku.swccgo.logic.timing.EffectResult;
 import com.gempukku.swccgo.logic.timing.GuiUtils;
 import com.gempukku.swccgo.logic.timing.PassthruEffect;
+import com.gempukku.swccgo.logic.timing.StandardEffect;
+import com.gempukku.swccgo.game.state.WeaponFiringState;
 import com.gempukku.swccgo.logic.timing.results.AboutToCompleteDrawingDestinyResult;
 import com.gempukku.swccgo.logic.timing.results.AboutToDrawDestinyCardResult;
 import com.gempukku.swccgo.logic.timing.results.CostToDrawDestinyCardResult;
@@ -505,7 +511,7 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
         // Add modifiers to total weapon destiny (unless this is combined firing)
         if (_destinyType==DestinyType.WEAPON_DESTINY || _destinyType==DestinyType.EPIC_EVENT_AND_WEAPON_DESTINY) {
             SeparatelyOrCombinedFiringState soc = gameState.getSeparatelyOrCombinedFiringState();
-            // Combined: each firing is a single weapon destiny (draw modifiers only), not a weapon destiny total.
+            // TC-combined: each firing is draw modifiers only, not a weapon destiny total.
             if (soc == null || !soc.isCombined()) {
                 totalDestiny = game.getModifiersQuerying().getTotalWeaponDestiny(gameState, _performingPlayerId, totalDestiny);
             }
@@ -710,10 +716,15 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
                                 }
                             }
                             soc.addFiringDestiny(firingDestiny);
+                            soc.setDrawDestinyEffect(_drawDestinyEffect);
+                            PhysicalCard socWeapon = soc.getWeapon();
+                            if (socWeapon != null) {
+                                soc.setVariableXSnapshot(game.getModifiersQuerying().getVariableValue(gameState, socWeapon, Variable.X, 0f));
+                            }
                             if (gameState.getWeaponFiringState() != null) {
                                 soc.setCardFiringWeapon(gameState.getWeaponFiringState().getCardFiringWeapon());
                             }
-                            gameState.sendMessage("Combined " + soc.getFiringLabel().toLowerCase() + " weapon destiny (draw modifiers only): " + GuiUtils.formatAsString(firingDestiny));
+                            gameState.sendMessage(soc.getCombinedDrawModifiersOnlyMessage(socWeapon, firingDestiny));
 
                             if (!soc.hasCompletedExpectedFirings()) {
                                 // Defer hit resolution until remaining combined firings complete.
@@ -725,7 +736,13 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
                             float combined = soc.getCombinedFiringDestinySum();
                             totalDestiny = game.getModifiersQuerying().getTotalWeaponDestiny(gameState, _performingPlayerId, combined);
                             soc.markResolved();
-                            gameState.sendMessage(soc.getCombinedTotalDestinyMessage(GuiUtils.formatAsString(totalDestiny)));
+                            PhysicalCard socTarget = soc.getCombinedTarget();
+                            float socDefense = socTarget != null
+                                    ? game.getModifiersQuerying().getDefenseValue(gameState, socTarget)
+                                    : 0f;
+                            gameState.sendMessage(soc.getCombinedDestiniesMathMessage(
+                                    GuiUtils.formatAsString(combined), GuiUtils.formatAsString(totalDestiny),
+                                    GuiUtils.formatAsString(socDefense)));
                         }
 
                         // Callback
@@ -768,6 +785,62 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
      * @param totalDestiny the total destiny value, or null if all destiny draws failed or were canceled
      */
     protected abstract void destinyDraws(SwccgGame game, List<PhysicalCard> destinyCardDraws, List<Float> destinyDrawValues, Float totalDestiny);
+
+    /**
+     * After unpaid TC-combined destinies are collected, run this firing's
+     * weapon-specific destinyDraws (hit, lost if X=3, ionize, etc.) against the combined total.
+     * Restores Variable X and a short-lived WeaponFiringState because those last only until
+     * the original fire action ended. Result effects are moved onto applyToAction.
+     */
+    public boolean applyDeferredWeaponResult(SwccgGame game, Action applyToAction, PhysicalCard weapon,
+                                          PhysicalCard cardFiringWeapon, SwccgBuiltInCardBlueprint permanentWeapon,
+                                          PhysicalCard target, float variableX, Float combinedTotal) {
+        GameState gameState = game.getGameState();
+        boolean beganFiring = false;
+        if (gameState.getWeaponFiringState() == null && weapon != null) {
+            gameState.beginWeaponFiring(weapon, permanentWeapon);
+            beganFiring = true;
+            WeaponFiringState wfs = gameState.getWeaponFiringState();
+            if (cardFiringWeapon != null) {
+                wfs.setCardFiringWeapon(cardFiringWeapon);
+            }
+            if (target != null) {
+                wfs.setTarget(target);
+            }
+            if (variableX != 0f) {
+                game.getModifiersEnvironment().addUntilEndOfWeaponFiringModifier(
+                        new SetInitialCalculationVariableModifier(weapon, weapon, variableX, Variable.X));
+            }
+        }
+        boolean queued = false;
+        try {
+            destinyDraws(game, _destinyCardDraws, _destinyDrawValues, combinedTotal);
+            if (_action instanceof AbstractAction && applyToAction instanceof AbstractAction
+                    && _action != applyToAction) {
+                for (StandardEffect effect : ((AbstractAction) _action).drainPendingEffects()) {
+                    applyToAction.appendEffect(effect);
+                    queued = true;
+                }
+            }
+        }
+        finally {
+            if (beganFiring) {
+                if (queued && applyToAction != null) {
+                    applyToAction.appendEffect(
+                            new PassthruEffect(applyToAction) {
+                                @Override
+                                protected void doPlayEffect(SwccgGame game) {
+                                    game.getGameState().finishWeaponFiring();
+                                }
+                            });
+                }
+                else {
+                    gameState.finishWeaponFiring();
+                }
+            }
+        }
+        return queued;
+    }
 
     @Override
     protected boolean wasActionCarriedOut() {
@@ -1447,13 +1520,20 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
                                 return;
 
                             if (_destinyType != DestinyType.RACE_DESTINY) {
-                                String totalMsg = _performingPlayerId + "'s total " + _destinyType.getHumanReadable() + " is " + GuiUtils.formatAsString(totalDestiny);
-                                SeparatelyOrCombinedFiringState soc = game.getGameState().getSeparatelyOrCombinedFiringState();
-                                if (soc != null && soc.getCurrentFiringNumber() > 0
-                                        && (_destinyType == DestinyType.WEAPON_DESTINY || _destinyType == DestinyType.EPIC_EVENT_AND_WEAPON_DESTINY)) {
-                                    totalMsg = soc.getFiringLabel() + ": " + totalMsg;
+                                GameState gameState = game.getGameState();
+                                SeparatelyOrCombinedFiringState soc = gameState.getSeparatelyOrCombinedFiringState();
+                                boolean combinedDrawModsOnly = (soc != null && soc.isCombined());
+                                // TC-combined: do not print a finished-looking "total weapon destiny"
+                                // per shot. Draw-modifiers-only lines plus the combined math block
+                                // are the resolve log.
+                                if (!combinedDrawModsOnly) {
+                                    String totalMsg = _performingPlayerId + "'s total " + _destinyType.getHumanReadable() + " is " + GuiUtils.formatAsString(totalDestiny);
+                                    if (soc != null && soc.getCurrentFiringNumber() > 0
+                                            && (_destinyType == DestinyType.WEAPON_DESTINY || _destinyType == DestinyType.EPIC_EVENT_AND_WEAPON_DESTINY)) {
+                                        totalMsg = soc.getFiringLabel() + ": " + totalMsg;
+                                    }
+                                    gameState.sendMessage(totalMsg);
                                 }
-                                game.getGameState().sendMessage(totalMsg);
                             }
 
                             actionsEnvironment.emitEffectResult(

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/Destiny.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/Destiny.java
@@ -510,6 +510,13 @@ public interface Destiny extends BaseQuery {
             SwccgBuiltInCardBlueprint permanentWeapon = weaponFiringState.getPermanentWeaponFiring();
             Collection<PhysicalCard> weaponTargets = weaponFiringState.getTargets();
             PhysicalCard cardFiringWeapon = weaponFiringState.getCardFiringWeapon();
+            // EachWeaponDestinyForWeaponFiredByModifier (Defiance +2) keys off the card firing,
+            // not the weapon card. If state still points at the weapon itself or has no firer,
+            // use the attached host (the starship).
+            if (weapon != null && weapon.getAttachedTo() != null
+                    && (cardFiringWeapon == null || cardFiringWeapon.getCardId() == weapon.getCardId())) {
+                cardFiringWeapon = weapon.getAttachedTo();
+            }
 
             for (Modifier modifier : getModifiers(gameState, ModifierType.EACH_WEAPON_DESTINY)) {
                 if (!mayNotModifyDestinyDraw(gameState, modifier.getSource(gameState) != null ? modifier.getSource(gameState).getOwner() : null)) {

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/Destiny.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/Destiny.java
@@ -1108,21 +1108,21 @@ public interface Destiny extends BaseQuery {
      * @return the total weapon destiny
      */
     default float getTotalWeaponDestiny(GameState gameState, String playerId, float baseTotalDestiny) {
-        float result = baseTotalDestiny;
-
-        // Get from WeaponFiringState
         WeaponFiringState weaponFiringState = gameState.getWeaponFiringState();
-        if (weaponFiringState != null) {
-            PhysicalCard weapon = weaponFiringState.getCardFiring();
-            SwccgBuiltInCardBlueprint permanentWeapon = weaponFiringState.getPermanentWeaponFiring();
-            Collection<PhysicalCard> weaponTargets = weaponFiringState.getTargets();
-            PhysicalCard cardFiringWeapon = weaponFiringState.getCardFiringWeapon();
-
-            for (Modifier modifier : getModifiers(gameState, ModifierType.TOTAL_WEAPON_DESTINY)) {
-                result += modifier.getTotalWeaponDestinyModifier(gameState, query(), cardFiringWeapon, weapon, permanentWeapon, weaponTargets);
-            }
+        if (weaponFiringState == null) {
+            return Math.max(0, baseTotalDestiny);
         }
+        return getTotalWeaponDestiny(gameState, weaponFiringState.getCardFiringWeapon(), weaponFiringState.getCardFiring(),
+                weaponFiringState.getPermanentWeaponFiring(), weaponFiringState.getTargets(), baseTotalDestiny);
+    }
 
+    default float getTotalWeaponDestiny(GameState gameState, PhysicalCard cardFiringWeapon, PhysicalCard weapon,
+                                        SwccgBuiltInCardBlueprint permanentWeapon, Collection<PhysicalCard> weaponTargets,
+                                        float baseTotalDestiny) {
+        float result = baseTotalDestiny;
+        for (Modifier modifier : getModifiers(gameState, ModifierType.TOTAL_WEAPON_DESTINY)) {
+            result += modifier.getTotalWeaponDestinyModifier(gameState, query(), cardFiringWeapon, weapon, permanentWeapon, weaponTargets);
+        }
         return Math.max(0, result);
     }
 

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/ModifiersLogic.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/ModifiersLogic.java
@@ -2152,7 +2152,7 @@ public class ModifiersLogic implements ModifiersEnvironment, ModifiersState, Mod
         List<Integer> otherDevices = new LinkedList<Integer>();
         if (usedDevices != null)
             for (Integer cardId : usedDevices)
-                if (cardId!=device.getCardId())
+                if (cardId!=device.getCardId() && !otherDevices.contains(cardId))
                     otherDevices.add(cardId);
 
         return otherDevices;
@@ -2175,7 +2175,7 @@ public class ModifiersLogic implements ModifiersEnvironment, ModifiersState, Mod
         List<Integer> otherWeapons = new LinkedList<Integer>();
         if (usedWeapons != null)
             for (Integer cardId : usedWeapons)
-                if (cardId!=weapon.getCardId())
+                if (cardId!=weapon.getCardId() && !otherWeapons.contains(cardId))
                     otherWeapons.add(cardId);
 
         return otherWeapons;

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/DefaultSwccgGame.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/DefaultSwccgGame.java
@@ -546,8 +546,13 @@ public class DefaultSwccgGame implements SwccgGame {
     @Override
     public void takeSnapshot(String description) {
         pruneSnapshots();
-        // need to specifically exclude when getPlayCardStates() is not empty to allow for battles to be initiated by interrupts
-        if (_gameState.getPlayCardStates().isEmpty())
+        // Skip snapshot while play-card or firing sub-states are open. generateSnapshot throws on those
+        // fields; playCardStates must stay skipped so interrupt-initiated battles still work. Skipping a
+        // leaked SeparatelyOrCombinedFiringState / WeaponFiringState also prevents weapons-segment Pass
+        // from aborting the game.
+        if (_gameState.getPlayCardStates().isEmpty()
+                && _gameState.getSeparatelyOrCombinedFiringState() == null
+                && !_gameState.isDuringWeaponFiring())
             _snapshots.add(GameSnapshot.createGameSnapshot(getNextSnapshotId(), description, _gameState, _modifiersLogic, _actionsEnvironment, _turnProcedure));
     }
 

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/DefaultSwccgGame.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/DefaultSwccgGame.java
@@ -11,6 +11,7 @@ import com.gempukku.swccgo.communication.UserFeedback;
 import com.gempukku.swccgo.game.*;
 import com.gempukku.swccgo.game.layout.LocationsLayout;
 import com.gempukku.swccgo.game.state.GameState;
+import com.gempukku.swccgo.game.state.SeparatelyOrCombinedFiringState;
 import com.gempukku.swccgo.game.state.actions.DefaultActionsEnvironment;
 import com.gempukku.swccgo.logic.PlayerOrder;
 import com.gempukku.swccgo.logic.decisions.MultipleChoiceAwaitingDecision;
@@ -546,6 +547,12 @@ public class DefaultSwccgGame implements SwccgGame {
     @Override
     public void takeSnapshot(String description) {
         pruneSnapshots();
+        // After a fire-twice shot has started, clear leaked separately-or-combined state before snapshot.
+        // Do not clear during destinies (weapon firing is open) or before the first shot (targeting).
+        SeparatelyOrCombinedFiringState soc = _gameState.getSeparatelyOrCombinedFiringState();
+        if (soc != null && soc.getCurrentFiringNumber() > 0 && !_gameState.isDuringWeaponFiring()) {
+            _gameState.finishSeparatelyOrCombinedFiring();
+        }
         // Skip snapshot while play-card or firing sub-states are open. generateSnapshot throws on those
         // fields; playCardStates must stay skipped so interrupt-initiated battles still work. Skipping a
         // leaked SeparatelyOrCombinedFiringState / WeaponFiringState also prevents weapons-segment Pass

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
@@ -1,0 +1,313 @@
+package com.gempukku.swccgo.cards.set1.light;
+
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.game.PhysicalCardImpl;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Card_1_39_Tests {
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>()
+                {{
+                    put("tc", "1_39");
+                    put("karie", "9_18");
+                    put("pilot", "1_27");
+                    put("red7", "7_146");
+                    put("xwing", "1_146");
+                    put("ept", "9_88");
+                }},
+                new HashMap<>()
+                {{
+                    put("stalker", "3_152");
+                    put("tie", "1_304");
+                    put("tie2", "1_304");
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSSpaceSystem,
+                StartingSetup.DefaultDSSpaceSystem,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void TargetingComputerStatsAndKeywordsAreCorrect() {
+        /**
+         * Title: Targeting Computer
+         * Uniqueness: Unrestricted
+         * Side: Light
+         * Type: Device
+         * Destiny: 3
+         * Game Text: Use 2 Force to deploy on any starship. Adds 1 to starship's maneuver. If this starship is using a
+         *      weapon during a battle, you may fire that weapon twice, separately or combined. Subtract 1 from each
+         *      destiny draw when firing.
+         * Lore: Specially designed for use on Rebel starfighters. Assists pilots on torpedo runs. Automatically locks
+         *      on pre-programmed target points.
+         * Set: Premiere
+         * Rarity: U1
+         */
+        var scn = GetScenario();
+        var card = scn.GetLSCard("tc").getBlueprint();
+
+        assertEquals("Targeting Computer", card.getTitle());
+        assertEquals(Uniqueness.UNRESTRICTED, card.getUniqueness());
+        assertEquals(Side.LIGHT, card.getSide());
+        assertTrue(card.isCardType(CardType.DEVICE));
+        assertEquals(3, card.getDestiny(), scn.epsilon);
+        assertEquals(Rarity.U1, card.getRarity());
+    }
+
+    @Test
+    public void TargetingComputerDeploysOnStarshipForTwoForceAndAddsOneManeuver() {
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var red7 = scn.GetLSCard("red7");
+        var karie = scn.GetLSCard("karie");
+        scn.MoveCardsToHand(tc);
+
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        scn.MoveCardsToLocation(system, red7);
+        scn.BoardAsPilot(red7, karie);
+
+        assertEquals(4, scn.GetManeuver(red7));
+
+        scn.SkipToLSTurn(Phase.DEPLOY);
+        assertTrue(scn.LSDeployAvailable(tc));
+        scn.LSDeployCard(tc);
+        assertTrue(scn.LSHasCardChoiceAvailable(red7));
+        scn.LSChooseCard(red7);
+        scn.PassAllResponses();
+
+        assertTrue(scn.IsAttachedTo(red7, tc));
+        assertEquals(2, scn.GetDeployCost(tc));
+        assertEquals(5, scn.GetManeuver(red7));
+    }
+
+    @Test
+    public void TargetingComputerCannotBeUsedOutsideBattle() {
+        var scn = GetScenario();
+        setupRed7(scn, true);
+
+        scn.SkipToLSTurn(Phase.CONTROL);
+        assertFalse(scn.LSCardActionAvailable(scn.GetLSCard("tc"), "Fire a weapon twice"));
+
+        scn.SkipToPhase(Phase.DEPLOY);
+        assertFalse(scn.LSCardActionAvailable(scn.GetLSCard("tc"), "Fire a weapon twice"));
+    }
+
+    @Test
+    public void TargetingComputerIsLimitedToOneUsagePerDevicePerBattle() {
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var ept = scn.GetLSCard("ept");
+        var stalker = scn.GetDSCard("stalker");
+        setupRed7(scn, true);
+
+        startWeaponsSegment(scn);
+
+        assertTrue(scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseWeaponIfPrompted(scn, ept);
+        scn.LSChoose("Separately");
+        fireOneShot(scn, stalker, 1);
+        fireOneShot(scn, stalker, 1);
+
+        passOptionalResponses(scn);
+        // After the weapon has been fired twice, LS may have no remaining weapons actions
+        // and the engine auto-passes to DS. Either way the device must not be usable again.
+        if (scn.AwaitingLSWeaponsSegmentActions()) {
+            assertFalse(scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
+        }
+        else {
+            assertTrue("Expected a weapons segment after TC usage. Current decision: "
+                            + (scn.GetCurrentDecision() == null ? "null" : scn.GetCurrentDecision().getText()),
+                    scn.AwaitingDSWeaponsSegmentActions());
+        }
+    }
+
+    @Test
+    public void TargetingComputerFiresTwiceSeparatelyPayingForceTwiceAndCanRetarget() {
+        // Red 7 fires Proton Torpedoes for free, so use a generic X-wing (permanent pilot) + EPT.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var ept = scn.GetLSCard("ept");
+        var tie = scn.GetDSCard("tie");
+        var tie2 = scn.GetDSCard("tie2");
+        setupXwing(scn);
+
+        startWeaponsSegment(scn);
+
+        int forceBefore = scn.GetLSForcePileCount();
+        assertTrue(scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseWeaponIfPrompted(scn, ept);
+        scn.LSChoose("Separately");
+
+        // Without Karie, dest 7 vs TIE: 7 -1 TC -1 EPT (non-capital) = 5 vs maneuver 3 = hit.
+        fireOneShot(scn, tie, 7);
+        assertTrue(tie.isHit());
+        assertFalse(tie2.isHit());
+
+        fireOneShot(scn, tie2, 7);
+        assertTrue(tie2.isHit());
+
+        // EPT costs 1 Force per firing; both shots of the overall action must pay.
+        assertEquals(forceBefore - 2, scn.GetLSForcePileCount());
+    }
+
+    @Test
+    public void TargetingComputerCombinedAddsDrawsThenAppliesTotalModifiersOnce() {
+        /**
+         * AR Example 1 structure (Karie + EPT + TC vs Stalker armor 7):
+         * Each draw: printed + Karie +1 + TC -1. Combined sum, then EPT +1 vs capital, then compare to DV.
+         * AR lists destinies 4 then 2 "for a total of 7" then +1 = 8 vs 7. Rule-text math for 4 then 2 is
+         * (4+1-1)+(2+1-1)=6, then +1 total = 7 vs 7, which does not hit (need > DV). Destinies 4 then 3
+         * produce the intended hit: (4+1-1)+(3+1-1)=7, +1 total = 8 vs 7.
+         */
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var ept = scn.GetLSCard("ept");
+        var stalker = scn.GetDSCard("stalker");
+        setupRed7(scn, true);
+
+        startWeaponsSegment(scn);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseWeaponIfPrompted(scn, ept);
+        scn.LSChoose("Combined");
+
+        fireOneShot(scn, stalker, 4);
+        assertFalse("First combined shot must not resolve a hit by itself", stalker.isHit());
+
+        fireOneShot(scn, stalker, 3);
+        assertTrue(stalker.isHit());
+        assertEquals(7, scn.GetDefense(stalker));
+    }
+
+    @Test
+    public void TargetingComputerSubtractsOneFromEachDrawNotFromCombinedTotal() {
+        // Without Karie: destinies 4 and 4 combined.
+        // Per-draw TC -1: (4-1)+(4-1)=6, EPT +1 vs capital = 7 vs Stalker 7 = miss.
+        // If -1 were applied once to the total: 4+4-1+1 = 8 vs 7 = hit.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var ept = scn.GetLSCard("ept");
+        var stalker = scn.GetDSCard("stalker");
+        setupRed7(scn, false);
+
+        startWeaponsSegment(scn);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseWeaponIfPrompted(scn, ept);
+        scn.LSChoose("Combined");
+
+        fireOneShot(scn, stalker, 4);
+        fireOneShot(scn, stalker, 4);
+
+        assertFalse("TC -1 must apply to each draw, not once to the combined total", stalker.isHit());
+    }
+
+    @Test
+    public void TargetingComputerCombinedCanHitWhenSeparateShotsWouldMiss() {
+        // With Karie, destinies 4 and 4:
+        // Separately each shot is (4+1-1)+1 EPT = 5 vs 7 miss.
+        // Combined: (4+1-1)+(4+1-1)+1 EPT = 9 vs 7 hit.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var ept = scn.GetLSCard("ept");
+        var stalker = scn.GetDSCard("stalker");
+        setupRed7(scn, true);
+
+        startWeaponsSegment(scn);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseWeaponIfPrompted(scn, ept);
+        scn.LSChoose("Combined");
+
+        fireOneShot(scn, stalker, 4);
+        assertFalse(stalker.isHit());
+        fireOneShot(scn, stalker, 4);
+        assertTrue(stalker.isHit());
+    }
+
+    private void setupRed7(VirtualTableScenario scn, boolean includeKarie) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var red7 = scn.GetLSCard("red7");
+        var ept = scn.GetLSCard("ept");
+        var tc = scn.GetLSCard("tc");
+        var stalker = scn.GetDSCard("stalker");
+        var tie = scn.GetDSCard("tie");
+        var tie2 = scn.GetDSCard("tie2");
+
+        scn.MoveCardsToLocation(system, red7, stalker, tie, tie2);
+        if (includeKarie) {
+            scn.BoardAsPilot(red7, scn.GetLSCard("karie"));
+        }
+        else {
+            scn.BoardAsPilot(red7, scn.GetLSCard("pilot"));
+        }
+        scn.AttachCardsTo(red7, ept, tc);
+    }
+
+    private void setupXwing(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var xwing = scn.GetLSCard("xwing");
+        var ept = scn.GetLSCard("ept");
+        var tc = scn.GetLSCard("tc");
+        var stalker = scn.GetDSCard("stalker");
+        var tie = scn.GetDSCard("tie");
+        var tie2 = scn.GetDSCard("tie2");
+
+        scn.MoveCardsToLocation(system, xwing, stalker, tie, tie2);
+        scn.AttachCardsTo(xwing, ept, tc);
+    }
+
+    private void startWeaponsSegment(VirtualTableScenario scn) {
+        scn.SkipToLSTurn(Phase.BATTLE);
+        scn.LSInitiateBattle(scn.GetLSStartingLocation());
+        passOptionalResponses(scn);
+        assertTrue(scn.AwaitingLSWeaponsSegmentActions());
+    }
+
+    private void chooseWeaponIfPrompted(VirtualTableScenario scn, PhysicalCardImpl weapon) {
+        if (scn.LSDecisionAvailable("Choose weapon")) {
+            scn.LSChooseCard(weapon);
+        }
+    }
+
+    private void fireOneShot(VirtualTableScenario scn, PhysicalCardImpl target, int destiny) {
+        // Combined second shots auto-target and may already be at Force/Fire responses.
+        // Prepare destiny before passing those responses so the next draw is stubbed.
+        if (scn.LSGetDecision() != null && scn.LSHasCardChoiceAvailable(target)) {
+            scn.LSChooseCard(target);
+        }
+        scn.PrepareLSDestiny(destiny);
+        scn.PassForceUseResponses();
+        scn.PassWeaponFireWithDestinyDraw();
+    }
+
+    private void passOptionalResponses(VirtualTableScenario scn) {
+        if (scn.GetCurrentDecision() != null) {
+            scn.PassAllResponses();
+        }
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
@@ -1,7 +1,6 @@
 package com.gempukku.swccgo.cards.set1.light;
 
 import com.gempukku.swccgo.common.CardType;
-import com.gempukku.swccgo.common.IonizationType;
 import com.gempukku.swccgo.common.Phase;
 import com.gempukku.swccgo.common.Rarity;
 import com.gempukku.swccgo.common.Side;
@@ -126,16 +125,15 @@ public class Card_1_39_Tests {
         var stalker = scn.GetDSCard("stalker");
         setupRed7(scn, true);
 
-        startWeaponsSegment(scn);
+        scn.StartBattleAndSkipToWeaponsSegment();
 
         assertTrue(scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
         scn.LSUseCardAction(tc, "Fire a weapon twice");
-        chooseWeaponIfPrompted(scn, ept);
-        scn.LSChoose("Separately");
+        chooseSeparatelyOrCombined(scn, "Separately");
         fireOneShot(scn, stalker, 1);
         fireOneShot(scn, stalker, 1);
 
-        passOptionalResponses(scn);
+        scn.PassAllResponses();
         // After the weapon has been fired twice, LS may have no remaining weapons actions
         // and the engine auto-passes to DS. Either way the device must not be usable again.
         if (scn.AwaitingLSWeaponsSegmentActions()) {
@@ -158,13 +156,12 @@ public class Card_1_39_Tests {
         var tie2 = scn.GetDSCard("tie2");
         setupXwing(scn);
 
-        startWeaponsSegment(scn);
+        scn.StartBattleAndSkipToWeaponsSegment();
 
         int forceBefore = scn.GetLSForcePileCount();
         assertTrue(scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
         scn.LSUseCardAction(tc, "Fire a weapon twice");
-        chooseWeaponIfPrompted(scn, ept);
-        scn.LSChoose("Separately");
+        chooseSeparatelyOrCombined(scn, "Separately");
 
         // Without Karie, dest 7 vs TIE: 7 -1 TC -1 EPT (non-capital) = 5 vs maneuver 3 = hit.
         fireOneShot(scn, tie, 7);
@@ -193,11 +190,10 @@ public class Card_1_39_Tests {
         var stalker = scn.GetDSCard("stalker");
         setupRed7(scn, true);
 
-        startWeaponsSegment(scn);
+        scn.StartBattleAndSkipToWeaponsSegment();
 
         scn.LSUseCardAction(tc, "Fire a weapon twice");
-        chooseWeaponIfPrompted(scn, ept);
-        scn.LSChoose("Combined");
+        chooseSeparatelyOrCombined(scn, "Combined");
 
         fireOneShot(scn, stalker, 4);
         assertFalse("First combined shot must not resolve a hit by itself", stalker.isHit());
@@ -218,11 +214,10 @@ public class Card_1_39_Tests {
         var stalker = scn.GetDSCard("stalker");
         setupRed7(scn, false);
 
-        startWeaponsSegment(scn);
+        scn.StartBattleAndSkipToWeaponsSegment();
 
         scn.LSUseCardAction(tc, "Fire a weapon twice");
-        chooseWeaponIfPrompted(scn, ept);
-        scn.LSChoose("Combined");
+        chooseSeparatelyOrCombined(scn, "Combined");
 
         fireOneShot(scn, stalker, 4);
         fireOneShot(scn, stalker, 4);
@@ -241,11 +236,10 @@ public class Card_1_39_Tests {
         var stalker = scn.GetDSCard("stalker");
         setupRed7(scn, true);
 
-        startWeaponsSegment(scn);
+        scn.StartBattleAndSkipToWeaponsSegment();
 
         scn.LSUseCardAction(tc, "Fire a weapon twice");
-        chooseWeaponIfPrompted(scn, ept);
-        scn.LSChoose("Combined");
+        chooseSeparatelyOrCombined(scn, "Combined");
 
         fireOneShot(scn, stalker, 4);
         assertFalse(stalker.isHit());
@@ -265,12 +259,11 @@ public class Card_1_39_Tests {
         var tie2 = scn.GetDSCard("tie2");
         setupXwingLaser(scn);
 
-        startWeaponsSegment(scn);
+        scn.StartBattleAndSkipToWeaponsSegment();
 
         assertTrue(scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
         scn.LSUseCardAction(tc, "Fire a weapon twice");
-        chooseWeaponIfPrompted(scn, xwlc);
-        scn.LSChoose("Separately");
+        chooseSeparatelyOrCombined(scn, "Separately");
 
         fireOneShot(scn, tie, 5, 0);
         assertTrue(tie.isHit());
@@ -290,11 +283,10 @@ public class Card_1_39_Tests {
         var tie = scn.GetDSCard("tie");
         setupXwingLaser(scn);
 
-        startWeaponsSegment(scn);
+        scn.StartBattleAndSkipToWeaponsSegment();
 
         scn.LSUseCardAction(tc, "Fire a weapon twice");
-        chooseWeaponIfPrompted(scn, xwlc);
-        scn.LSChoose("Combined");
+        chooseSeparatelyOrCombined(scn, "Combined");
 
         fireOneShot(scn, tie, 4, 0);
         assertFalse("First combined X-wing Laser Cannon shot must not resolve a hit by itself", tie.isHit());
@@ -315,20 +307,19 @@ public class Card_1_39_Tests {
         var tie2 = scn.GetDSCard("tie2");
         setupYwingIon(scn);
 
-        startWeaponsSegment(scn);
+        scn.StartBattleAndSkipToWeaponsSegment();
 
         int forceBefore = scn.GetLSForcePileCount();
         scn.LSUseCardAction(tc, "Fire a weapon twice");
-        chooseWeaponIfPrompted(scn, sw4);
-        scn.LSChoose("Separately");
+        chooseSeparatelyOrCombined(scn, "Separately");
 
         fireOneShot(scn, tie, 5);
-        assertTrue(isIonized(tie));
+        assertTrue(scn.IsIonized(tie));
         assertFalse(tie.isHit());
-        assertFalse(isIonized(tie2));
+        assertFalse(scn.IsIonized(tie2));
 
         fireOneShot(scn, tie2, 5);
-        assertTrue(isIonized(tie2));
+        assertTrue(scn.IsIonized(tie2));
         assertFalse(tie2.isHit());
         assertEquals(forceBefore - 2, scn.GetLSForcePileCount());
     }
@@ -342,18 +333,17 @@ public class Card_1_39_Tests {
         var tie = scn.GetDSCard("tie");
         setupYwingIon(scn);
 
-        startWeaponsSegment(scn);
+        scn.StartBattleAndSkipToWeaponsSegment();
 
         scn.LSUseCardAction(tc, "Fire a weapon twice");
-        chooseWeaponIfPrompted(scn, sw4);
-        scn.LSChoose("Combined");
+        chooseSeparatelyOrCombined(scn, "Combined");
 
         fireOneShot(scn, tie, 4);
-        assertFalse(isIonized(tie));
+        assertFalse(scn.IsIonized(tie));
         assertFalse(tie.isHit());
 
         fireOneShot(scn, tie, 4);
-        assertTrue(isIonized(tie));
+        assertTrue(scn.IsIonized(tie));
         assertFalse("Ion Cannon must ionize, not hit", tie.isHit());
     }
 
@@ -368,28 +358,27 @@ public class Card_1_39_Tests {
         var tie2 = scn.GetDSCard("tie2");
         setupYwingIon(scn);
 
-        startWeaponsSegment(scn);
-        drainLSForcePileTo(scn, 1);
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.DrainLSForcePileTo(1);
         assertEquals(1, scn.GetLSForcePileCount());
 
         scn.LSUseCardAction(tc, "Fire a weapon twice");
-        chooseWeaponIfPrompted(scn, sw4);
-        scn.LSChoose("Separately");
+        chooseSeparatelyOrCombined(scn, "Separately");
 
         fireOneShot(scn, tie, 5);
-        assertTrue(isIonized(tie));
+        assertTrue(scn.IsIonized(tie));
         assertFalse(tie.isHit());
-        assertFalse(isIonized(tie2));
+        assertFalse(scn.IsIonized(tie2));
         assertEquals(0, scn.GetLSForcePileCount());
 
-        passOptionalResponses(scn);
+        scn.PassAllResponses();
         if (scn.AwaitingLSWeaponsSegmentActions()) {
             assertFalse(scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
         }
         else {
             assertTrue(scn.AwaitingDSWeaponsSegmentActions() || scn.GetCurrentDecision() != null);
         }
-        assertFalse("Second TIE must not be ionized when shot 2 cannot pay", isIonized(tie2));
+        assertFalse("Second TIE must not be ionized when shot 2 cannot pay", scn.IsIonized(tie2));
     }
 
     @Test
@@ -402,18 +391,17 @@ public class Card_1_39_Tests {
         var tie = scn.GetDSCard("tie");
         setupYwingIon(scn);
 
-        startWeaponsSegment(scn);
-        drainLSForcePileTo(scn, 1);
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.DrainLSForcePileTo(1);
         assertEquals(1, scn.GetLSForcePileCount());
 
         scn.LSUseCardAction(tc, "Fire a weapon twice");
-        chooseWeaponIfPrompted(scn, sw4);
-        scn.LSChoose("Combined");
+        chooseSeparatelyOrCombined(scn, "Combined");
 
         fireOneShot(scn, tie, 5);
-        passOptionalResponses(scn);
+        scn.PassAllResponses();
 
-        assertTrue("Completed combined firing must still apply vs the target", isIonized(tie));
+        assertTrue("Completed combined firing must still apply vs the target", scn.IsIonized(tie));
         assertFalse(tie.isHit());
         assertEquals(0, scn.GetLSForcePileCount());
         if (scn.AwaitingLSWeaponsSegmentActions()) {
@@ -431,11 +419,10 @@ public class Card_1_39_Tests {
         var stalker = scn.GetDSCard("stalker");
         setupHomeOne(scn);
 
-        startWeaponsSegment(scn);
+        scn.StartBattleAndSkipToWeaponsSegment();
 
         scn.LSUseCardAction(tc, "Fire a weapon twice");
-        chooseWeaponIfPrompted(scn, htb);
-        scn.LSChoose("Separately");
+        chooseSeparatelyOrCombined(scn, "Separately");
 
         fireTwoDestinyShot(scn, stalker, 7, 7);
         assertTrue(stalker.isHit());
@@ -451,12 +438,11 @@ public class Card_1_39_Tests {
         var stalker = scn.GetDSCard("stalker");
         setupHomeOne(scn);
 
-        startWeaponsSegment(scn);
-        ensureLSForcePile(scn, 4);
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
 
         scn.LSUseCardAction(tc, "Fire a weapon twice");
-        chooseWeaponIfPrompted(scn, htb);
-        scn.LSChoose("Combined");
+        chooseSeparatelyOrCombined(scn, "Combined");
 
         fireTwoDestinyShot(scn, stalker, 4, 4);
         assertFalse("First combined HTB firing must not resolve a hit by itself", stalker.isHit());
@@ -499,17 +485,13 @@ public class Card_1_39_Tests {
         scn.AttachCardsTo(xwing, ept, tc);
     }
 
-    private void startWeaponsSegment(VirtualTableScenario scn) {
-        scn.SkipToLSTurn(Phase.BATTLE);
-        scn.LSInitiateBattle(scn.GetLSStartingLocation());
-        passOptionalResponses(scn);
-        assertTrue(scn.AwaitingLSWeaponsSegmentActions());
-    }
-
-    private void chooseWeaponIfPrompted(VirtualTableScenario scn, PhysicalCardImpl weapon) {
-        if (scn.LSDecisionAvailable("Choose weapon")) {
-            scn.LSChooseCard(weapon);
-        }
+    private void chooseSeparatelyOrCombined(VirtualTableScenario scn, String mode) {
+        assertFalse("These setups attach one legal weapon; GEMP must auto-select it instead of prompting",
+                scn.LSDecisionAvailable("Choose weapon"));
+        assertTrue("Expected Separately/Combined prompt, got: "
+                        + (scn.GetCurrentDecision() == null ? "null" : scn.GetCurrentDecision().getText()),
+                scn.LSDecisionAvailable("separately or combined"));
+        scn.LSChoose(mode);
     }
 
     private void setupXwingLaser(VirtualTableScenario scn) {
@@ -597,30 +579,6 @@ public class Card_1_39_Tests {
         }
         int amount = forceToUse != null ? forceToUse : scn.LSGetChoiceMin();
         scn.LSDecided(amount);
-    }
-
-    private void ensureLSForcePile(VirtualTableScenario scn, int min) {
-        while (scn.GetLSForcePileCount() < min && scn.GetLSReserveDeckCount() > 2) {
-            scn.MoveCardsToTopOfLSForcePile(scn.GetTopOfLSReserveDeck());
-        }
-    }
-
-    private void drainLSForcePileTo(VirtualTableScenario scn, int remaining) {
-        while (scn.GetLSForcePileCount() > remaining) {
-            scn.MoveCardsToHand(scn.GetTopOfLSForcePile());
-        }
-    }
-
-    private boolean isIonized(PhysicalCardImpl card) {
-        return card.getIonization() != null
-                && (card.getIonization().contains(IonizationType.DEFENSE_IONIZED)
-                || card.getIonization().contains(IonizationType.HYPERSPEED_IONIZED));
-    }
-
-    private void passOptionalResponses(VirtualTableScenario scn) {
-        if (scn.GetCurrentDecision() != null) {
-            scn.PassAllResponses();
-        }
     }
 
     private void passPostFiringResponses(VirtualTableScenario scn) {

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
@@ -489,8 +489,10 @@ public class Card_1_39_Tests {
 
     @Test
     public void DefianceHeavyTurbolaserVsVictoryClassAddsTwoToEachDraw() {
-        // HTB draws two destinies. Defiance +2 each. Vs VSD (capital) HTB -1 total, not -6 vs starfighter.
-        // Printed 2,2 without +2: 2+2-1=3 vs armor 5 miss. With +2: 4+4-1=7 vs 5 hit.
+        // HTB draws two destinies vs VSD (capital): HTB -1 total, not -6 vs starfighter. No Targeting Computer.
+        // Printed destinies 2 and 2. No bonus: 2+2-1=3 vs armor 5 miss.
+        // +1 each would be (2+1)+(2+1)-1=5 vs 5 miss (equal fails).
+        // +2 each is (2+2)+(2+2)-1=7 vs 5 hit. +2 per draw is required; a hypothetical +1 cannot pass.
         var scn = GetScenario();
         var htb = scn.GetLSCard("htb");
         var vsd = scn.GetDSCard("vsd");
@@ -506,6 +508,8 @@ public class Card_1_39_Tests {
         assertEquals(5, scn.GetDefense(vsd));
         assertTrue("Each HTB draw from Defiance must include +2 (2+2 + 2+2 -1 vs VSD 5)", vsd.isHit());
         assertWeaponDestinyDrawValues(scn, 4, 4);
+        assertEquals("total weapon destiny must be 7 so +1 each (5 vs 5 miss) cannot pass",
+                7, lastTotalWeaponDestiny(scn));
         assertFalse("Ordinary non-TC shots stay unlabeled", gameLog(scn).contains("firing 1"));
     }
 
@@ -652,6 +656,26 @@ public class Card_1_39_Tests {
 
     private String gameLog(VirtualTableScenario scn) {
         return String.join("\n", scn.gameState().getLastMessages());
+    }
+
+    private int lastTotalWeaponDestiny(VirtualTableScenario scn) {
+        Integer last = null;
+        for (String msg : scn.gameState().getLastMessages()) {
+            String lower = msg.toLowerCase();
+            int idx = lower.lastIndexOf("total weapon destiny is ");
+            if (idx >= 0) {
+                String rest = msg.substring(idx + "total weapon destiny is ".length()).trim();
+                last = (int) Float.parseFloat(rest.split("[^0-9.]")[0]);
+                continue;
+            }
+            idx = msg.indexOf("Total destiny: ");
+            if (idx >= 0) {
+                String rest = msg.substring(idx + "Total destiny: ".length()).trim();
+                last = (int) Float.parseFloat(rest.split("[^0-9.]")[0]);
+            }
+        }
+        assertTrue("Expected a total weapon destiny log, got: " + gameLog(scn), last != null);
+        return last;
     }
 
     private void assertWeaponDestinyDrawValues(VirtualTableScenario scn, int... expected) {

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
@@ -5,6 +5,7 @@ import com.gempukku.swccgo.common.Phase;
 import com.gempukku.swccgo.common.Rarity;
 import com.gempukku.swccgo.common.Side;
 import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.common.Zone;
 import com.gempukku.swccgo.framework.StartingSetup;
 import com.gempukku.swccgo.framework.VirtualTableScenario;
 import com.gempukku.swccgo.game.PhysicalCardImpl;
@@ -293,6 +294,34 @@ public class Card_1_39_Tests {
 
         fireOneShot(scn, tie, 4, 0);
         assertTrue(tie.isHit());
+    }
+
+    @Test
+    public void TargetingComputerCombinedXwingLaserCannonX3LosesTieNotMerelyHit() {
+        // Combined twice at X=3: destinies 4 then 4, TC -1 each => 3+3=6, then +X=3 > TIE DV 3.
+        // XWLC must lose the TIE (not HitCardEffect).
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var xwlc = scn.GetLSCard("xwlc");
+        var tie = scn.GetDSCard("tie");
+        setupXwingLaser(scn);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(6);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseSeparatelyOrCombined(scn, "Combined");
+
+        fireOneShot(scn, tie, 4, 3);
+        assertFalse("First combined XWLC shot must not resolve a hit or loss by itself", tie.isHit());
+        assertEquals(Zone.AT_LOCATION, tie.getZone());
+
+        fireOneShot(scn, tie, 4, 3);
+        scn.PassResponses("ABOUT_TO_BE_LOST");
+        scn.PassAllResponses();
+        assertTrue("Combined X-wing Laser Cannon at X=3 must lose the TIE, not merely hit",
+                tie.getZone() == Zone.LOST_PILE || tie.getZone() == Zone.TOP_OF_LOST_PILE);
+        assertFalse(tie.getZone() == Zone.AT_LOCATION);
     }
 
     @Test
@@ -585,6 +614,9 @@ public class Card_1_39_Tests {
         // Ion Cannon resets attributes then ionizes; do not PassAllResponses or combined shot 2's Fire window is consumed.
         scn.PassResponses("ATTRIBUTE_RESET_OR_MODIFIED");
         scn.PassResponses("Ionized");
+        scn.PassResponses("ABOUT_TO_BE_LOST");
+        scn.PassResponses("ABOUT_TO_BE_HIT");
+        scn.PassResponses("HIT -");
         scn.PassResponses("FIRED_WEAPON");
     }
 }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
@@ -11,7 +11,10 @@ import com.gempukku.swccgo.framework.VirtualTableScenario;
 import com.gempukku.swccgo.game.PhysicalCardImpl;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -33,12 +36,14 @@ public class Card_1_39_Tests {
                     put("homeone", "9_74");
                     put("htb", "9_89");
                     put("ept", "9_88");
+                    put("defiance", "9_67");
                 }},
                 new HashMap<>()
                 {{
                     put("stalker", "3_152");
                     put("tie", "1_304");
                     put("tie2", "1_304");
+                    put("vsd", "2_155");
                 }},
                 10,
                 10,
@@ -458,6 +463,84 @@ public class Card_1_39_Tests {
     }
 
     @Test
+    public void TargetingComputerDontFireLeavesDeviceUnusedSoItCanBeUsedLaterThisBattle() {
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var tie = scn.GetDSCard("tie");
+        setupXwingLaser(scn);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+
+        assertTrue(scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseSeparatelyOrCombined(scn, "Don't Fire (Cancel)");
+
+        assertTrue("Don't Fire must return to weapons-segment actions, got: "
+                        + (scn.GetCurrentDecision() == null ? "null" : scn.GetCurrentDecision().getText()),
+                scn.AwaitingLSWeaponsSegmentActions());
+        assertTrue("Don't Fire must not consume Targeting Computer",
+                scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseSeparatelyOrCombined(scn, "Separately");
+        fireOneShot(scn, tie, 5, 0);
+        assertTrue(tie.isHit());
+    }
+
+    @Test
+    public void DefianceHeavyTurbolaserVsVictoryClassAddsTwoToEachDraw() {
+        // HTB draws two destinies. Defiance +2 each. Vs VSD (capital) HTB -1 total, not -6 vs starfighter.
+        // Printed 2,2 without +2: 2+2-1=3 vs armor 5 miss. With +2: 4+4-1=7 vs 5 hit.
+        var scn = GetScenario();
+        var htb = scn.GetLSCard("htb");
+        var vsd = scn.GetDSCard("vsd");
+        setupDefiance(scn, false);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
+
+        assertTrue(scn.LSCardActionAvailable(htb, "Fire"));
+        scn.LSUseCardAction(htb, "Fire");
+        fireTwoDestinyShot(scn, vsd, 2, 2);
+
+        assertEquals(5, scn.GetDefense(vsd));
+        assertTrue("Each HTB draw from Defiance must include +2 (2+2 + 2+2 -1 vs VSD 5)", vsd.isHit());
+        assertWeaponDestinyDrawValues(scn, 4, 4);
+        assertFalse("Ordinary non-TC shots stay unlabeled", gameLog(scn).contains("firing 1"));
+    }
+
+    @Test
+    public void DefianceTargetingComputerCombinedAppliesMinusOneAndPlusTwoPerDraw() {
+        // TC -1 and Defiance +2 per draw (net +1 vs printed). HTB two draws per firing.
+        // Printed 2,2 then 2,2: each firing (2-1+2)*2=6. Combined 12, HTB -1 vs capital = 11 vs VSD 5 hit.
+        // Without Defiance +2: (2-1)*2 per firing, combined 4, -1 = 3 vs 5 miss.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var vsd = scn.GetDSCard("vsd");
+        setupDefiance(scn, true);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseSeparatelyOrCombined(scn, "Combined");
+
+        fireTwoDestinyShot(scn, vsd, 2, 2);
+        assertFalse("First combined HTB firing must not resolve a hit by itself", vsd.isHit());
+
+        fireTwoDestinyShot(scn, vsd, 2, 2);
+        assertTrue("TC -1 and Defiance +2 must both apply per draw", vsd.isHit());
+        assertWeaponDestinyDrawValues(scn, 3, 3, 3, 3);
+
+        String log = gameLog(scn);
+        assertTrue(log.contains("twice: combined"));
+        assertTrue(log.contains("Targeting Computer Combined firing 1"));
+        assertTrue(log.contains("Targeting Computer Combined firing 2"));
+        assertFalse("No parentheses around the weapon name", log.contains("firing 1 ("));
+        assertFalse(log.contains("firing 2 ("));
+    }
+
+    @Test
     public void TargetingComputerFiresHeavyTurbolaserFromHomeOneCombined() {
         // Combined HTB vs Stalker: each firing is one weapon destiny (sum of two TC-modified draws).
         // dest 4,4 => (4-1)+(4-1)=6 stored, not a hit yet. Second firing 4,4 => 6. Combined 12, total -1 = 11 vs 7 hit.
@@ -517,9 +600,12 @@ public class Card_1_39_Tests {
     private void chooseSeparatelyOrCombined(VirtualTableScenario scn, String mode) {
         assertFalse("These setups attach one legal weapon; GEMP must auto-select it instead of prompting",
                 scn.LSDecisionAvailable("Choose weapon"));
-        assertTrue("Expected Separately/Combined prompt, got: "
+        assertTrue("Expected Fire a weapon twice prompt, got: "
                         + (scn.GetCurrentDecision() == null ? "null" : scn.GetCurrentDecision().getText()),
-                scn.LSDecisionAvailable("separately or combined"));
+                scn.LSDecisionAvailable("Fire a weapon twice"));
+        assertTrue(scn.LSChoiceAvailable("Separately"));
+        assertTrue(scn.LSChoiceAvailable("Combined"));
+        assertTrue(scn.LSChoiceAvailable("Don't Fire (Cancel)"));
         scn.LSChoose(mode);
     }
 
@@ -547,6 +633,42 @@ public class Card_1_39_Tests {
         var tie2 = scn.GetDSCard("tie2");
         scn.MoveCardsToLocation(system, ywing, stalker, tie, tie2);
         scn.AttachCardsTo(ywing, sw4, tc);
+    }
+
+    private void setupDefiance(VirtualTableScenario scn, boolean withTc) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var defiance = scn.GetLSCard("defiance");
+        var htb = scn.GetLSCard("htb");
+        var vsd = scn.GetDSCard("vsd");
+        scn.MoveCardsToLocation(system, defiance, vsd);
+        if (withTc) {
+            scn.AttachCardsTo(defiance, htb, scn.GetLSCard("tc"));
+        }
+        else {
+            scn.AttachCardsTo(defiance, htb);
+        }
+    }
+
+    private String gameLog(VirtualTableScenario scn) {
+        return String.join("\n", scn.gameState().getLastMessages());
+    }
+
+    private void assertWeaponDestinyDrawValues(VirtualTableScenario scn, int... expected) {
+        List<Integer> actual = new ArrayList<>();
+        for (String msg : scn.gameState().getLastMessages()) {
+            int idx = msg.indexOf(" as a ");
+            int destIdx = msg.indexOf(" for weapon destiny");
+            if (idx >= 0 && destIdx > idx) {
+                actual.add((int) Float.parseFloat(msg.substring(idx + " as a ".length(), destIdx).trim()));
+            }
+        }
+        assertTrue("Expected last weapon destiny draws " + Arrays.toString(expected) + " but saw " + actual,
+                actual.size() >= expected.length);
+        List<Integer> last = actual.subList(actual.size() - expected.length, actual.size());
+        for (int i = 0; i < expected.length; i++) {
+            assertEquals("weapon destiny draw " + (i + 1) + " of " + last, expected[i], last.get(i).intValue());
+        }
     }
 
     private void setupHomeOne(VirtualTableScenario scn) {

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
@@ -604,6 +604,32 @@ public class Card_1_39_Tests {
     }
 
     @Test
+    public void TargetingComputerAttachedDoesNotSubtractFromNormalHeavyTurbolaserFire() {
+        // Playtest: Verrack on Defiance fires HTB at Executor with Targeting Computer attached but unused.
+        // Printed 3 (HTB) and 6 (Concentrate All Fire): each +2 Defiance +2 Verrack vs capital.
+        // Correct: 7 and 10, total 17-1=16 vs armor 12.
+        // Unused TC -1 would make 6 and 9, total 14.
+        var scn = GetScenario();
+        var htb = scn.GetLSCard("htb");
+        var executor = scn.GetDSCard("executor");
+        setupDefianceVerrack(scn, true);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
+
+        assertTrue(scn.LSCardActionAvailable(htb, "Fire"));
+        scn.LSUseCardAction(htb, "Fire");
+        fireTwoDestinyShot(scn, executor, 3, 6);
+
+        assertEquals(12, scn.GetDefense(executor));
+        assertWeaponDestinyDrawValues(scn, 7, 10);
+        assertEquals("unused Targeting Computer must not subtract 1 per draw (that would total 14)",
+                16, lastTotalWeaponDestiny(scn));
+        assertTrue(executor.isHit());
+        assertFalse("Ordinary non-TC shots stay unlabeled", gameLog(scn).contains("firing 1"));
+    }
+
+    @Test
     public void DefianceDackVerrackTargetingComputerSeparatelyEachBonusesRequiredVsExecutor() {
         // TC -1 each. Printed 3 and 3: each draw 3+2+1+2-1=7, total 14-1=13 vs 12 hit.
         // Missing Dack: 11 vs 12 miss.
@@ -859,6 +885,22 @@ public class Card_1_39_Tests {
         scn.AttachCardsTo(ywing, sw4, tc);
     }
 
+
+    private void setupDefianceVerrack(VirtualTableScenario scn, boolean withTc) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var defiance = scn.GetLSCard("defiance");
+        var htb = scn.GetLSCard("htb");
+        var executor = scn.GetDSCard("executor");
+        scn.MoveCardsToLocation(system, defiance, executor);
+        scn.BoardAsPassenger(defiance, scn.GetLSCard("verrack"));
+        if (withTc) {
+            scn.AttachCardsTo(defiance, htb, scn.GetLSCard("tc"));
+        }
+        else {
+            scn.AttachCardsTo(defiance, htb);
+        }
+    }
 
     private void setupDefianceGunners(VirtualTableScenario scn, boolean withTc) {
         scn.StartGame();

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
@@ -653,6 +653,30 @@ public class Card_1_39_Tests {
     }
 
     @Test
+    public void DefianceKarieDackVerrackTargetingComputerSeparatelyDrawsAreEightNotNineVsExecutor() {
+        // Playtest: Targeting Computer fires Heavy Turbolaser Battery twice separately at Executor.
+        // Defiance +2 each (FiredBy), Karie Neth +1, Dack Ralter +1, Captain Verrack +2 vs capital = +6.
+        // Targeting Computer -1 each while using Fire a weapon twice. Printed 3 and 3 must be 8 and 8, not 9 and 9.
+        // Heavy Turbolaser Battery -1 vs capital still applies to the total: 16-1=15 vs armor 12.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var executor = scn.GetDSCard("executor");
+        setupDefianceKarieGunners(scn);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseSeparatelyOrCombined(scn, "Separately");
+        fireTwoDestinyShot(scn, executor, 3, 3);
+
+        assertWeaponDestinyDrawValues(scn, 8, 8);
+        assertEquals("Targeting Computer -1 must apply to each draw; 9+9-1 vs capital would total 17",
+                15, lastTotalWeaponDestiny(scn));
+        assertTrue(executor.isHit());
+    }
+
+    @Test
     public void TargetingComputerSeparatelyFireTwiceClearsFiringStateAfterDefianceHitsCapital() {
         // Playtest crash: Targeting Computer fires Heavy Turbolaser Battery twice separately
         // (TIE, then a capital). Defiance required response reduces the capital power by 5.
@@ -936,6 +960,22 @@ public class Card_1_39_Tests {
         }
     }
 
+    /**
+     * Defiance with Karie Neth piloting, Dack Ralter and Captain Verrack as passengers,
+     * Heavy Turbolaser Battery and Targeting Computer, facing Executor.
+     */
+    private void setupDefianceKarieGunners(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var defiance = scn.GetLSCard("defiance");
+        var htb = scn.GetLSCard("htb");
+        var executor = scn.GetDSCard("executor");
+        scn.MoveCardsToLocation(system, defiance, executor);
+        scn.BoardAsPilot(defiance, scn.GetLSCard("karie"));
+        scn.BoardAsPassenger(defiance, scn.GetLSCard("dack"), scn.GetLSCard("verrack"));
+        scn.AttachCardsTo(defiance, htb, scn.GetLSCard("tc"));
+    }
+
     private void setupDefianceGunners(VirtualTableScenario scn, boolean withTc) {
         scn.StartGame();
         var system = scn.GetLSStartingLocation();
@@ -994,9 +1034,9 @@ public class Card_1_39_Tests {
      * still set the game is canceled.
      */
     private void assertFireTwiceStateCleared(VirtualTableScenario scn) {
+        scn.game().takeSnapshot("after Targeting Computer");
         assertTrue("Targeting Computer fire-twice must clear separately-or-combined firing state",
                 scn.gameState().getSeparatelyOrCombinedFiringState() == null);
-        scn.game().takeSnapshot("after Targeting Computer");
     }
 
     /**

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
@@ -553,6 +553,8 @@ public class Card_1_39_Tests {
         assertTrue(log.contains("Targeting Computer Combined firing 2"));
         assertFalse("No parentheses around the weapon name", log.contains("firing 1 ("));
         assertFalse(log.contains("firing 2 ("));
+
+        assertFireTwiceStateCleared(scn);
     }
 
     @Test
@@ -648,6 +650,38 @@ public class Card_1_39_Tests {
         assertWeaponDestinyDrawValues(scn, 7, 7);
         assertEquals(13, lastTotalWeaponDestiny(scn));
         assertTrue("Separately HTB still needs Dack, Verrack, and Defiance each-draw bonuses", executor.isHit());
+    }
+
+    @Test
+    public void TargetingComputerSeparatelyFireTwiceClearsFiringStateAfterDefianceHitsCapital() {
+        // Playtest crash: Targeting Computer fires Heavy Turbolaser Battery twice separately
+        // (TIE, then a capital). Defiance required response reduces the capital power by 5.
+        // Weapons-segment Pass then aborted because separately-or-combined firing state was still set.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var tie = scn.GetDSCard("tie");
+        var vsd = scn.GetDSCard("vsd");
+        setupDefiance(scn, true);
+        scn.MoveCardsToLocation(scn.GetLSStartingLocation(), tie);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseSeparatelyOrCombined(scn, "Separately");
+
+        fireTwoDestinyShot(scn, tie, 7, 7);
+        assertTrue(tie.isHit());
+
+        int vsdPowerBefore = scn.GetPower(vsd);
+        fireTwoDestinyShot(scn, vsd, 7, 7);
+        assertTrue(vsd.isHit());
+        scn.PassResponses("required");
+        scn.PassResponses("power by 5");
+        scn.PassAllResponses();
+        assertEquals("Defiance required response must reduce the capital power by 5", vsdPowerBefore - 5, scn.GetPower(vsd));
+
+        assertFireTwiceStateCleared(scn);
     }
 
     @Test
@@ -954,6 +988,20 @@ public class Card_1_39_Tests {
         }
     }
 
+    /**
+     * After Targeting Computer fire-twice finishes, separately-or-combined firing state must be empty
+     * and taking a snapshot must not throw. Weapons-segment Pass snapshots the game; if that state is
+     * still set the game is canceled.
+     */
+    private void assertFireTwiceStateCleared(VirtualTableScenario scn) {
+        assertTrue("Targeting Computer fire-twice must clear separately-or-combined firing state",
+                scn.gameState().getSeparatelyOrCombinedFiringState() == null);
+        scn.game().takeSnapshot("after Targeting Computer");
+    }
+
+    /**
+     * Defiance with Heavy Turbolaser Battery (and Targeting Computer when withTc) facing a Victory-class Star Destroyer.
+     */
     private void setupDefiance(VirtualTableScenario scn, boolean withTc) {
         scn.StartGame();
         var system = scn.GetLSStartingLocation();
@@ -1055,6 +1103,9 @@ public class Card_1_39_Tests {
         scn.PassDestinyDrawResponses();
         scn.PassResponses("ABOUT_TO_BE_HIT");
         scn.PassResponses("HIT -");
+        // Defiance required: Reduce a capital starship power by 5 after it is hit.
+        scn.PassResponses("required");
+        scn.PassResponses("power by 5");
         scn.PassResponses("FIRED_WEAPON");
         passPostFiringResponses(scn);
     }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
@@ -26,6 +26,20 @@ public class Card_1_39_Tests {
                 new HashMap<>()
                 {{
                     put("tc", "1_39");
+                    put("tc2", "1_39");
+                    put("tc3", "1_39");
+                    put("tc4", "1_39");
+                    put("bwing", "7_140");
+                    put("squadron", "7_150");
+                    put("sw42", "2_081");
+                    put("sw43", "2_081");
+                    put("sw44", "2_081");
+                    put("xwlc2", "7_162");
+                    put("xwlc3", "7_162");
+                    put("xwlc4", "7_162");
+                    put("htb2", "9_89");
+                    put("htb3", "9_89");
+                    put("htb4", "9_89");
                     put("karie", "9_18");
                     put("pilot", "1_27");
                     put("red7", "7_146");
@@ -56,7 +70,7 @@ public class Card_1_39_Tests {
                     put("vsd", "2_155");
                     put("executor", "4_167");
                 }},
-                10,
+                40,
                 10,
                 StartingSetup.DefaultLSSpaceSystem,
                 StartingSetup.DefaultDSSpaceSystem,
@@ -871,6 +885,342 @@ public class Card_1_39_Tests {
         assertTrue(tie.isHit());
     }
 
+
+    @Test
+    public void TargetingComputerFourCopiesMayDeployOnBwingEvenIfOnlyOneCanBeUsed() {
+        /**
+         * Advanced Rulebook Devices: any number of Targeting Computers may deploy on a starship
+         * even if that ship cannot use all of them this turn. A starfighter may use only one device
+         * per turn. Cumulative Rule: copies of Targeting Computer do not stack +1 maneuver.
+         */
+        var scn = GetScenario();
+        var bwing = scn.GetLSCard("bwing");
+        var tc = scn.GetLSCard("tc");
+        var tc2 = scn.GetLSCard("tc2");
+        var tc3 = scn.GetLSCard("tc3");
+        var tc4 = scn.GetLSCard("tc4");
+        scn.MoveCardsToHand(tc, tc2, tc3, tc4);
+
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        scn.MoveCardsToLocation(system, bwing);
+
+        // Open format: Dark Side goes first. Skip to Light Side deploy, then move Reserve
+        // into the Force Pile so four Targeting Computers (2 Force each) can deploy.
+        scn.SkipToLSTurn(Phase.DEPLOY);
+        scn.EnsureLSForcePile(8);
+        assertTrue("Expected Light Side deploy actions, got: " + decisionDump(scn),
+                scn.AwaitingLSDeployPhaseActions());
+
+        PhysicalCardImpl[] computers = { tc, tc2, tc3, tc4 };
+        for (PhysicalCardImpl computer : computers) {
+            assertTrue("Targeting Computer must be deployable on the B-wing. " + decisionDump(scn),
+                    scn.LSGetDecision() != null && scn.LSDeployAvailable(computer));
+            scn.LSDeployCard(computer);
+            if (scn.LSGetDecision() != null && scn.LSHasCardChoiceAvailable(bwing)) {
+                scn.LSChooseCard(bwing);
+            }
+            if (scn.GetCurrentDecision() != null) {
+                scn.PassAllResponses();
+            }
+            // Deploy phase alternates players the same way weapons segment does.
+            if (scn.AwaitingDSDeployPhaseActions()) {
+                scn.DSPass();
+            }
+            assertTrue(scn.IsAttachedTo(bwing, computer));
+        }
+
+        assertEquals("Cumulative Rule: four Targeting Computers still add only +1 maneuver, not +4",
+                3, scn.GetManeuver(bwing));
+    }
+
+    @Test
+    public void TargetingComputerStarfighterMayUseOnlyOneCopyPerTurn() {
+        // B-wing Attack Fighter may fire many weapons each turn, so leftover SW-4 Ion Cannons
+        // stay fireable after one Targeting Computer. The starfighter may still use only one
+        // device per turn, so the other three Targeting Computers cannot Fire a weapon twice.
+        var scn = GetScenario();
+        var bwing = scn.GetLSCard("bwing");
+        var tc = scn.GetLSCard("tc");
+        var tc2 = scn.GetLSCard("tc2");
+        var tc3 = scn.GetLSCard("tc3");
+        var tc4 = scn.GetLSCard("tc4");
+        var sw4 = scn.GetLSCard("sw4");
+        var sw42 = scn.GetLSCard("sw42");
+        var tie = scn.GetDSCard("tie");
+        setupBwingWithFourTargetingComputers(scn);
+
+        assertEquals("Unused Targeting Computers still give +1 maneuver (continuous text is not using the device)",
+                3, scn.GetManeuver(bwing));
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(6);
+
+        assertTrue(fireTwiceAvailable(scn, tc));
+        assertTrue(fireTwiceAvailable(scn, tc2));
+        assertTrue(fireTwiceAvailable(scn, tc3));
+        assertTrue(fireTwiceAvailable(scn, tc4));
+
+        useFireAWeaponTwice(scn, tc, sw4, "Separately");
+        fireOneShot(scn, tie, 1);
+        fireOneShot(scn, tie, 1);
+        passDarkSideWeaponsIfNeeded(scn);
+
+        assertTrue("B-wing still has unused SW-4 Ion Cannons, so Light Side stays in weapons segment. "
+                        + decisionDump(scn),
+                scn.AwaitingLSWeaponsSegmentActions());
+        assertFalse("That Targeting Computer copy cannot be used again this turn. " + decisionDump(scn),
+                fireTwiceAvailable(scn, tc));
+        assertFalse("Starfighter may use only one device per turn. " + decisionDump(scn),
+                fireTwiceAvailable(scn, tc2));
+        assertFalse("Starfighter may use only one device per turn", fireTwiceAvailable(scn, tc3));
+        assertFalse("Starfighter may use only one device per turn", fireTwiceAvailable(scn, tc4));
+        assertTrue("Leftover SW-4 Ion Cannon can still Fire (device limit is not a weapon limit). "
+                        + decisionDump(scn),
+                scn.LSCardActionAvailable(sw42, "Fire"));
+        assertEquals("After using one Targeting Computer, maneuver is still +1, not +4 and not lost",
+                3, scn.GetManeuver(bwing));
+    }
+
+    @Test
+    public void TargetingComputerSquadronMayUseThreeCopiesPerTurn() {
+        // X-wing Assault Squadron is a Decipher squadron-class starship (Filters.squadron).
+        // Squadrons may use three different devices per turn. After three Targeting Computers
+        // are used, the fourth cannot Fire a weapon twice this turn.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var tc2 = scn.GetLSCard("tc2");
+        var tc3 = scn.GetLSCard("tc3");
+        var tc4 = scn.GetLSCard("tc4");
+        var xwlc = scn.GetLSCard("xwlc");
+        var xwlc2 = scn.GetLSCard("xwlc2");
+        var xwlc3 = scn.GetLSCard("xwlc3");
+        var tie = scn.GetDSCard("tie");
+        setupSquadronWithFourTargetingComputers(scn);
+
+        scn.EnsureLSForcePile(4);
+        scn.StartBattleAndSkipToWeaponsSegment();
+
+        assertTrue(fireTwiceAvailable(scn, tc));
+        assertTrue(fireTwiceAvailable(scn, tc2));
+        assertTrue(fireTwiceAvailable(scn, tc3));
+        assertTrue(fireTwiceAvailable(scn, tc4));
+
+        useFireAWeaponTwice(scn, tc, xwlc, "Separately");
+        fireOneShot(scn, tie, 1, 0);
+        fireOneShot(scn, tie, 1, 0);
+        passDarkSideWeaponsIfNeeded(scn);
+        assertTrue("Squadron may use a second Targeting Computer this turn. " + decisionDump(scn),
+                fireTwiceAvailable(scn, tc2));
+        assertFalse("The Targeting Computer copy already used cannot Fire a weapon twice again this turn",
+                fireTwiceAvailable(scn, tc));
+
+        useFireAWeaponTwice(scn, tc2, xwlc2, "Separately");
+        fireOneShot(scn, tie, 1, 0);
+        fireOneShot(scn, tie, 1, 0);
+        passDarkSideWeaponsIfNeeded(scn);
+        assertTrue("Squadron may use a third Targeting Computer this turn. " + decisionDump(scn),
+                fireTwiceAvailable(scn, tc3));
+
+        useFireAWeaponTwice(scn, tc3, xwlc3, "Separately");
+        fireOneShot(scn, tie, 1, 0);
+        fireOneShot(scn, tie, 1, 0);
+        passDarkSideWeaponsIfNeeded(scn);
+
+        if (scn.AwaitingLSWeaponsSegmentActions()) {
+            assertFalse("Squadron may use only three devices per turn. " + decisionDump(scn),
+                    fireTwiceAvailable(scn, tc4));
+        }
+        else {
+            assertTrue("Expected weapons segment after three Targeting Computer uses. " + decisionDump(scn),
+                    scn.AwaitingDSWeaponsSegmentActions());
+        }
+    }
+
+    @Test
+    public void TargetingComputerCapitalMayUseAllFourCopiesPerTurn() {
+        // Home One is a capital starship and may use any number of devices per turn.
+        // Using copy A does not prevent using copy B, C, or D this turn.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var tc2 = scn.GetLSCard("tc2");
+        var tc3 = scn.GetLSCard("tc3");
+        var tc4 = scn.GetLSCard("tc4");
+        var htb = scn.GetLSCard("htb");
+        var htb2 = scn.GetLSCard("htb2");
+        var htb3 = scn.GetLSCard("htb3");
+        var htb4 = scn.GetLSCard("htb4");
+        var stalker = scn.GetDSCard("stalker");
+        setupCapitalWithFourTargetingComputers(scn);
+
+        scn.EnsureLSForcePile(16);
+        scn.StartBattleAndSkipToWeaponsSegment();
+
+        PhysicalCardImpl[] computers = { tc, tc2, tc3, tc4 };
+        PhysicalCardImpl[] batteries = { htb, htb2, htb3, htb4 };
+        for (int i = 0; i < computers.length; i++) {
+            assertTrue("Capital may use Targeting Computer copy " + (i + 1) + " this turn. "
+                            + decisionDump(scn),
+                    fireTwiceAvailable(scn, computers[i]));
+            useFireAWeaponTwice(scn, computers[i], batteries[i], "Separately");
+            fireTwoDestinyShot(scn, stalker, 1, 1);
+            fireTwoDestinyShot(scn, stalker, 1, 1);
+            passDarkSideWeaponsIfNeeded(scn);
+            assertFalse("Used Targeting Computer copy " + (i + 1) + " cannot Fire a weapon twice again this turn. "
+                            + decisionDump(scn),
+                    fireTwiceAvailable(scn, computers[i]));
+        }
+    }
+
+    @Test
+    public void TargetingComputerEachCopyCanBeUsedOnlyOncePerTurn() {
+        // One Rule: an individual Targeting Computer copy can only be used once per turn.
+        // OncePerBattle is not enough if a second battle the same turn would re-offer it.
+        // No clean Decipher card initiates a second battle the same turn, so this checks the
+        // same-copy limit in one battle on a capital (device slots are unlimited there).
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var tc2 = scn.GetLSCard("tc2");
+        var tc3 = scn.GetLSCard("tc3");
+        var tc4 = scn.GetLSCard("tc4");
+        var htb = scn.GetLSCard("htb");
+        var stalker = scn.GetDSCard("stalker");
+        setupCapitalWithFourTargetingComputers(scn);
+
+        scn.EnsureLSForcePile(8);
+        scn.StartBattleAndSkipToWeaponsSegment();
+
+        assertTrue(fireTwiceAvailable(scn, tc));
+        useFireAWeaponTwice(scn, tc, htb, "Separately");
+        fireTwoDestinyShot(scn, stalker, 1, 1);
+        fireTwoDestinyShot(scn, stalker, 1, 1);
+        passDarkSideWeaponsIfNeeded(scn);
+
+        assertTrue("After using copy A, Light Side should still have weapons actions. " + decisionDump(scn),
+                scn.AwaitingLSWeaponsSegmentActions());
+        assertFalse("Copy A cannot Fire a weapon twice again this turn. " + decisionDump(scn),
+                fireTwiceAvailable(scn, tc));
+        assertTrue("Using copy A does not prevent using copy B this turn. " + decisionDump(scn),
+                fireTwiceAvailable(scn, tc2));
+        assertTrue("Copy C is still available this turn", fireTwiceAvailable(scn, tc3));
+        assertTrue("Copy D is still available this turn", fireTwiceAvailable(scn, tc4));
+    }
+
+
+    /**
+     * B-wing Attack Fighter with four Targeting Computers and four SW-4 Ion Cannons vs two TIEs.
+     * The B-wing may fire many weapons during battle, so leftover cannons stay fireable after
+     * one Targeting Computer is used.
+     */
+    private void setupBwingWithFourTargetingComputers(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var bwing = scn.GetLSCard("bwing");
+        var tie = scn.GetDSCard("tie");
+        var tie2 = scn.GetDSCard("tie2");
+        scn.MoveCardsToLocation(system, bwing, tie, tie2);
+        scn.AttachCardsTo(bwing,
+                scn.GetLSCard("sw4"), scn.GetLSCard("sw42"), scn.GetLSCard("sw43"), scn.GetLSCard("sw44"),
+                scn.GetLSCard("tc"), scn.GetLSCard("tc2"), scn.GetLSCard("tc3"), scn.GetLSCard("tc4"));
+    }
+
+    /**
+     * X-wing Assault Squadron with four Targeting Computers and four X-wing Laser Cannons vs two TIEs.
+     * Squadrons may use three different devices per turn.
+     */
+    private void setupSquadronWithFourTargetingComputers(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var squadron = scn.GetLSCard("squadron");
+        var tie = scn.GetDSCard("tie");
+        var tie2 = scn.GetDSCard("tie2");
+        scn.MoveCardsToLocation(system, squadron, tie, tie2);
+        scn.AttachCardsTo(squadron,
+                scn.GetLSCard("xwlc"), scn.GetLSCard("xwlc2"), scn.GetLSCard("xwlc3"), scn.GetLSCard("xwlc4"),
+                scn.GetLSCard("tc"), scn.GetLSCard("tc2"), scn.GetLSCard("tc3"), scn.GetLSCard("tc4"));
+    }
+
+    /**
+     * Home One with four Targeting Computers and four Heavy Turbolaser Batteries vs Stalker.
+     * Capitals may use any number of devices per turn. Stalker is the proven Home One target.
+     */
+    private void setupCapitalWithFourTargetingComputers(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var homeone = scn.GetLSCard("homeone");
+        var stalker = scn.GetDSCard("stalker");
+        scn.MoveCardsToLocation(system, homeone, stalker);
+        scn.AttachCardsTo(homeone,
+                scn.GetLSCard("htb"), scn.GetLSCard("htb2"), scn.GetLSCard("htb3"), scn.GetLSCard("htb4"),
+                scn.GetLSCard("tc"), scn.GetLSCard("tc2"), scn.GetLSCard("tc3"), scn.GetLSCard("tc4"));
+    }
+
+    /**
+     * Starts Fire a weapon twice on the given Targeting Computer. If several weapons can fire,
+     * choose the given weapon. Then pick Separately or Combined.
+     */
+    private void useFireAWeaponTwice(VirtualTableScenario scn, PhysicalCardImpl targetingComputer,
+                                     PhysicalCardImpl weapon, String mode) {
+        assertTrue("Fire a weapon twice must be available on that Targeting Computer. " + decisionDump(scn),
+                fireTwiceAvailable(scn, targetingComputer));
+        scn.LSUseCardAction(targetingComputer, "Fire a weapon twice");
+        if (scn.LSGetDecision() != null && scn.LSDecisionAvailable("Choose weapon")) {
+            scn.LSChooseCard(weapon);
+        }
+        assertTrue("Expected Fire a weapon twice prompt, got: " + decisionDump(scn),
+                scn.LSGetDecision() != null && scn.LSDecisionAvailable("Fire a weapon twice"));
+        assertTrue(scn.LSChoiceAvailable("Separately"));
+        assertTrue(scn.LSChoiceAvailable("Combined"));
+        assertTrue(scn.LSChoiceAvailable("Don't Fire (Cancel)"));
+        scn.LSChoose(mode);
+    }
+
+    /**
+     * Weapons segment alternates players. After Light Side uses a Targeting Computer, Dark Side
+     * is asked next even if Light Side still has weapons or devices. Pass Dark Side to get back
+     * to Light Side's remaining Targeting Computers.
+     */
+    private void passDarkSideWeaponsIfNeeded(VirtualTableScenario scn) {
+        if (scn.AwaitingDSWeaponsSegmentActions()) {
+            scn.DSPass();
+        }
+    }
+
+    /**
+     * True if Light Side currently has Fire a weapon twice on that Targeting Computer copy.
+     * False (does not throw) when Light Side has no decision.
+     */
+    private boolean fireTwiceAvailable(VirtualTableScenario scn, PhysicalCardImpl targetingComputer) {
+        return scn.LSGetDecision() != null && scn.LSCardActionAvailable(targetingComputer, "Fire a weapon twice");
+    }
+
+    /**
+     * Light Side and Dark Side current decision text plus Light Side action list, for assertion messages.
+     */
+    private String decisionDump(VirtualTableScenario scn) {
+        String ls = scn.LSGetDecision() == null ? "null" : scn.LSGetDecision().getText();
+        String ds = scn.DSGetDecision() == null ? "null" : scn.DSGetDecision().getText();
+        String actions = "n/a";
+        try {
+            if (scn.LSGetDecision() != null) {
+                actions = String.valueOf(scn.GetLSAvailableActions());
+            }
+        }
+        catch (RuntimeException ignored) {
+            actions = "(no actionText)";
+        }
+        String phase = String.valueOf(scn.gameState().getCurrentPhase());
+        String player = String.valueOf(scn.gameState().getCurrentPlayerId());
+        String soc = scn.gameState().getSeparatelyOrCombinedFiringState() == null ? "none" : "active";
+        int force = scn.GetLSForcePileCount();
+        String logTail = "";
+        java.util.List<String> msgs = scn.gameState().getLastMessages();
+        int from = Math.max(0, msgs.size() - 12);
+        logTail = String.join(" | ", msgs.subList(from, msgs.size()));
+        return "player=" + player + " phase=" + phase + " force=" + force + " soc=" + soc
+                + " LS=" + ls + " actions=" + actions + " DS=" + ds + " log=" + logTail;
+    }
+
     private void setupRed7(VirtualTableScenario scn, boolean includeKarie) {
         scn.StartGame();
         var system = scn.GetLSStartingLocation();
@@ -1117,6 +1467,9 @@ public class Card_1_39_Tests {
     private void fireOneShot(VirtualTableScenario scn, PhysicalCardImpl target, int destiny, Integer forceToUse) {
         // Combined second shots auto-target and may already be at Force/Fire responses.
         // Prepare destiny before passing those responses so the next draw is stubbed.
+        if (scn.AwaitingLSWeaponsSegmentActions() || scn.AwaitingDSWeaponsSegmentActions()) {
+            return;
+        }
         if (scn.LSGetDecision() != null && scn.LSHasCardChoiceAvailable(target)) {
             scn.LSChooseCard(target);
         }
@@ -1128,6 +1481,9 @@ public class Card_1_39_Tests {
     }
 
     private void fireTwoDestinyShot(VirtualTableScenario scn, PhysicalCardImpl target, int destiny1, int destiny2) {
+        if (scn.AwaitingLSWeaponsSegmentActions() || scn.AwaitingDSWeaponsSegmentActions()) {
+            return;
+        }
         if (scn.LSGetDecision() != null && scn.LSHasCardChoiceAvailable(target)) {
             scn.LSChooseCard(target);
         }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
@@ -37,6 +37,16 @@ public class Card_1_39_Tests {
                     put("htb", "9_89");
                     put("ept", "9_88");
                     put("defiance", "9_67");
+                    put("dack", "3_4");
+                    put("verrack", "9_7");
+                    put("cec", "7_56");
+                    put("corellia", "2_61");
+                    put("falcon", "1_143");
+                    put("gunner", "3_17");
+                    put("qlc", "1_159");
+                    put("tennumb", "9_29");
+                    put("blue5", "9_63");
+                    put("missiles", "9_87");
                 }},
                 new HashMap<>()
                 {{
@@ -44,6 +54,7 @@ public class Card_1_39_Tests {
                     put("tie", "1_304");
                     put("tie2", "1_304");
                     put("vsd", "2_155");
+                    put("executor", "4_167");
                 }},
                 10,
                 10,
@@ -567,6 +578,215 @@ public class Card_1_39_Tests {
         assertTrue(stalker.isHit());
     }
 
+
+    @Test
+    public void DefianceDackVerrackHeavyTurbolaserEachBonusesRequiredVsExecutor() {
+        // Dack passenger +1 each, Verrack aboard +2 each vs capital, Defiance +2 each, HTB -1 total vs capital.
+        // Printed 2 and 2: each draw 2+2+1+2=7, total 14-1=13 vs Executor armor 12 hit.
+        // Missing Dack: 12-1=11 vs 12 miss. Missing Verrack or Defiance is even lower.
+        var scn = GetScenario();
+        var htb = scn.GetLSCard("htb");
+        var executor = scn.GetDSCard("executor");
+        setupDefianceGunners(scn, false);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
+
+        assertTrue(scn.LSCardActionAvailable(htb, "Fire"));
+        scn.LSUseCardAction(htb, "Fire");
+        fireTwoDestinyShot(scn, executor, 2, 2);
+
+        assertEquals(12, scn.GetDefense(executor));
+        assertWeaponDestinyDrawValues(scn, 7, 7);
+        assertEquals("total must be 13 so dropping Dack's +1 each (11 vs 12) cannot pass",
+                13, lastTotalWeaponDestiny(scn));
+        assertTrue("Dack + Verrack + Defiance each-draw bonuses are all required to hit Executor", executor.isHit());
+    }
+
+    @Test
+    public void DefianceDackVerrackTargetingComputerSeparatelyEachBonusesRequiredVsExecutor() {
+        // TC -1 each. Printed 3 and 3: each draw 3+2+1+2-1=7, total 14-1=13 vs 12 hit.
+        // Missing Dack: 11 vs 12 miss.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var executor = scn.GetDSCard("executor");
+        setupDefianceGunners(scn, true);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseSeparatelyOrCombined(scn, "Separately");
+        fireTwoDestinyShot(scn, executor, 3, 3);
+
+        assertWeaponDestinyDrawValues(scn, 7, 7);
+        assertEquals(13, lastTotalWeaponDestiny(scn));
+        assertTrue("Separately HTB still needs Dack, Verrack, and Defiance each-draw bonuses", executor.isHit());
+    }
+
+    @Test
+    public void DefianceDackVerrackTargetingComputerCombinedEachBonusesRequiredVsExecutor() {
+        // Combined HTB: two draws per firing, twice, then HTB -1 once.
+        // Printed 0 x4 with TC -1: each draw 0+2+1+2-1=4, combined 16-1=15 vs 12 hit.
+        // Missing Dack: 12-1=11 vs 12 miss.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var executor = scn.GetDSCard("executor");
+        setupDefianceGunners(scn, true);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseSeparatelyOrCombined(scn, "Combined");
+        fireTwoDestinyShot(scn, executor, 0, 0);
+        assertFalse("First combined HTB firing must not resolve a hit by itself", executor.isHit());
+        fireTwoDestinyShot(scn, executor, 0, 0);
+
+        assertWeaponDestinyDrawValues(scn, 4, 4, 4, 4);
+        assertEquals("combined total 15 so missing Dack's +1 on all four draws (11 vs 12) cannot pass",
+                15, lastTotalWeaponDestiny(scn));
+        assertTrue(executor.isHit());
+    }
+
+    @Test
+    public void FalconCecKarieRogueGunnerQuadLaserEachBonusesRequiredVsVictoryClass() {
+        // CEC +2 each on Quad Laser Cannon, Karie +1 each aboard, Rogue Gunner +1 each as passenger.
+        // Vs capital: Quad Laser's +1 vs starfighter does not apply. Printed 2: 2+2+1+1=6 vs VSD 5 hit.
+        // Missing Karie or Rogue Gunner: 5 vs 5 miss. Missing CEC: 4 vs 5 miss.
+        var scn = GetScenario();
+        var qlc = scn.GetLSCard("qlc");
+        var vsd = scn.GetDSCard("vsd");
+        setupFalconCec(scn, false);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
+
+        assertTrue(scn.LSCardActionAvailable(qlc, "Fire"));
+        scn.LSUseCardAction(qlc, "Fire");
+        fireOneShot(scn, vsd, 2);
+
+        assertEquals(5, scn.GetDefense(vsd));
+        assertWeaponDestinyDrawValues(scn, 6);
+        assertEquals(6, lastTotalWeaponDestiny(scn));
+        assertTrue("CEC, Karie, and Rogue Gunner each-draw bonuses are all required to hit VSD", vsd.isHit());
+    }
+
+    @Test
+    public void FalconCecKarieRogueGunnerTargetingComputerSeparatelyEachBonusesRequiredVsVictoryClass() {
+        // TC -1 each. Printed 3: 3+2+1+1-1=6 vs VSD 5 hit. Missing a +1 character: 5 vs 5 miss.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var vsd = scn.GetDSCard("vsd");
+        setupFalconCec(scn, true);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseSeparatelyOrCombined(scn, "Separately");
+        fireOneShot(scn, vsd, 3);
+
+        assertWeaponDestinyDrawValues(scn, 6);
+        assertEquals(6, lastTotalWeaponDestiny(scn));
+        assertTrue(vsd.isHit());
+    }
+
+    @Test
+    public void FalconCecKarieRogueGunnerTargetingComputerCombinedEachBonusesRequiredVsVictoryClass() {
+        // Combined two draws, then Quad Laser total +1 vs starfighter does not apply vs capital.
+        // Printed 0 and 0 with TC -1: each 0+2+1+1-1=3, combined 6 vs 5 hit.
+        // Missing a +1 character: 2+2=4 vs 5 miss.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var vsd = scn.GetDSCard("vsd");
+        setupFalconCec(scn, true);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseSeparatelyOrCombined(scn, "Combined");
+        fireOneShot(scn, vsd, 0);
+        assertFalse("First combined Quad Laser firing must not resolve a hit by itself", vsd.isHit());
+        fireOneShot(scn, vsd, 0);
+
+        assertWeaponDestinyDrawValues(scn, 3, 3);
+        assertEquals(6, lastTotalWeaponDestiny(scn));
+        assertTrue(vsd.isHit());
+    }
+
+    @Test
+    public void TenNumbBlueSquadron5ConcussionMissilesTotalBonusRequiredVsTie() {
+        // Blue Squadron 5 +2 each draw. Ten Numb +2 total on a B-wing he pilots. Missiles +1 total vs starfighter.
+        // One draw: EACH vs TOTAL look the same. Printed 0 as 2, total 0+2+2+1=5 vs TIE 3 hit.
+        // Without Ten Numb: 3 vs 3 miss.
+        var scn = GetScenario();
+        var missiles = scn.GetLSCard("missiles");
+        var tie = scn.GetDSCard("tie");
+        setupTenNumbBlue5(scn, false);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
+
+        assertTrue(scn.LSCardActionAvailable(missiles, "Fire"));
+        scn.LSUseCardAction(missiles, "Fire");
+        fireOneShot(scn, tie, 0);
+
+        assertEquals(3, scn.GetDefense(tie));
+        assertWeaponDestinyDrawValues(scn, 2);
+        assertEquals("total 5 so Ten Numb's +2 is required (3 vs 3 miss)", 5, lastTotalWeaponDestiny(scn));
+        assertTrue(tie.isHit());
+    }
+
+    @Test
+    public void TenNumbBlueSquadron5TargetingComputerSeparatelyTotalBonusRequiredVsTie() {
+        // TC -1 each. Printed 0 as 1, then Ten Numb +2 total and missiles +1 total: 1+2+1=4 vs TIE 3 hit.
+        // Without Ten Numb: 2 vs 3 miss. One draw still cannot tell EACH from TOTAL.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var tie = scn.GetDSCard("tie");
+        setupTenNumbBlue5(scn, true);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseSeparatelyOrCombined(scn, "Separately");
+        fireOneShot(scn, tie, 0);
+
+        assertWeaponDestinyDrawValues(scn, 1);
+        assertEquals(4, lastTotalWeaponDestiny(scn));
+        assertTrue(tie.isHit());
+    }
+
+    @Test
+    public void TenNumbBlueSquadron5TargetingComputerCombinedAppliesTotalOnceNotPerDraw() {
+        // Combined is the EACH vs TOTAL distinguisher.
+        // Printed 0 and 0: each draw 0+2 Blue -1 TC = 1 (Ten Numb must NOT be on the draw).
+        // Combined 1+1=2, then Ten Numb +2 total once and missiles +1 once = 5 vs TIE 3 hit.
+        // If Ten Numb were wrongly each-draw, draws would log as 3 and 3 and the total would be 7.
+        // Without Ten Numb: 3 vs 3 miss.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var tie = scn.GetDSCard("tie");
+        setupTenNumbBlue5(scn, true);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseSeparatelyOrCombined(scn, "Combined");
+        fireOneShot(scn, tie, 0);
+        assertFalse("First combined Concussion Missiles firing must not resolve a hit by itself", tie.isHit());
+        fireOneShot(scn, tie, 0);
+
+        assertWeaponDestinyDrawValues(scn, 1, 1);
+        assertEquals("total 5 means Ten Numb +2 applied once; EACH would log 3+3 and total 7",
+                5, lastTotalWeaponDestiny(scn));
+        assertTrue(tie.isHit());
+    }
+
     private void setupRed7(VirtualTableScenario scn, boolean includeKarie) {
         scn.StartGame();
         var system = scn.GetLSStartingLocation();
@@ -637,6 +857,59 @@ public class Card_1_39_Tests {
         var tie2 = scn.GetDSCard("tie2");
         scn.MoveCardsToLocation(system, ywing, stalker, tie, tie2);
         scn.AttachCardsTo(ywing, sw4, tc);
+    }
+
+
+    private void setupDefianceGunners(VirtualTableScenario scn, boolean withTc) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var defiance = scn.GetLSCard("defiance");
+        var htb = scn.GetLSCard("htb");
+        var executor = scn.GetDSCard("executor");
+        scn.MoveCardsToLocation(system, defiance, executor);
+        scn.BoardAsPassenger(defiance, scn.GetLSCard("dack"), scn.GetLSCard("verrack"));
+        if (withTc) {
+            scn.AttachCardsTo(defiance, htb, scn.GetLSCard("tc"));
+        }
+        else {
+            scn.AttachCardsTo(defiance, htb);
+        }
+    }
+
+    private void setupFalconCec(VirtualTableScenario scn, boolean withTc) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var falcon = scn.GetLSCard("falcon");
+        var qlc = scn.GetLSCard("qlc");
+        var vsd = scn.GetDSCard("vsd");
+        var corellia = scn.GetLSCard("corellia");
+        scn.MoveLocationToTable(corellia);
+        scn.AttachCardsTo(corellia, scn.GetLSCard("cec"));
+        scn.MoveCardsToLocation(system, falcon, vsd);
+        scn.BoardAsPilot(falcon, scn.GetLSCard("karie"));
+        scn.BoardAsPassenger(falcon, scn.GetLSCard("gunner"));
+        if (withTc) {
+            scn.AttachCardsTo(falcon, qlc, scn.GetLSCard("tc"));
+        }
+        else {
+            scn.AttachCardsTo(falcon, qlc);
+        }
+    }
+
+    private void setupTenNumbBlue5(VirtualTableScenario scn, boolean withTc) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var blue5 = scn.GetLSCard("blue5");
+        var missiles = scn.GetLSCard("missiles");
+        var tie = scn.GetDSCard("tie");
+        scn.MoveCardsToLocation(system, blue5, tie);
+        scn.BoardAsPilot(blue5, scn.GetLSCard("tennumb"));
+        if (withTc) {
+            scn.AttachCardsTo(blue5, missiles, scn.GetLSCard("tc"));
+        }
+        else {
+            scn.AttachCardsTo(blue5, missiles);
+        }
     }
 
     private void setupDefiance(VirtualTableScenario scn, boolean withTc) {

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
@@ -1,6 +1,7 @@
 package com.gempukku.swccgo.cards.set1.light;
 
 import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.IonizationType;
 import com.gempukku.swccgo.common.Phase;
 import com.gempukku.swccgo.common.Rarity;
 import com.gempukku.swccgo.common.Side;
@@ -26,6 +27,11 @@ public class Card_1_39_Tests {
                     put("pilot", "1_27");
                     put("red7", "7_146");
                     put("xwing", "1_146");
+                    put("ywing", "1_147");
+                    put("xwlc", "7_162");
+                    put("sw4", "2_081");
+                    put("homeone", "9_74");
+                    put("htb", "9_89");
                     put("ept", "9_88");
                 }},
                 new HashMap<>()
@@ -247,6 +253,218 @@ public class Card_1_39_Tests {
         assertTrue(stalker.isHit());
     }
 
+
+    @Test
+    public void TargetingComputerFiresXwingLaserCannonTwiceSeparately() {
+        // 7_162 X-wing Laser Cannon: may use X=0..3 Force; destiny + X > DV to hit.
+        // With X=0 vs TIE maneuver 3: dest 5, TC -1 => 4 > 3 hit. Retarget second TIE.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var xwlc = scn.GetLSCard("xwlc");
+        var tie = scn.GetDSCard("tie");
+        var tie2 = scn.GetDSCard("tie2");
+        setupXwingLaser(scn);
+
+        startWeaponsSegment(scn);
+
+        assertTrue(scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseWeaponIfPrompted(scn, xwlc);
+        scn.LSChoose("Separately");
+
+        fireOneShot(scn, tie, 5, 0);
+        assertTrue(tie.isHit());
+        assertFalse(tie2.isHit());
+
+        fireOneShot(scn, tie2, 5, 0);
+        assertTrue(tie2.isHit());
+    }
+
+    @Test
+    public void TargetingComputerFiresXwingLaserCannonTwiceCombined() {
+        // Combined X=0: first dest 4 is (4-1)=3 stored, not yet a hit vs TIE 3.
+        // Second dest 4: (4-1)=3. Combined 6 vs 3 hits the single target.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var xwlc = scn.GetLSCard("xwlc");
+        var tie = scn.GetDSCard("tie");
+        setupXwingLaser(scn);
+
+        startWeaponsSegment(scn);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseWeaponIfPrompted(scn, xwlc);
+        scn.LSChoose("Combined");
+
+        fireOneShot(scn, tie, 4, 0);
+        assertFalse("First combined X-wing Laser Cannon shot must not resolve a hit by itself", tie.isHit());
+
+        fireOneShot(scn, tie, 4, 0);
+        assertTrue(tie.isHit());
+    }
+
+    @Test
+    public void TargetingComputerFiresSw4IonCannonTwiceSeparatelyAndIonizes() {
+        // 2_081 SW-4 Ion Cannon (LS ion cannon; Premiere 1_318 is DS Star Destroyer only).
+        // Cost 1 Force. Destiny > DV ionizes (armor/maneuver=0, hyperspeed=0); does not "hit".
+        // dest 5, TC -1 => 4 > TIE 3 ionize.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var sw4 = scn.GetLSCard("sw4");
+        var tie = scn.GetDSCard("tie");
+        var tie2 = scn.GetDSCard("tie2");
+        setupYwingIon(scn);
+
+        startWeaponsSegment(scn);
+
+        int forceBefore = scn.GetLSForcePileCount();
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseWeaponIfPrompted(scn, sw4);
+        scn.LSChoose("Separately");
+
+        fireOneShot(scn, tie, 5);
+        assertTrue(isIonized(tie));
+        assertFalse(tie.isHit());
+        assertFalse(isIonized(tie2));
+
+        fireOneShot(scn, tie2, 5);
+        assertTrue(isIonized(tie2));
+        assertFalse(tie2.isHit());
+        assertEquals(forceBefore - 2, scn.GetLSForcePileCount());
+    }
+
+    @Test
+    public void TargetingComputerFiresSw4IonCannonTwiceCombinedAndIonizes() {
+        // Combined: dest 4 then 4. Each firing (4-1)=3. Combined 6 > TIE 3 ionizes; not a hit.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var sw4 = scn.GetLSCard("sw4");
+        var tie = scn.GetDSCard("tie");
+        setupYwingIon(scn);
+
+        startWeaponsSegment(scn);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseWeaponIfPrompted(scn, sw4);
+        scn.LSChoose("Combined");
+
+        fireOneShot(scn, tie, 4);
+        assertFalse(isIonized(tie));
+        assertFalse(tie.isHit());
+
+        fireOneShot(scn, tie, 4);
+        assertTrue(isIonized(tie));
+        assertFalse("Ion Cannon must ionize, not hit", tie.isHit());
+    }
+
+    @Test
+    public void TargetingComputerSeparatelySkipsUnpaidSecondShotWithoutRewindingFirst() {
+        // Appendix B option A: SW-4 costs 1 Force per shot. With 1 Force remaining,
+        // shot 1 pays and ionizes; shot 2 does not initiate; TC is still used.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var sw4 = scn.GetLSCard("sw4");
+        var tie = scn.GetDSCard("tie");
+        var tie2 = scn.GetDSCard("tie2");
+        setupYwingIon(scn);
+
+        startWeaponsSegment(scn);
+        drainLSForcePileTo(scn, 1);
+        assertEquals(1, scn.GetLSForcePileCount());
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseWeaponIfPrompted(scn, sw4);
+        scn.LSChoose("Separately");
+
+        fireOneShot(scn, tie, 5);
+        assertTrue(isIonized(tie));
+        assertFalse(tie.isHit());
+        assertFalse(isIonized(tie2));
+        assertEquals(0, scn.GetLSForcePileCount());
+
+        passOptionalResponses(scn);
+        if (scn.AwaitingLSWeaponsSegmentActions()) {
+            assertFalse(scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
+        }
+        else {
+            assertTrue(scn.AwaitingDSWeaponsSegmentActions() || scn.GetCurrentDecision() != null);
+        }
+        assertFalse("Second TIE must not be ionized when shot 2 cannot pay", isIonized(tie2));
+    }
+
+    @Test
+    public void TargetingComputerCombinedAppliesCompletedFiringsWhenSecondShotCannotPay() {
+        // Appendix B option A combined: dest 5 stored as (5-1)=4, shot 2 cannot pay.
+        // Combined total of completed firings 4 > TIE 3 still ionizes. Action does not fully fail.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var sw4 = scn.GetLSCard("sw4");
+        var tie = scn.GetDSCard("tie");
+        setupYwingIon(scn);
+
+        startWeaponsSegment(scn);
+        drainLSForcePileTo(scn, 1);
+        assertEquals(1, scn.GetLSForcePileCount());
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseWeaponIfPrompted(scn, sw4);
+        scn.LSChoose("Combined");
+
+        fireOneShot(scn, tie, 5);
+        passOptionalResponses(scn);
+
+        assertTrue("Completed combined firing must still apply vs the target", isIonized(tie));
+        assertFalse(tie.isHit());
+        assertEquals(0, scn.GetLSForcePileCount());
+        if (scn.AwaitingLSWeaponsSegmentActions()) {
+            assertFalse(scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
+        }
+    }
+
+    @Test
+    public void TargetingComputerFiresHeavyTurbolaserFromHomeOneSeparately() {
+        // Capital setup (AR example 2 structure): Home One 9_74 + Heavy Turbolaser Battery 9_89.
+        // HTB uses 2 Force, draws 2 destiny, total -1 vs capital. dest 7,7: (7-1)+(7-1)=12, then -1 = 11 vs Stalker 7 hit.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var htb = scn.GetLSCard("htb");
+        var stalker = scn.GetDSCard("stalker");
+        setupHomeOne(scn);
+
+        startWeaponsSegment(scn);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseWeaponIfPrompted(scn, htb);
+        scn.LSChoose("Separately");
+
+        fireTwoDestinyShot(scn, stalker, 7, 7);
+        assertTrue(stalker.isHit());
+    }
+
+    @Test
+    public void TargetingComputerFiresHeavyTurbolaserFromHomeOneCombined() {
+        // Combined HTB vs Stalker: each firing is one weapon destiny (sum of two TC-modified draws).
+        // dest 4,4 => (4-1)+(4-1)=6 stored, not a hit yet. Second firing 4,4 => 6. Combined 12, total -1 = 11 vs 7 hit.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var htb = scn.GetLSCard("htb");
+        var stalker = scn.GetDSCard("stalker");
+        setupHomeOne(scn);
+
+        startWeaponsSegment(scn);
+        ensureLSForcePile(scn, 4);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseWeaponIfPrompted(scn, htb);
+        scn.LSChoose("Combined");
+
+        fireTwoDestinyShot(scn, stalker, 4, 4);
+        assertFalse("First combined HTB firing must not resolve a hit by itself", stalker.isHit());
+
+        fireTwoDestinyShot(scn, stalker, 4, 4);
+        assertTrue(stalker.isHit());
+    }
+
     private void setupRed7(VirtualTableScenario scn, boolean includeKarie) {
         scn.StartGame();
         var system = scn.GetLSStartingLocation();
@@ -294,20 +512,121 @@ public class Card_1_39_Tests {
         }
     }
 
+    private void setupXwingLaser(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var xwing = scn.GetLSCard("xwing");
+        var xwlc = scn.GetLSCard("xwlc");
+        var tc = scn.GetLSCard("tc");
+        var stalker = scn.GetDSCard("stalker");
+        var tie = scn.GetDSCard("tie");
+        var tie2 = scn.GetDSCard("tie2");
+        scn.MoveCardsToLocation(system, xwing, stalker, tie, tie2);
+        scn.AttachCardsTo(xwing, xwlc, tc);
+    }
+
+    private void setupYwingIon(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var ywing = scn.GetLSCard("ywing");
+        var sw4 = scn.GetLSCard("sw4");
+        var tc = scn.GetLSCard("tc");
+        var stalker = scn.GetDSCard("stalker");
+        var tie = scn.GetDSCard("tie");
+        var tie2 = scn.GetDSCard("tie2");
+        scn.MoveCardsToLocation(system, ywing, stalker, tie, tie2);
+        scn.AttachCardsTo(ywing, sw4, tc);
+    }
+
+    private void setupHomeOne(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var homeone = scn.GetLSCard("homeone");
+        var htb = scn.GetLSCard("htb");
+        var tc = scn.GetLSCard("tc");
+        var stalker = scn.GetDSCard("stalker");
+        var tie = scn.GetDSCard("tie");
+        scn.MoveCardsToLocation(system, homeone, stalker, tie);
+        scn.AttachCardsTo(homeone, htb, tc);
+    }
+
     private void fireOneShot(VirtualTableScenario scn, PhysicalCardImpl target, int destiny) {
+        fireOneShot(scn, target, destiny, null);
+    }
+
+    private void fireOneShot(VirtualTableScenario scn, PhysicalCardImpl target, int destiny, Integer forceToUse) {
         // Combined second shots auto-target and may already be at Force/Fire responses.
         // Prepare destiny before passing those responses so the next draw is stubbed.
         if (scn.LSGetDecision() != null && scn.LSHasCardChoiceAvailable(target)) {
             scn.LSChooseCard(target);
         }
+        chooseForceAmountIfPrompted(scn, forceToUse);
         scn.PrepareLSDestiny(destiny);
         scn.PassForceUseResponses();
         scn.PassWeaponFireWithDestinyDraw();
+        passPostFiringResponses(scn);
+    }
+
+    private void fireTwoDestinyShot(VirtualTableScenario scn, PhysicalCardImpl target, int destiny1, int destiny2) {
+        if (scn.LSGetDecision() != null && scn.LSHasCardChoiceAvailable(target)) {
+            scn.LSChooseCard(target);
+        }
+        chooseForceAmountIfPrompted(scn, null);
+        scn.PassForceUseResponses();
+        // Prepare first draw before Fire responses (combined shot 2 may already be in that window).
+        // Prepare each subsequent draw immediately before it so the same destiny value can be reused
+        // (LS destiny pack has only one card per 0-7).
+        scn.PrepareLSDestiny(destiny1);
+        scn.PassResponses("Fire ");
+        scn.PassDestinyDrawResponses();
+        scn.PrepareLSDestiny(destiny2);
+        scn.PassDestinyDrawResponses();
+        scn.PassResponses("ABOUT_TO_BE_HIT");
+        scn.PassResponses("HIT -");
+        scn.PassResponses("FIRED_WEAPON");
+        passPostFiringResponses(scn);
+    }
+
+    private void chooseForceAmountIfPrompted(VirtualTableScenario scn, Integer forceToUse) {
+        if (scn.LSGetDecision() == null || scn.LSGetDecision().getText() == null) {
+            return;
+        }
+        String text = scn.LSGetDecision().getText().toLowerCase();
+        if (!(text.contains("amount") || text.contains("how much") || text.contains("force to use") || text.contains("x ="))) {
+            return;
+        }
+        int amount = forceToUse != null ? forceToUse : scn.LSGetChoiceMin();
+        scn.LSDecided(amount);
+    }
+
+    private void ensureLSForcePile(VirtualTableScenario scn, int min) {
+        while (scn.GetLSForcePileCount() < min && scn.GetLSReserveDeckCount() > 2) {
+            scn.MoveCardsToTopOfLSForcePile(scn.GetTopOfLSReserveDeck());
+        }
+    }
+
+    private void drainLSForcePileTo(VirtualTableScenario scn, int remaining) {
+        while (scn.GetLSForcePileCount() > remaining) {
+            scn.MoveCardsToHand(scn.GetTopOfLSForcePile());
+        }
+    }
+
+    private boolean isIonized(PhysicalCardImpl card) {
+        return card.getIonization() != null
+                && (card.getIonization().contains(IonizationType.DEFENSE_IONIZED)
+                || card.getIonization().contains(IonizationType.HYPERSPEED_IONIZED));
     }
 
     private void passOptionalResponses(VirtualTableScenario scn) {
         if (scn.GetCurrentDecision() != null) {
             scn.PassAllResponses();
         }
+    }
+
+    private void passPostFiringResponses(VirtualTableScenario scn) {
+        // Ion Cannon resets attributes then ionizes; do not PassAllResponses or combined shot 2's Fire window is consumed.
+        scn.PassResponses("ATTRIBUTE_RESET_OR_MODIFIED");
+        scn.PassResponses("Ionized");
+        scn.PassResponses("FIRED_WEAPON");
     }
 }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
@@ -1,6 +1,8 @@
 package com.gempukku.swccgo.cards.set1.light;
 
 import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.ExpansionSet;
 import com.gempukku.swccgo.common.Phase;
 import com.gempukku.swccgo.common.Rarity;
 import com.gempukku.swccgo.common.Side;
@@ -104,8 +106,16 @@ public class Card_1_39_Tests {
         assertEquals("Targeting Computer", card.getTitle());
         assertEquals(Uniqueness.UNRESTRICTED, card.getUniqueness());
         assertEquals(Side.LIGHT, card.getSide());
-        assertTrue(card.isCardType(CardType.DEVICE));
+        scn.BlueprintCardTypeCheck(card, new ArrayList<>() {{
+            add(CardType.DEVICE);
+        }});
         assertEquals(3, card.getDestiny(), scn.epsilon);
+        scn.BlueprintIconCheck(card, new ArrayList<>() {{
+            add(Icon.DEVICE);
+        }});
+        scn.BlueprintKeywordCheck(card, new ArrayList<>() {{
+        }});
+        assertEquals(ExpansionSet.PREMIERE, card.getExpansionSet());
         assertEquals(Rarity.U1, card.getRarity());
     }
 
@@ -513,7 +523,7 @@ public class Card_1_39_Tests {
     }
 
     @Test
-    public void DefianceHeavyTurbolaserVsVictoryClassAddsTwoToEachDraw() {
+    public void TargetingComputerDoesNotAffectUnattachedHeavyTurbolaserVsVictoryClass() {
         // HTB draws two destinies vs VSD (capital): HTB -1 total, not -6 vs starfighter. No Targeting Computer.
         // Printed destinies 2 and 2. No bonus: 2+2-1=3 vs armor 5 miss.
         // +1 each would be (2+1)+(2+1)-1=5 vs 5 miss (equal fails).
@@ -539,7 +549,7 @@ public class Card_1_39_Tests {
     }
 
     @Test
-    public void DefianceTargetingComputerCombinedAppliesMinusOneAndPlusTwoPerDraw() {
+    public void TargetingComputerCombinedAppliesMinusOneAndPlusTwoPerDrawOnCapital() {
         // TC -1 and Defiance +2 per draw (net +1 vs printed). HTB two draws per firing.
         // Printed 2,2 then 2,2: each firing (2-1+2)*2=6. Combined 12, HTB -1 vs capital = 11 vs VSD 5 hit.
         // Without Defiance +2: (2-1)*2 per firing, combined 4, -1 = 3 vs 5 miss.
@@ -596,7 +606,7 @@ public class Card_1_39_Tests {
 
 
     @Test
-    public void DefianceDackVerrackHeavyTurbolaserEachBonusesRequiredVsExecutor() {
+    public void TargetingComputerNotRequiredForIndependentHeavyTurbolaserBonuses() {
         // Dack passenger +1 each, Verrack aboard +2 each vs capital, Defiance +2 each, HTB -1 total vs capital.
         // Printed 2 and 2: each draw 2+2+1+2=7, total 14-1=13 vs Executor armor 12 hit.
         // Missing Dack: 12-1=11 vs 12 miss. Missing Verrack or Defiance is even lower.
@@ -646,7 +656,7 @@ public class Card_1_39_Tests {
     }
 
     @Test
-    public void DefianceDackVerrackTargetingComputerSeparatelyEachBonusesRequiredVsExecutor() {
+    public void TargetingComputerSeparatelyAppliesEachBonusesRequiredVsExecutor() {
         // TC -1 each. Printed 3 and 3: each draw 3+2+1+2-1=7, total 14-1=13 vs 12 hit.
         // Missing Dack: 11 vs 12 miss.
         var scn = GetScenario();
@@ -667,7 +677,7 @@ public class Card_1_39_Tests {
     }
 
     @Test
-    public void DefianceKarieDackVerrackTargetingComputerSeparatelyDrawsAreEightNotNineVsExecutor() {
+    public void TargetingComputerSeparatelyDrawTotalsAccountForGunnerAndPilot() {
         // Playtest: Targeting Computer fires Heavy Turbolaser Battery twice separately at Executor.
         // Defiance +2 each (FiredBy), Karie Neth +1, Dack Ralter +1, Captain Verrack +2 vs capital = +6.
         // Targeting Computer -1 each while using Fire a weapon twice. Printed 3 and 3 must be 8 and 8, not 9 and 9.
@@ -723,7 +733,7 @@ public class Card_1_39_Tests {
     }
 
     @Test
-    public void DefianceDackVerrackTargetingComputerCombinedEachBonusesRequiredVsExecutor() {
+    public void TargetingComputerCombinedAppliesEachBonusesRequiredVsExecutor() {
         // Combined HTB: two draws per firing, twice, then HTB -1 once.
         // Printed 0 x4 with TC -1: each draw 0+2+1+2-1=4, combined 16-1=15 vs 12 hit.
         // Missing Dack: 12-1=11 vs 12 miss.
@@ -748,7 +758,7 @@ public class Card_1_39_Tests {
     }
 
     @Test
-    public void FalconCecKarieRogueGunnerQuadLaserEachBonusesRequiredVsVictoryClass() {
+    public void TargetingComputerNotRequiredForIndependentQuadLaserBonuses() {
         // CEC +2 each on Quad Laser Cannon, Karie +1 each aboard, Rogue Gunner +1 each as passenger.
         // Vs capital: Quad Laser's +1 vs starfighter does not apply. Printed 2: 2+2+1+1=6 vs VSD 5 hit.
         // Missing Karie or Rogue Gunner: 5 vs 5 miss. Missing CEC: 4 vs 5 miss.
@@ -771,7 +781,7 @@ public class Card_1_39_Tests {
     }
 
     @Test
-    public void FalconCecKarieRogueGunnerTargetingComputerSeparatelyEachBonusesRequiredVsVictoryClass() {
+    public void TargetingComputerSeparatelyAppliesQuadLaserBonusesVsVictoryClass() {
         // TC -1 each. Printed 3: 3+2+1+1-1=6 vs VSD 5 hit. Missing a +1 character: 5 vs 5 miss.
         var scn = GetScenario();
         var tc = scn.GetLSCard("tc");
@@ -791,7 +801,7 @@ public class Card_1_39_Tests {
     }
 
     @Test
-    public void FalconCecKarieRogueGunnerTargetingComputerCombinedEachBonusesRequiredVsVictoryClass() {
+    public void TargetingComputerCombinedAppliesQuadLaserBonusesVsVictoryClass() {
         // Combined two draws, then Quad Laser total +1 vs starfighter does not apply vs capital.
         // Printed 0 and 0 with TC -1: each 0+2+1+1-1=3, combined 6 vs 5 hit.
         // Missing a +1 character: 2+2=4 vs 5 miss.
@@ -815,7 +825,7 @@ public class Card_1_39_Tests {
     }
 
     @Test
-    public void TenNumbBlueSquadron5ConcussionMissilesTotalBonusRequiredVsTie() {
+    public void TargetingComputerNotRequiredForIndependentConcussionMissileBonus() {
         // Blue Squadron 5 +2 each draw. Ten Numb +2 total on a B-wing he pilots. Missiles +1 total vs starfighter.
         // One draw: EACH vs TOTAL look the same. Printed 0 as 2, total 0+2+2+1=5 vs TIE 3 hit.
         // Without Ten Numb: 3 vs 3 miss.
@@ -838,7 +848,7 @@ public class Card_1_39_Tests {
     }
 
     @Test
-    public void TenNumbBlueSquadron5TargetingComputerSeparatelyTotalBonusRequiredVsTie() {
+    public void TargetingComputerSeparatelyAppliesConcussionMissileTotalBonus() {
         // TC -1 each. Printed 0 as 1, then Ten Numb +2 total and missiles +1 total: 1+2+1=4 vs TIE 3 hit.
         // Without Ten Numb: 2 vs 3 miss. One draw still cannot tell EACH from TOTAL.
         var scn = GetScenario();
@@ -859,7 +869,7 @@ public class Card_1_39_Tests {
     }
 
     @Test
-    public void TenNumbBlueSquadron5TargetingComputerCombinedAppliesTotalOnceNotPerDraw() {
+    public void TargetingComputerCombinedAppliesConcussionMissileTotalOnceNotPerDraw() {
         // Combined is the EACH vs TOTAL distinguisher.
         // Printed 0 and 0: each draw 0+2 Blue -1 TC = 1 (Ten Numb must NOT be on the draw).
         // Combined 1+1=2, then Ten Numb +2 total once and missiles +1 once = 5 vs TIE 3 hit.
@@ -909,12 +919,12 @@ public class Card_1_39_Tests {
         // into the Force Pile so four Targeting Computers (2 Force each) can deploy.
         scn.SkipToLSTurn(Phase.DEPLOY);
         scn.EnsureLSForcePile(8);
-        assertTrue("Expected Light Side deploy actions, got: " + decisionDump(scn),
+        assertTrue("Expected Light Side deploy actions, got: " ,
                 scn.AwaitingLSDeployPhaseActions());
 
         PhysicalCardImpl[] computers = { tc, tc2, tc3, tc4 };
         for (PhysicalCardImpl computer : computers) {
-            assertTrue("Targeting Computer must be deployable on the B-wing. " + decisionDump(scn),
+            assertTrue("Targeting Computer must be deployable on the B-wing. " ,
                     scn.LSGetDecision() != null && scn.LSDeployAvailable(computer));
             scn.LSDeployCard(computer);
             if (scn.LSGetDecision() != null && scn.LSHasCardChoiceAvailable(bwing)) {
@@ -967,16 +977,16 @@ public class Card_1_39_Tests {
         passDarkSideWeaponsIfNeeded(scn);
 
         assertTrue("B-wing still has unused SW-4 Ion Cannons, so Light Side stays in weapons segment. "
-                        + decisionDump(scn),
+                        ,
                 scn.AwaitingLSWeaponsSegmentActions());
-        assertFalse("That Targeting Computer copy cannot be used again this turn. " + decisionDump(scn),
+        assertFalse("That Targeting Computer copy cannot be used again this turn. " ,
                 fireTwiceAvailable(scn, tc));
-        assertFalse("Starfighter may use only one device per turn. " + decisionDump(scn),
+        assertFalse("Starfighter may use only one device per turn. " ,
                 fireTwiceAvailable(scn, tc2));
         assertFalse("Starfighter may use only one device per turn", fireTwiceAvailable(scn, tc3));
         assertFalse("Starfighter may use only one device per turn", fireTwiceAvailable(scn, tc4));
         assertTrue("Leftover SW-4 Ion Cannon can still Fire (device limit is not a weapon limit). "
-                        + decisionDump(scn),
+                        ,
                 scn.LSCardActionAvailable(sw42, "Fire"));
         assertEquals("After using one Targeting Computer, maneuver is still +1, not +4 and not lost",
                 3, scn.GetManeuver(bwing));
@@ -1010,7 +1020,7 @@ public class Card_1_39_Tests {
         fireOneShot(scn, tie, 1, 0);
         fireOneShot(scn, tie, 1, 0);
         passDarkSideWeaponsIfNeeded(scn);
-        assertTrue("Squadron may use a second Targeting Computer this turn. " + decisionDump(scn),
+        assertTrue("Squadron may use a second Targeting Computer this turn. " ,
                 fireTwiceAvailable(scn, tc2));
         assertFalse("The Targeting Computer copy already used cannot Fire a weapon twice again this turn",
                 fireTwiceAvailable(scn, tc));
@@ -1019,7 +1029,7 @@ public class Card_1_39_Tests {
         fireOneShot(scn, tie, 1, 0);
         fireOneShot(scn, tie, 1, 0);
         passDarkSideWeaponsIfNeeded(scn);
-        assertTrue("Squadron may use a third Targeting Computer this turn. " + decisionDump(scn),
+        assertTrue("Squadron may use a third Targeting Computer this turn. " ,
                 fireTwiceAvailable(scn, tc3));
 
         useFireAWeaponTwice(scn, tc3, xwlc3, "Separately");
@@ -1028,11 +1038,11 @@ public class Card_1_39_Tests {
         passDarkSideWeaponsIfNeeded(scn);
 
         if (scn.AwaitingLSWeaponsSegmentActions()) {
-            assertFalse("Squadron may use only three devices per turn. " + decisionDump(scn),
+            assertFalse("Squadron may use only three devices per turn. " ,
                     fireTwiceAvailable(scn, tc4));
         }
         else {
-            assertTrue("Expected weapons segment after three Targeting Computer uses. " + decisionDump(scn),
+            assertTrue("Expected weapons segment after three Targeting Computer uses. " ,
                     scn.AwaitingDSWeaponsSegmentActions());
         }
     }
@@ -1060,14 +1070,14 @@ public class Card_1_39_Tests {
         PhysicalCardImpl[] batteries = { htb, htb2, htb3, htb4 };
         for (int i = 0; i < computers.length; i++) {
             assertTrue("Capital may use Targeting Computer copy " + (i + 1) + " this turn. "
-                            + decisionDump(scn),
+                            ,
                     fireTwiceAvailable(scn, computers[i]));
             useFireAWeaponTwice(scn, computers[i], batteries[i], "Separately");
             fireTwoDestinyShot(scn, stalker, 1, 1);
             fireTwoDestinyShot(scn, stalker, 1, 1);
             passDarkSideWeaponsIfNeeded(scn);
             assertFalse("Used Targeting Computer copy " + (i + 1) + " cannot Fire a weapon twice again this turn. "
-                            + decisionDump(scn),
+                            ,
                     fireTwiceAvailable(scn, computers[i]));
         }
     }
@@ -1096,11 +1106,11 @@ public class Card_1_39_Tests {
         fireTwoDestinyShot(scn, stalker, 1, 1);
         passDarkSideWeaponsIfNeeded(scn);
 
-        assertTrue("After using copy A, Light Side should still have weapons actions. " + decisionDump(scn),
+        assertTrue("After using copy A, Light Side should still have weapons actions. " ,
                 scn.AwaitingLSWeaponsSegmentActions());
-        assertFalse("Copy A cannot Fire a weapon twice again this turn. " + decisionDump(scn),
+        assertFalse("Copy A cannot Fire a weapon twice again this turn. " ,
                 fireTwiceAvailable(scn, tc));
-        assertTrue("Using copy A does not prevent using copy B this turn. " + decisionDump(scn),
+        assertTrue("Using copy A does not prevent using copy B this turn. " ,
                 fireTwiceAvailable(scn, tc2));
         assertTrue("Copy C is still available this turn", fireTwiceAvailable(scn, tc3));
         assertTrue("Copy D is still available this turn", fireTwiceAvailable(scn, tc4));
@@ -1161,13 +1171,13 @@ public class Card_1_39_Tests {
      */
     private void useFireAWeaponTwice(VirtualTableScenario scn, PhysicalCardImpl targetingComputer,
                                      PhysicalCardImpl weapon, String mode) {
-        assertTrue("Fire a weapon twice must be available on that Targeting Computer. " + decisionDump(scn),
+        assertTrue("Fire a weapon twice must be available on that Targeting Computer. " ,
                 fireTwiceAvailable(scn, targetingComputer));
         scn.LSUseCardAction(targetingComputer, "Fire a weapon twice");
         if (scn.LSGetDecision() != null && scn.LSDecisionAvailable("Choose weapon")) {
             scn.LSChooseCard(weapon);
         }
-        assertTrue("Expected Fire a weapon twice prompt, got: " + decisionDump(scn),
+        assertTrue("Expected Fire a weapon twice prompt, got: " ,
                 scn.LSGetDecision() != null && scn.LSDecisionAvailable("Fire a weapon twice"));
         assertTrue(scn.LSChoiceAvailable("Separately"));
         assertTrue(scn.LSChoiceAvailable("Combined"));
@@ -1192,33 +1202,6 @@ public class Card_1_39_Tests {
      */
     private boolean fireTwiceAvailable(VirtualTableScenario scn, PhysicalCardImpl targetingComputer) {
         return scn.LSGetDecision() != null && scn.LSCardActionAvailable(targetingComputer, "Fire a weapon twice");
-    }
-
-    /**
-     * Light Side and Dark Side current decision text plus Light Side action list, for assertion messages.
-     */
-    private String decisionDump(VirtualTableScenario scn) {
-        String ls = scn.LSGetDecision() == null ? "null" : scn.LSGetDecision().getText();
-        String ds = scn.DSGetDecision() == null ? "null" : scn.DSGetDecision().getText();
-        String actions = "n/a";
-        try {
-            if (scn.LSGetDecision() != null) {
-                actions = String.valueOf(scn.GetLSAvailableActions());
-            }
-        }
-        catch (RuntimeException ignored) {
-            actions = "(no actionText)";
-        }
-        String phase = String.valueOf(scn.gameState().getCurrentPhase());
-        String player = String.valueOf(scn.gameState().getCurrentPlayerId());
-        String soc = scn.gameState().getSeparatelyOrCombinedFiringState() == null ? "none" : "active";
-        int force = scn.GetLSForcePileCount();
-        String logTail = "";
-        java.util.List<String> msgs = scn.gameState().getLastMessages();
-        int from = Math.max(0, msgs.size() - 12);
-        logTail = String.join(" | ", msgs.subList(from, msgs.size()));
-        return "player=" + player + " phase=" + phase + " force=" + force + " soc=" + soc
-                + " LS=" + ls + " actions=" + actions + " DS=" + ds + " log=" + logTail;
     }
 
     private void setupRed7(VirtualTableScenario scn, boolean includeKarie) {

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/framework/Battles.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/framework/Battles.java
@@ -1,5 +1,6 @@
 package com.gempukku.swccgo.framework;
 
+import com.gempukku.swccgo.common.Phase;
 import com.gempukku.swccgo.common.Zone;
 import com.gempukku.swccgo.game.PhysicalCardImpl;
 
@@ -61,6 +62,59 @@ public interface Battles extends Decisions, GameProcedures, PileProperties {
         PassBattleStartResponses();
     }
 
+
+    /**
+     * Skips to the Light Side Battle phase, initiates battle at the Light Side starting location, and arrives at
+     * LS weapons segment actions.
+     */
+    default void StartBattleAndSkipToWeaponsSegment() {
+        StartBattleAndSkipToWeaponsSegment(LS, GetLSStartingLocation());
+    }
+
+    /**
+     * Skips to the Light Side Battle phase, initiates battle at the given location, and arrives at LS weapons segment actions.
+     * @param location The location to start battle at.
+     */
+    default void StartBattleAndSkipToWeaponsSegment(PhysicalCardImpl location) {
+        StartBattleAndSkipToWeaponsSegment(LS, location);
+    }
+
+    /**
+     * Skips to the given player's Battle phase, has that player initiate battle at the given location, and arrives at
+     * that player's weapons segment actions.
+     * @param player The player who should initiate.
+     * @param location The location to start battle at.
+     */
+    default void StartBattleAndSkipToWeaponsSegment(String player, PhysicalCardImpl location) {
+        if(player.equals(LS)) {
+            SkipToLSTurn(Phase.BATTLE);
+            LSInitiateBattle(location);
+            PassAllResponses();
+            assertTrue("Expected LS weapons segment actions after initiating battle", AwaitingLSWeaponsSegmentActions());
+        }
+        else {
+            SkipToDSTurn(Phase.BATTLE);
+            DSInitiateBattle(location);
+            PassAllResponses();
+            assertTrue("Expected DS weapons segment actions after initiating battle", AwaitingDSWeaponsSegmentActions());
+        }
+    }
+
+    /**
+     * Skips to the Light Side Battle phase, initiates battle at the given location, and arrives at LS weapons segment actions.
+     * @param location The location to start battle at.
+     */
+    default void LSStartBattleAndSkipToWeaponsSegment(PhysicalCardImpl location) {
+        StartBattleAndSkipToWeaponsSegment(LS, location);
+    }
+
+    /**
+     * Skips to the Dark Side Battle phase, initiates battle at the given location, and arrives at DS weapons segment actions.
+     * @param location The location to start battle at.
+     */
+    default void DSStartBattleAndSkipToWeaponsSegment(PhysicalCardImpl location) {
+        StartBattleAndSkipToWeaponsSegment(DS, location);
+    }
 
     /**
      * Right after battle has been initiated, skips to the start of the Power Segment right before the first player is

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/framework/CardProperties.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/framework/CardProperties.java
@@ -320,6 +320,14 @@ public interface CardProperties extends TestBase {
     }
 
     /**
+     * @param card The card to inspect.
+     * @return True if the card currently has any ionization type applied.
+     */
+    default boolean IsIonized(PhysicalCardImpl card) {
+        return card.getIonization() != null && !card.getIonization().isEmpty();
+    }
+
+    /**
      * Checks whether a card is wholly immune to attrition
      * @param card The card to check
      * @return True if no amount of attrition can affect this card, false otherwise.

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/framework/ZoneManipulation.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/framework/ZoneManipulation.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 
 /**
@@ -589,5 +590,61 @@ public interface ZoneManipulation extends TestBase{
 
 
 
+
+
+    /**
+     * Moves cards from the Light Side Reserve Deck onto the Force Pile until it has at least min cards.
+     * Leaves at least 2 cards in Reserve so destiny stubs remain. Fails if the pile cannot reach min.
+     * @param min Minimum Force Pile size to ensure.
+     */
+    default void EnsureLSForcePile(int min) { EnsureForcePile(LS, min); }
+
+    /**
+     * Moves cards from the Dark Side Reserve Deck onto the Force Pile until it has at least min cards.
+     * Leaves at least 2 cards in Reserve so destiny stubs remain. Fails if the pile cannot reach min.
+     * @param min Minimum Force Pile size to ensure.
+     */
+    default void EnsureDSForcePile(int min) { EnsureForcePile(DS, min); }
+
+    /**
+     * Moves cards from the given player's Reserve Deck onto their Force Pile until it has at least min cards.
+     * Leaves at least 2 cards in Reserve so destiny stubs remain. Fails if the pile cannot reach min.
+     * @param player The player whose Force Pile to fill.
+     * @param min Minimum Force Pile size to ensure.
+     */
+    default void EnsureForcePile(String player, int min) {
+        while (gameState().getForcePile(player).size() < min && gameState().getReserveDeck(player).size() > 2) {
+            MoveCardsToTopOfForcePile(player, (PhysicalCardImpl) gameState().getReserveDeck(player).getFirst());
+        }
+        assertTrue("Unable to ensure " + player + " Force Pile has at least " + min
+                + " cards (have " + gameState().getForcePile(player).size() + ")",
+                gameState().getForcePile(player).size() >= min);
+    }
+
+    /**
+     * Moves cards from the Light Side Force Pile into hand until exactly remaining cards are left in the pile.
+     * @param remaining Target Force Pile count.
+     */
+    default void DrainLSForcePileTo(int remaining) { DrainForcePileTo(LS, remaining); }
+
+    /**
+     * Moves cards from the Dark Side Force Pile into hand until exactly remaining cards are left in the pile.
+     * @param remaining Target Force Pile count.
+     */
+    default void DrainDSForcePileTo(int remaining) { DrainForcePileTo(DS, remaining); }
+
+    /**
+     * Moves cards from the given player's Force Pile into hand until exactly remaining cards are left in the pile.
+     * @param player The player whose Force Pile to drain.
+     * @param remaining Target Force Pile count.
+     */
+    default void DrainForcePileTo(String player, int remaining) {
+        while (gameState().getForcePile(player).size() > remaining) {
+            MoveCardsToHand((PhysicalCardImpl) gameState().getForcePile(player).getFirst());
+        }
+        assertTrue(player + " Force Pile should be drained to " + remaining
+                + " (have " + gameState().getForcePile(player).size() + ")",
+                gameState().getForcePile(player).size() == remaining);
+    }
 
 }


### PR DESCRIPTION
Implements Targeting Computer (`1_39`).

## Summary
Premiere Light Device: deploy for 2 Force on your starship (+1 maneuver). During battle, once per copy, fire a weapon twice as one overall action — Separately or Combined. Subtract 1 from each destiny draw only while using Fire a weapon twice.

## Card
- **Id / title:** `1_39` / Targeting Computer
- **Type:** Light Device, Premiere
- **Game text:** Use 2 Force to deploy on any of your starships. Adds 1 to maneuver. During battle, may fire one of that starship's weapons twice (as one action, separately or combined). Subtract 1 from each destiny draw while doing so.

## What changed
- Adds `Card1_039` with Separately / Combined / Don't Fire (Cancel) three-button UI
- Engine: `SeparatelyOrCombinedFiringState` plus hooks in `GameState`, `WeaponFiringState`, `DrawDestinyEffect`, and `Destiny` so combined shots skip per-firing total modifiers and resolve after both draws
- Separately: choose/resolve, then choose/resolve again (may retarget); Force paid per firing as each shot initiates
- Combined: each firing is a single weapon destiny (draw modifiers only); destinies added, then total weapon destiny modifiers once vs one target
- Once per copy per turn (not merely once per battle); usage recorded when Separately or Combined is chosen; Don't Fire leaves the copy unused
- Device-per-turn slots: starfighter 1, squadron 3, capital unlimited
- Per-turn device/weapon slot counting uses **unique** copies, so firing a weapon twice still spends one weapon slot and one device slot (a squadron can still use three different Targeting Computers in one turn)
- Crash/leak fixes: finish separately-or-combined firing state only after a shot has started; unused attached TC must not −1 ordinary Fire; fire-twice −1 must still apply when SOC is live

## Design choices
- Not Maul-style repeated firing — one overall action with Separately or Combined
- Appendix B option A: if the second shot cannot pay, the first still resolved when separately; completed combined firings still combine
- Multiple Targeting Computers on the same ship do **not** stack +1 maneuver (Cumulative Rule)
- Continuous +1 maneuver is not “using” the device
- Combined Attack / Precise Attack are not in this PR (see #1007)

## Tests
`Card_1_39_Tests` — **37** tests:
- Stats; deploy 2 Force; +1 maneuver; cannot use outside battle
- One usage per device; fire twice separately (retarget, Force twice); combined destinies then total mods
- TC −1 each draw (not once on combined total); combined can hit when separate would miss
- XWLC / SW-4 Ion Cannon separately and combined; XWLC at X=3 combined loses the TIE
- Unpaid second separately does not rewind first; combined unpaid shot-2 still applies completed firings
- Don't Fire leaves TC unused; HTB from Home One separately/combined
- Defiance + HTB +2 each draw with/without TC; SOC cleared after separately + Defiance response (no snapshot crash)
- Playtest −1 path: Defiance+Karie+Dack+Verrack+HTB vs Executor separately → 8 and 8 (not 9)
- Unused TC does not −1 ordinary Fire (Defiance+Verrack+HTB vs Executor: 7 and 10)
- Falcon/CEC/Karie/Rogue Gunner/QLC and Ten Numb/Blue 5/Concussion Missiles EACH vs TOTAL coverage
- Four copies on B-wing: maneuver +1 not +4; starfighter/squadron/capital per-turn copy limits

## Known gaps
- Combined Attack / Precise Attack live on later stacked PRs (#1007 / #1014)

Closes #70

---
Tests follow VHD/PlayersCommittee naming (method names lead with card title + behavior; exclusive BlueprintIconCheck/KeywordCheck where applicable).