### PR TITLE
Implement Combined Attack (1_75)

### DIFF
--- a/src/gemp-swccg-async/src/main/web/js/gemp-016/gameUi.js
+++ b/src/gemp-swccg-async/src/main/web/js/gemp-016/gameUi.js
@@ -2405,12 +2405,13 @@ var GempSwccgGameUI = Class.extend({
         var text = decision.getAttribute("text");
         var results = this.getDecisionParameters(decision, "results");
         var defaultIndex = this.getDecisionParameter(decision, "defaultIndex");
+        var asButtons = this.getDecisionParameter(decision, "asButtons") == "true";
 
         var that = this;
         this.smallDialog
             .html(text);
 
-        if (results.length > 2 || this.settingsAlwaysDropDown || defaultIndex >= 0) {
+        if (!asButtons && (results.length > 2 || this.settingsAlwaysDropDown || defaultIndex >= 0)) {
             var html = "<br /><select id='multipleChoiceDecision'>";
             for (var i = 0; i < results.length; i++) {
                 html += "<option " + (i == defaultIndex ? "selected='selected' " : "") + "value='" + i + "'>" + results[i] + "</option>";

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/FireWeaponAsCombinedAction.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/FireWeaponAsCombinedAction.java
@@ -3,67 +3,25 @@ package com.gempukku.swccgo.cards.actions;
 import com.gempukku.swccgo.filters.Filter;
 import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.game.SwccgGame;
-import com.gempukku.swccgo.logic.actions.AbstractAction;
 import com.gempukku.swccgo.logic.actions.AbstractTopLevelRuleAction;
 import com.gempukku.swccgo.logic.timing.Effect;
-import com.gempukku.swccgo.logic.timing.TargetingEffect;
 
+/**
+ * Legacy stub for firing one weapon multiple times as a combined firing.
+ *
+ * Targeting Computer (1_39) fire-twice combined is implemented with SeparatelyOrCombinedFiringState,
+ * not this class. Combined Attack (1_75) is multi-weapon and uses CombinedAttackFiringState plus
+ * FireWeaponsCombinedAction. Do not treat Combined Attack as TC fire-twice.
+ *
+ * Left in place so the original filename remains; body stays unused.
+ */
 public class FireWeaponAsCombinedAction extends AbstractTopLevelRuleAction {
     private PhysicalCard _weaponToFire;
-    private PhysicalCard _cardFiringWeapon;
-    private TargetingEffect _chooseTargetEffect;
-    private boolean _targetChosen;
-    private TargetingEffect _targetTargetEffect;
-    private boolean _targetTargeted;
-    private PhysicalCard _target;
-    private int _timesToFire;
-    private int _timesFired;
-    private boolean _totalWeaponDestinyCalculated;
-    private int _totalWeaponDestiny;
-    private int _numDestiniesDrawn;
-    private boolean _weaponCompleted;
-    private AbstractAction _that;
-    private boolean _cancelAction;
 
     public FireWeaponAsCombinedAction(final SwccgGame game, PhysicalCard weaponToFire, PhysicalCard cardFiringWeapon, Filter filter, int timesToFire) {
         super(weaponToFire, weaponToFire.getOwner());
-
-        _that = this;
         _weaponToFire = weaponToFire;
-        _cardFiringWeapon = cardFiringWeapon;
         setPerformingPlayer(weaponToFire.getOwner());
-        _timesToFire = timesToFire;
-
-        /*
-
-        _chooseTargetEffect =
-                new TargetActiveCardEffect(_that, weaponToFire, weaponToFire.getOwner(), "Choose target to fire at", false, TargetingReason.BEFORE_WEAPON_TARGETING, true, filter) {
-                    @Override
-                    protected void cardTargeted(SwccgGame game, PhysicalCard target) {
-                        if (target==null) {
-                            _cancelAction = true;
-                            return;
-                        }
-
-                        game.getGameState().getWeaponFiringState().setTarget(target);
-                        _target = target;
-                        game.getGameState().sendMessage(_weaponToFire.getOwner() + " targets to fire " + GameUtils.getCardLink(_weaponToFire) + " at " + GameUtils.getCardLink(_target) + " as part of combined firing");
-                        _targetTargetEffect =
-                                new TargetActiveCardEffect(_that, _weaponToFire, _weaponToFire.getOwner(), "Target with weapon", _weaponToFire.getBlueprint().getTargetingReasonWhenFiring(game, _weaponToFire), true, target) {
-                                    @Override
-                                    protected void cardTargeted(SwccgGame game, PhysicalCard target) {
-                                        if (target==null) {
-                                            _cancelAction = true;
-                                            return;
-                                        }
-
-                                        game.getGameState().getWeaponFiringState().setTarget(target);
-                                        _target = target;
-                                    }
-                                };
-                    }
-                };
-                */
     }
 
     @Override
@@ -78,95 +36,11 @@ public class FireWeaponAsCombinedAction extends AbstractTopLevelRuleAction {
 
     @Override
     public Effect nextEffect(final SwccgGame game) {
-            /*
-        if (!_cancelAction) {
-
-
-            // Start weapon firing state info
-            if (!game.getGameState().isDuringWeaponFiring()) {
-                game.getGameState().beginCombinedWeaponFiring();
-                game.getGameState().getWeaponFiringState().addCardFiring(_weaponToFire);
-            }
-
-            if (!_targetChosen) {
-                _targetChosen = true;
-
-                game.getModifiersQuerying().weaponUsedBy(_cardFiringWeapon, _weaponToFire);
-                game.getGameState().activatedCard(_weaponToFire.getOwner(), _weaponToFire);
-                return _chooseTargetEffect;
-            }
-
-            if (!isAnyCostFailed()) {
-                Effect cost = getNextCost();
-                if (cost != null)
-                    return cost;
-
-                if (!_targetTargeted) {
-                    _targetTargeted = true;
-
-                    // Mark weapon as been "fired"
-                    if (game.getGameState().isDuringBattle())
-                        game.getModifiersQuerying().firedInBattle(_weaponToFire);
-
-                    // Actually "target" the target card. This is were opponent can respond to the weapon targeting.
-                    return _targetTargetEffect;
-                }
-
-                if (_timesFired < _timesToFire) {
-                    _timesFired++;
-                    return new StackActionEffect(
-                           new FireWeaponDuringCombinedFiringAction(game, _weaponToFire, _cardFiringWeapon, _target) {
-                                @Override
-                                protected void weaponDestinyDrawComplete(SwccgGame game, List<PhysicalCard> destinyCardDraws, List<Integer> destinyDrawValues, Integer totalDestiny) {
-                                    if (totalDestiny!=null) {
-                                        _numDestiniesDrawn++;
-                                        _totalWeaponDestiny += totalDestiny;
-                                    }
-                                }
-                            });
-                }
-
-                Effect effect = getNextEffect();
-                if (effect != null)
-                    return effect;
-
-                // Get the total weapon destiny
-                if (!_totalWeaponDestinyCalculated) {
-                    _totalWeaponDestinyCalculated = true;
-                    if (_numDestiniesDrawn>0) {
-                        _totalWeaponDestiny = game.getModifiersQuerying().getTotalWeaponDestinyForCombinedFiring(game.getGameState(), _weaponToFire.getOwner(), _target, _totalWeaponDestiny);
-                        game.getGameState().sendMessage(_weaponToFire.getOwner() + "'s total weapon destiny is " + _totalWeaponDestiny);
-                    }
-                }
-
-                if (!_weaponCompleted) {
-                    _weaponCompleted = true;
-                    return new PassthruEffect(action) {
-                        @Override
-                        protected void doPlayEffect(SwccgGame game) {
-                            if (_numDestiniesDrawn>0)
-                                _weaponToFire.getBlueprint().weaponDestinyDrawComplete(game, _that, _weaponToFire, _target, _cardFiringWeapon, null, null, _totalWeaponDestiny);
-                            game.getActionsEnvironment().emitEffectResult(new FiredWeaponResult(_weaponToFire, _cardFiringWeapon, _target, false));
-                        }
-                    };
-                }
-            }
-        }
-
-
-        // End weapon firing state info
-        ((DefaultActionsEnvironment) game.getActionsEnvironment()).removeEndOfWeaponFiringActionProxies();
-        ((ModifiersLogic) game.getModifiersEnvironment()).removeEndOfWeaponFiring();
-        game.getGameState().finishWeaponFiring();
-
-        */
-
         return null;
     }
 
-
     @Override
     public boolean wasActionCarriedOut() {
-        return _weaponCompleted;
+        return false;
     }
 }

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/FireWeaponsCombinedAction.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/FireWeaponsCombinedAction.java
@@ -38,6 +38,8 @@ import java.util.List;
  * After all destinies: if 2+ weapons completed, the player chooses which weapon result applies first.
  */
 public class FireWeaponsCombinedAction extends AbstractSubActionEffect {
+    private static final String DO_NOT_USE_TARGETING_COMPUTER = "Do not use Targeting Computer";
+
     private final PhysicalCard _source;
     private final List<PhysicalCard> _weaponsInOrder;
     private final PhysicalCard _target;
@@ -87,32 +89,38 @@ public class FireWeaponsCombinedAction extends AbstractSubActionEffect {
 
         final PhysicalCard weapon = _weaponsInOrder.get(index);
         final Filter targetFilter = Filters.sameCardId(_target);
-        final PhysicalCard targetingComputer = findUsableTargetingComputer(game, weapon);
 
         subAction.appendEffect(
                 new PassthruEffect(subAction) {
                     @Override
                     protected void doPlayEffect(SwccgGame game) {
-                        if (targetingComputer != null) {
-                            // Same three-way as standalone Targeting Computer. UseDevice waits until
-                            // Separately/Combined so Don't Fire leaves the device unused.
+                        final List<PhysicalCard> targetingComputers = findUsableTargetingComputers(game, weapon);
+                        if (!targetingComputers.isEmpty()) {
+                            // Optional: use a specific unused Targeting Computer, or use none.
+                            // Combined Attack already adds destinies together, so choosing a Targeting
+                            // Computer always takes the combined path. No Separately / Combined / Don't Fire.
+                            List<String> options = new ArrayList<String>();
+                            for (PhysicalCard tc : targetingComputers) {
+                                options.add(GameUtils.getCardLink(tc));
+                            }
+                            options.add(DO_NOT_USE_TARGETING_COMPUTER);
                             subAction.appendEffect(
                                     new PlayoutDecisionEffect(subAction, _source.getOwner(),
-                                            new MultipleChoiceAwaitingDecision("Fire a weapon twice",
-                                                    new String[]{"Separately", "Combined", "Don't Fire (Cancel)"}) {
+                                            new MultipleChoiceAwaitingDecision(
+                                                    "Use Targeting Computer to fire this Combined Attack weapon twice?",
+                                                    options.toArray(new String[options.size()]), true) {
                                                 @Override
                                                 protected void validDecisionMade(int choiceIndex, String result) {
-                                                    if (result != null && result.startsWith("Don't Fire")) {
+                                                    if (result != null && result.startsWith("Do not use")) {
                                                         subAction.appendEffect(createFireEffect(weapon, targetFilter, false));
                                                         appendNextWeapon(subAction, game, index + 1);
                                                         return;
                                                     }
-                                                    final boolean combined = "Combined".equals(result);
-                                                    subAction.appendEffect(new UseDeviceEffect(subAction, targetingComputer));
-                                                    game.getGameState().beginSeparatelyOrCombinedFiring(targetingComputer, weapon, combined);
-                                                    final String mode = result.toLowerCase();
-                                                    game.getGameState().sendMessage(_source.getOwner() + " uses " + GameUtils.getCardLink(targetingComputer)
-                                                            + " to fire " + GameUtils.getCardLink(weapon) + " twice: " + mode);
+                                                    final PhysicalCard chosen = targetingComputers.get(choiceIndex);
+                                                    subAction.appendEffect(new UseDeviceEffect(subAction, chosen));
+                                                    game.getGameState().beginSeparatelyOrCombinedFiring(chosen, weapon, true);
+                                                    game.getGameState().sendMessage(_source.getOwner() + " uses " + GameUtils.getCardLink(chosen)
+                                                            + " to fire " + GameUtils.getCardLink(weapon) + " twice: combined");
                                                     subAction.appendEffect(createFireEffect(weapon, targetFilter, false));
                                                     subAction.appendEffect(createFireEffect(weapon, targetFilter, true));
                                                     subAction.appendEffect(
@@ -147,25 +155,27 @@ public class FireWeaponsCombinedAction extends AbstractSubActionEffect {
     }
 
     /**
-     * Targeting Computer on the starship firing this weapon, unused this battle, and currently usable.
+     * Unused usable Targeting Computers on the starship firing this Combined Attack weapon.
+     * Empty if the starship has none left; the player may still choose none when the list is not empty.
      */
-    private PhysicalCard findUsableTargetingComputer(SwccgGame game, PhysicalCard weapon) {
+    private List<PhysicalCard> findUsableTargetingComputers(SwccgGame game, PhysicalCard weapon) {
+        List<PhysicalCard> result = new ArrayList<PhysicalCard>();
         PhysicalCard starship = weapon.getAttachedTo();
         if (starship == null && Filters.starship.accepts(game, weapon)) {
             starship = weapon;
         }
         if (starship == null) {
-            return null;
+            return result;
         }
         Collection<PhysicalCard> computers = Filters.filterActive(game, _source,
                 Filters.and(Filters.title(Title.Targeting_Computer), Filters.attachedTo(starship)));
         for (PhysicalCard tc : computers) {
             if (GameConditions.canUseDevice(game, tc)
                     && GameConditions.isOncePerBattle(game, tc, tc.getCardId())) {
-                return tc;
+                result.add(tc);
             }
         }
-        return null;
+        return result;
     }
 
     /**

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/FireWeaponsCombinedAction.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/FireWeaponsCombinedAction.java
@@ -65,6 +65,17 @@ public class FireWeaponsCombinedAction extends AbstractSubActionEffect {
                         game.getGameState().sendMessage(_source.getOwner() + " plays Combined Attack targeting "
                                 + GameUtils.getCardLink(_target) + " with " + GameUtils.getAppendedNames(_weaponsInOrder));
                         game.getGameState().beginCombinedAttackFiring(_source, _target, _weaponsInOrder);
+                        // Always clear Combined Attack firing when this sub-action leaves the stack.
+                        // Nested finish after the last weapon can be skipped if a required response
+                        // completes nested fire without remaining parent effects.
+                        subAction.appendAfterEffect(
+                                new PassthruEffect(subAction) {
+                                    @Override
+                                    protected void doPlayEffect(SwccgGame game) {
+                                        game.getGameState().finishCombinedAttackFiring();
+                                    }
+                                }
+                        );
                         appendNextWeapon(subAction, game, 0);
                     }
                 }
@@ -111,6 +122,14 @@ public class FireWeaponsCombinedAction extends AbstractSubActionEffect {
                                             usedTargetingComputer[0] = true;
                                             subAction.appendEffect(new UseDeviceEffect(subAction, chosen));
                                             game.getGameState().beginSeparatelyOrCombinedFiring(chosen, weapon, true);
+                                            subAction.appendAfterEffect(
+                                                    new PassthruEffect(subAction) {
+                                                        @Override
+                                                        protected void doPlayEffect(SwccgGame game) {
+                                                            game.getGameState().finishSeparatelyOrCombinedFiring();
+                                                        }
+                                                    }
+                                            );
                                             game.getGameState().sendMessage(_source.getOwner() + " uses " + GameUtils.getCardLink(chosen)
                                                     + " to fire " + GameUtils.getCardLink(weapon) + " twice: combined");
                                             subAction.appendEffect(createFireEffect(weapon, targetFilter, false));

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/FireWeaponsCombinedAction.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/FireWeaponsCombinedAction.java
@@ -27,9 +27,10 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * Combined Attack result: fire the chosen starship weapons one at a time at the shared target, collect destiny
- * DRAWS, then apply the added total separately for each weapon (AR per-weapon total modifiers) using each
- * weapon's own destinyDraws path (X-wing Laser Cannon can lose the target; Ion Cannon ionizes; others hit).
+ * Combined Attack result: fire the chosen starship weapons one at a time at the shared target. Each firing
+ * is a complete total weapon destiny subtotal (draws plus that firing's total-weapon-destiny modifiers).
+ * Combined Attack adds those subtotals and applies that shared total for each participating weapon
+ * using each weapon's own destinyDraws path (X-wing Laser Cannon can lose the target; Ion Cannon ionizes; others hit).
  *
  * Pending option A: costs paid as each shot initiates; if a later weapon cannot pay, skip it; completed
  * destinies still combine and still get applied to the weapons that did fire.
@@ -181,8 +182,9 @@ public class FireWeaponsCombinedAction extends AbstractSubActionEffect {
     }
 
     /**
-     * After all fire: shared draw-sum applied separately per completed weapon via that weapon's own
-     * destinyDraws path. Player chooses apply order when 2+ weapons completed.
+     * After all fire: summed firing subtotals applied as the shared total for each completed
+     * weapon via that weapon's own destinyDraws path. Total-weapon-destiny modifiers are already
+     * inside each subtotal. Player chooses apply order when 2+ weapons completed.
      */
     private void resolveCombinedAttack(Action action, SwccgGame game) {
         CombinedAttackFiringState ca = game.getGameState().getCombinedAttackFiringState();
@@ -254,9 +256,9 @@ public class FireWeaponsCombinedAction extends AbstractSubActionEffect {
     private void applyWeaponRecord(Action action, SwccgGame game, CombinedAttackFiringState.WeaponRecord record,
                                    float drawSum, PhysicalCard target) {
         PhysicalCard weapon = record.getWeapon();
-        float total = Math.max(0, drawSum + record.getTotalModifierSnapshot());
+        float total = Math.max(0, drawSum);
         game.getGameState().sendMessage(CombinedAttackFiringState.getPerWeaponTotalMessage(
-                weapon, drawSum, record.getTotalModifierSnapshot(), total));
+                weapon, drawSum, 0f, total));
         boolean queued = false;
         if (record.getDrawDestinyEffect() != null) {
             queued = record.getDrawDestinyEffect().applyDeferredWeaponResult(game, action, weapon,

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/FireWeaponsCombinedAction.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/FireWeaponsCombinedAction.java
@@ -28,12 +28,13 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * Combined Attack result: fire the chosen starship weapons one at a time at the shared target. Each firing
- * is a complete total weapon destiny subtotal (draws plus that firing's total-weapon-destiny modifiers).
- * Combined Attack adds those subtotals and applies that shared total for each participating weapon
- * using each weapon's own destinyDraws path (X-wing Laser Cannon can lose the target; Ion Cannon ionizes; others hit).
+ * Combined Attack result: fire the chosen starship weapons one at a time at the shared target.
+ * Draw modifiers stay on each draw. TOTAL weapon destiny modifiers apply once to the grand total
+ * (same title once unless the card says cumulatively). That grand total is applied separately
+ * to each participating weapon using each weapon's own destinyDraws path (X-wing Laser Cannon
+ * can lose the target; Ion Cannon ionizes; others hit).
  *
- * Pending option A: costs paid as each shot initiates; if a later weapon cannot pay, skip it; completed
+ * Costs are paid as each shot initiates; if a later weapon cannot pay, skip it; completed
  * destinies still combine and still get applied to the weapons that did fire.
  *
  * After all destinies: if 2+ weapons completed, the player chooses which weapon result applies first.
@@ -214,9 +215,9 @@ public class FireWeaponsCombinedAction extends AbstractSubActionEffect {
     }
 
     /**
-     * After all fire: summed firing subtotals applied as the shared total for each completed
-     * weapon via that weapon's own destinyDraws path. Total-weapon-destiny modifiers are already
-     * inside each subtotal. Player chooses apply order when 2+ weapons completed.
+     * After all fire: sum destinies (draw modifiers only), apply TOTAL mods once to that grand
+     * total (same title once), then apply that shared total for each completed weapon via that
+     * weapon's own destinyDraws path. Player chooses apply order when 2+ weapons completed.
      */
     private void resolveCombinedAttack(Action action, SwccgGame game) {
         CombinedAttackFiringState ca = game.getGameState().getCombinedAttackFiringState();
@@ -228,11 +229,15 @@ public class FireWeaponsCombinedAction extends AbstractSubActionEffect {
             return;
         }
         float drawSum = ca.getDrawSum();
-        game.getGameState().sendMessage(ca.getAddedDestiniesMessage(GuiUtils.formatAsString(drawSum)));
+        float totalMods = ca.getSameTitleOnceTotalModifier();
+        float grandTotal = ca.getGrandTotal();
+        game.getGameState().sendMessage(ca.getAddedDestiniesMessage(
+                GuiUtils.formatAsString(drawSum), GuiUtils.formatAsString(totalMods),
+                GuiUtils.formatAsString(grandTotal)));
         List<CombinedAttackFiringState.WeaponRecord> records =
                 new ArrayList<CombinedAttackFiringState.WeaponRecord>(ca.getCompletedWeaponRecordsInOrder());
         ca.markResolved();
-        promptApplyOrder(action, game, records, drawSum, target);
+        promptApplyOrder(action, game, records, grandTotal, target);
     }
 
     private void promptApplyOrder(final Action action, final SwccgGame game,
@@ -290,7 +295,7 @@ public class FireWeaponsCombinedAction extends AbstractSubActionEffect {
         PhysicalCard weapon = record.getWeapon();
         float total = Math.max(0, drawSum);
         game.getGameState().sendMessage(CombinedAttackFiringState.getPerWeaponTotalMessage(
-                weapon, drawSum, 0f, total));
+                weapon, total, 0f, total));
         boolean queued = false;
         if (record.getDrawDestinyEffect() != null) {
             queued = record.getDrawDestinyEffect().applyDeferredWeaponResult(game, action, weapon,

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/FireWeaponsCombinedAction.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/FireWeaponsCombinedAction.java
@@ -11,6 +11,7 @@ import com.gempukku.swccgo.game.SwccgGame;
 import com.gempukku.swccgo.game.state.CombinedAttackFiringState;
 import com.gempukku.swccgo.logic.GameUtils;
 import com.gempukku.swccgo.logic.actions.SubAction;
+import com.gempukku.swccgo.logic.decisions.MultipleChoiceAwaitingDecision;
 import com.gempukku.swccgo.logic.decisions.YesNoDecision;
 import com.gempukku.swccgo.logic.effects.ChooseArbitraryCardsEffect;
 import com.gempukku.swccgo.logic.effects.FireWeaponEffect;
@@ -102,9 +103,30 @@ public class FireWeaponsCombinedAction extends AbstractSubActionEffect {
                                                 @Override
                                                 protected void yes() {
                                                     subAction.appendEffect(new UseDeviceEffect(subAction, targetingComputer));
-                                                    subAction.appendEffect(createFireEffect(weapon, targetFilter, false));
-                                                    subAction.appendEffect(createFireEffect(weapon, targetFilter, true));
-                                                    appendNextWeapon(subAction, game, index + 1);
+                                                    subAction.appendEffect(
+                                                            new PlayoutDecisionEffect(subAction, _source.getOwner(),
+                                                                    new MultipleChoiceAwaitingDecision("Fire twice separately or combined?", new String[]{"Separately", "Combined"}) {
+                                                                        @Override
+                                                                        protected void validDecisionMade(int choiceIndex, String result) {
+                                                                            final boolean combined = "Combined".equals(result);
+                                                                            game.getGameState().beginSeparatelyOrCombinedFiring(targetingComputer, weapon, combined);
+                                                                            game.getGameState().sendMessage(_source.getOwner() + " uses " + GameUtils.getCardLink(targetingComputer)
+                                                                                    + " to fire " + GameUtils.getCardLink(weapon) + " twice " + result
+                                                                                    + " as part of Combined Attack");
+                                                                            subAction.appendEffect(createFireEffect(weapon, targetFilter, false));
+                                                                            subAction.appendEffect(createFireEffect(weapon, targetFilter, true));
+                                                                            subAction.appendEffect(
+                                                                                    new PassthruEffect(subAction) {
+                                                                                        @Override
+                                                                                        protected void doPlayEffect(SwccgGame game) {
+                                                                                            game.getGameState().finishSeparatelyOrCombinedFiring();
+                                                                                        }
+                                                                                    }
+                                                                            );
+                                                                            appendNextWeapon(subAction, game, index + 1);
+                                                                        }
+                                                                    })
+                                                    );
                                                 }
 
                                                 @Override
@@ -211,7 +233,15 @@ public class FireWeaponsCombinedAction extends AbstractSubActionEffect {
                             applyWeaponRecord(action, game, chosenRecord, drawSum, target);
                         }
                         if (!leftover.isEmpty()) {
-                            promptApplyOrder(action, game, leftover, drawSum, target);
+                            final List<CombinedAttackFiringState.WeaponRecord> leftoverFinal = leftover;
+                            action.appendEffect(
+                                    new PassthruEffect(action) {
+                                        @Override
+                                        protected void doPlayEffect(SwccgGame game) {
+                                            promptApplyOrder(action, game, leftoverFinal, drawSum, target);
+                                        }
+                                    }
+                            );
                         }
                     }
                 }
@@ -232,12 +262,13 @@ public class FireWeaponsCombinedAction extends AbstractSubActionEffect {
         }
         if (!queued) {
             float defenseValue = game.getModifiersQuerying().getDefenseValue(game.getGameState(), target);
-            if (total > defenseValue) {
+            float valueForX = record.getVariableXSnapshot();
+            if ((total + valueForX) > defenseValue) {
                 game.getGameState().sendMessage("Result: Succeeded");
                 if (weapon.getBlueprint().hasKeyword(Keyword.ION_CANNON)) {
                     action.appendEffect(new IonizeStarshipEffect(action, target, weapon, false, true, true));
                 }
-                else if (record.getVariableXSnapshot() == 3f) {
+                else if (valueForX == 3f) {
                     action.appendEffect(new LoseCardFromTableEffect(action, target));
                 }
                 else {

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/FireWeaponsCombinedAction.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/FireWeaponsCombinedAction.java
@@ -2,6 +2,7 @@ package com.gempukku.swccgo.cards.actions;
 
 import com.gempukku.swccgo.cards.GameConditions;
 import com.gempukku.swccgo.cards.effects.UseDeviceEffect;
+import com.gempukku.swccgo.common.GameTextActionId;
 import com.gempukku.swccgo.common.Keyword;
 import com.gempukku.swccgo.common.Title;
 import com.gempukku.swccgo.filters.Filter;
@@ -120,6 +121,14 @@ public class FireWeaponsCombinedAction extends AbstractSubActionEffect {
                                         @Override
                                         protected void cardSelected(PhysicalCard chosen) {
                                             usedTargetingComputer[0] = true;
+                                            // Same once-per-copy counters as Card1_039. UseDeviceEffect
+                                            // excludes this copy from otherDevicesUsed, so without these
+                                            // increments Combined Attack would re-offer the same copy
+                                            // on a later weapon (capital: unlimited device slots).
+                                            String playerId = chosen.getOwner();
+                                            int cardId = chosen.getCardId();
+                                            game.getModifiersQuerying().getUntilEndOfTurnLimitCounter(chosen, playerId, cardId, GameTextActionId.OTHER_CARD_ACTION_DEFAULT).incrementToLimit(1, 1);
+                                            game.getModifiersQuerying().getUntilEndOfBattleLimitCounter(chosen, playerId, cardId, GameTextActionId.OTHER_CARD_ACTION_DEFAULT).incrementToLimit(1, 1);
                                             subAction.appendEffect(new UseDeviceEffect(subAction, chosen));
                                             game.getGameState().beginSeparatelyOrCombinedFiring(chosen, weapon, true);
                                             subAction.appendAfterEffect(
@@ -192,8 +201,12 @@ public class FireWeaponsCombinedAction extends AbstractSubActionEffect {
         Collection<PhysicalCard> computers = Filters.filterActive(game, _source,
                 Filters.and(Filters.title(Title.Targeting_Computer), Filters.attachedTo(starship)));
         for (PhysicalCard tc : computers) {
+            String playerId = tc.getOwner();
+            // playerId is required: 3-arg OncePerTurn/OncePerBattle pass playerId=null and never
+            // match the counters incremented with the owner's id.
             if (GameConditions.canUseDevice(game, tc)
-                    && GameConditions.isOncePerBattle(game, tc, tc.getCardId())) {
+                    && GameConditions.isOncePerTurn(game, tc, playerId, tc.getCardId())
+                    && GameConditions.isOncePerBattle(game, tc, playerId, tc.getCardId())) {
                 result.add(tc);
             }
         }

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/FireWeaponsCombinedAction.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/FireWeaponsCombinedAction.java
@@ -12,7 +12,6 @@ import com.gempukku.swccgo.game.state.CombinedAttackFiringState;
 import com.gempukku.swccgo.logic.GameUtils;
 import com.gempukku.swccgo.logic.actions.SubAction;
 import com.gempukku.swccgo.logic.decisions.MultipleChoiceAwaitingDecision;
-import com.gempukku.swccgo.logic.decisions.YesNoDecision;
 import com.gempukku.swccgo.logic.effects.ChooseArbitraryCardsEffect;
 import com.gempukku.swccgo.logic.effects.FireWeaponEffect;
 import com.gempukku.swccgo.logic.effects.HitCardEffect;
@@ -95,43 +94,35 @@ public class FireWeaponsCombinedAction extends AbstractSubActionEffect {
                     @Override
                     protected void doPlayEffect(SwccgGame game) {
                         if (targetingComputer != null) {
+                            // Same three-way as standalone Targeting Computer. UseDevice waits until
+                            // Separately/Combined so Don't Fire leaves the device unused.
                             subAction.appendEffect(
                                     new PlayoutDecisionEffect(subAction, _source.getOwner(),
-                                            new YesNoDecision("Use " + GameUtils.getCardLink(targetingComputer)
-                                                    + " to fire " + GameUtils.getCardLink(weapon)
-                                                    + " twice as part of Combined Attack?") {
+                                            new MultipleChoiceAwaitingDecision("Fire a weapon twice",
+                                                    new String[]{"Separately", "Combined", "Don't Fire (Cancel)"}) {
                                                 @Override
-                                                protected void yes() {
+                                                protected void validDecisionMade(int choiceIndex, String result) {
+                                                    if (result != null && result.startsWith("Don't Fire")) {
+                                                        subAction.appendEffect(createFireEffect(weapon, targetFilter, false));
+                                                        appendNextWeapon(subAction, game, index + 1);
+                                                        return;
+                                                    }
+                                                    final boolean combined = "Combined".equals(result);
                                                     subAction.appendEffect(new UseDeviceEffect(subAction, targetingComputer));
-                                                    subAction.appendEffect(
-                                                            new PlayoutDecisionEffect(subAction, _source.getOwner(),
-                                                                    new MultipleChoiceAwaitingDecision("Fire twice separately or combined?", new String[]{"Separately", "Combined"}) {
-                                                                        @Override
-                                                                        protected void validDecisionMade(int choiceIndex, String result) {
-                                                                            final boolean combined = "Combined".equals(result);
-                                                                            game.getGameState().beginSeparatelyOrCombinedFiring(targetingComputer, weapon, combined);
-                                                                            game.getGameState().sendMessage(_source.getOwner() + " uses " + GameUtils.getCardLink(targetingComputer)
-                                                                                    + " to fire " + GameUtils.getCardLink(weapon) + " twice " + result
-                                                                                    + " as part of Combined Attack");
-                                                                            subAction.appendEffect(createFireEffect(weapon, targetFilter, false));
-                                                                            subAction.appendEffect(createFireEffect(weapon, targetFilter, true));
-                                                                            subAction.appendEffect(
-                                                                                    new PassthruEffect(subAction) {
-                                                                                        @Override
-                                                                                        protected void doPlayEffect(SwccgGame game) {
-                                                                                            game.getGameState().finishSeparatelyOrCombinedFiring();
-                                                                                        }
-                                                                                    }
-                                                                            );
-                                                                            appendNextWeapon(subAction, game, index + 1);
-                                                                        }
-                                                                    })
-                                                    );
-                                                }
-
-                                                @Override
-                                                protected void no() {
+                                                    game.getGameState().beginSeparatelyOrCombinedFiring(targetingComputer, weapon, combined);
+                                                    final String mode = result.toLowerCase();
+                                                    game.getGameState().sendMessage(_source.getOwner() + " uses " + GameUtils.getCardLink(targetingComputer)
+                                                            + " to fire " + GameUtils.getCardLink(weapon) + " twice: " + mode);
                                                     subAction.appendEffect(createFireEffect(weapon, targetFilter, false));
+                                                    subAction.appendEffect(createFireEffect(weapon, targetFilter, true));
+                                                    subAction.appendEffect(
+                                                            new PassthruEffect(subAction) {
+                                                                @Override
+                                                                protected void doPlayEffect(SwccgGame game) {
+                                                                    game.getGameState().finishSeparatelyOrCombinedFiring();
+                                                                }
+                                                            }
+                                                    );
                                                     appendNextWeapon(subAction, game, index + 1);
                                                 }
                                             })

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/FireWeaponsCombinedAction.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/FireWeaponsCombinedAction.java
@@ -1,152 +1,199 @@
 package com.gempukku.swccgo.cards.actions;
 
+import com.gempukku.swccgo.cards.GameConditions;
+import com.gempukku.swccgo.cards.effects.UseDeviceEffect;
+import com.gempukku.swccgo.common.Keyword;
+import com.gempukku.swccgo.common.Title;
 import com.gempukku.swccgo.filters.Filter;
+import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.game.SwccgGame;
-import com.gempukku.swccgo.logic.actions.AbstractAction;
-import com.gempukku.swccgo.logic.actions.AbstractTopLevelRuleAction;
-import com.gempukku.swccgo.logic.timing.Effect;
+import com.gempukku.swccgo.game.state.CombinedAttackFiringState;
+import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.actions.SubAction;
+import com.gempukku.swccgo.logic.decisions.YesNoDecision;
+import com.gempukku.swccgo.logic.effects.FireWeaponEffect;
+import com.gempukku.swccgo.logic.effects.HitCardEffect;
+import com.gempukku.swccgo.logic.effects.IonizeStarshipEffect;
+import com.gempukku.swccgo.logic.effects.PlayoutDecisionEffect;
+import com.gempukku.swccgo.logic.timing.AbstractSubActionEffect;
+import com.gempukku.swccgo.logic.timing.Action;
+import com.gempukku.swccgo.logic.timing.GuiUtils;
+import com.gempukku.swccgo.logic.timing.PassthruEffect;
 
-import java.util.LinkedList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
-public class FireWeaponsCombinedAction extends AbstractTopLevelRuleAction {
-    private PhysicalCard _sourceCard;
-    private PhysicalCard _target;
-    private boolean _weaponFireOrderChosen;
-    private List<PhysicalCard> _weaponsFiredInOrder = new LinkedList<PhysicalCard>();
-    private boolean _totalWeaponDestinyCalculated;
-    private int _totalWeaponDestiny;
-    private int _numDestiniesDrawn;
-    private int _numWeaponsCompleted;
-    private AbstractAction _that;
-    private boolean _abortAction;
+/**
+ * Combined Attack result: fire the chosen starship weapons one at a time at the shared target, collect destiny
+ * DRAWS, then apply the added total separately for each weapon (AR per-weapon total modifiers).
+ *
+ * The old stub applied one combined total-modifier pass and reused that number for every weapon. That is weaker
+ * than AR (Heavy Turbolaser -6 vs starfighter must apply only when resolving HT). This rewrite prefers AR:
+ * shared draw-sum + each weapon's own total modifiers, applied after all fire (Gergall).
+ *
+ * Pending option A: costs paid as each shot initiates; if a later weapon cannot pay, skip it; completed
+ * destinies still combine and still get applied to the weapons that did fire.
+ */
+public class FireWeaponsCombinedAction extends AbstractSubActionEffect {
+    private final PhysicalCard _source;
+    private final List<PhysicalCard> _weaponsInOrder;
+    private final PhysicalCard _target;
 
-    public FireWeaponsCombinedAction(final SwccgGame game, final PhysicalCard sourceCard, Filter weaponsToFireFilter, PhysicalCard target) {
-        super(sourceCard, sourceCard.getOwner());
-
-        /*
-
-        _that = this;
-        _sourceCard = sourceCard;
-        setPerformingPlayer(sourceCard.getOwner());
+    public FireWeaponsCombinedAction(Action action, PhysicalCard source, List<PhysicalCard> weaponsInOrder, PhysicalCard target) {
+        super(action);
+        _source = source;
+        _weaponsInOrder = weaponsInOrder;
         _target = target;
+    }
 
-        _chooseWeaponsInOrderEffect =
-                new ChooseCardsOneAtATimeEffect(this, sourceCard.getOwner(), "Choose weapons to fire combined in order", Filters.and(weaponsToFireFilter, Filters.canFireAtTarget(target, 0))) {
+    @Override
+    public boolean isPlayableInFull(SwccgGame game) {
+        return true;
+    }
+
+    @Override
+    protected SubAction getSubAction(final SwccgGame game) {
+        final SubAction subAction = new SubAction(_action);
+        subAction.appendEffect(
+                new PassthruEffect(subAction) {
                     @Override
-                    protected void cardChosen(SwccgGame game, final PhysicalCard weapon) {
-                        if (weapon==null) {
-                            _abortAction = true;
-                            return;
-                        }
-
-                        game.getModifiersQuerying().weaponUsedBy(weapon.getAttachedTo(), weapon);
-                        if (game.getGameState().isDuringBattle())
-                            game.getModifiersQuerying().firedInBattle(weapon);
-
-                        game.getGameState().sendMessage(sourceCard.getOwner() + " targets to fire " + GameUtils.getCardLink(weapon) + " at " + GameUtils.getCardLink(_target) + " as part of combined firing");
-                        SubAction subAction = new SubAction(_that);
-                        subAction.appendEffect(
-                                new TargetActiveCardEffect(_that, weapon, weapon.getOwner(), "Target with weapon", weapon.getBlueprint().getTargetingReasonWhenFiring(game, weapon), false, _target) {
-                                    @Override
-                                    protected void cardTargeted(SwccgGame game, PhysicalCard target) {
-                                        if (target==null) {
-                                            _abortAction = true;
-                                            return;
-                                        }
-
-                                        game.getGameState().getWeaponFiringState().setTarget(target);
-                                        _target = target;
-                                        game.getActionsEnvironment().addActionToStack(
-                                                new FireWeaponDuringCombinedFiringAction(game, weapon, weapon.getAttachedTo(), _target) {
-                                                    @Override
-                                                    protected void weaponDestinyDrawComplete(SwccgGame game, List<PhysicalCard> destinyCardDraws, List<Integer> destinyDrawValues, Integer totalDestiny) {
-                                                        _weaponsFiredInOrder.add(weapon);
-                                                        if (totalDestiny!=null) {
-                                                            _numDestiniesDrawn++;
-                                                            _totalWeaponDestiny += totalDestiny;
-                                                        }
-                                                    }
-                                                });
-                                    }
-                                });
-                        game.getActionsEnvironment().addActionToStack(subAction);
-                    }
-                };
-                */
-    }
-
-    @Override
-    public PhysicalCard getActionSource() {
-        return _sourceCard;
-    }
-
-    @Override
-    public String getText() {
-        return null;
-    }
-
-    @Override
-    public Effect nextEffect(final SwccgGame game) {
-/*        if (!_abortAction) {
-
-            // Start weapon firing state info
-            if (!game.getGameState().isDuringWeaponFiring()) {
-                game.getGameState().beginCombinedWeaponFiring();
-                game.getGameState().getWeaponFiringState().setTarget(_target);
-            }
-
-            if (!isAnyCostFailed()) {
-                Effect cost = getNextCost();
-                if (cost != null)
-                    return cost;
-
-                if (!_weaponFireOrderChosen) {
-                    _weaponFireOrderChosen = true;
-                    return _chooseWeaponsInOrderEffect;
-                }
-
-                Effect effect = getNextEffect();
-                if (effect != null)
-                    return effect;
-
-                // Get the total weapon destiny
-                if (!_totalWeaponDestinyCalculated) {
-                    _totalWeaponDestinyCalculated = true;
-                    if (_numDestiniesDrawn>0) {
-                        _totalWeaponDestiny = game.getModifiersQuerying().getTotalWeaponDestinyForCombinedFiring(game.getGameState(), _sourceCard.getOwner(), _target, _totalWeaponDestiny);
-                        game.getGameState().sendMessage(_sourceCard.getOwner() + "'s total weapon destiny is " + _totalWeaponDestiny);
+                    protected void doPlayEffect(SwccgGame game) {
+                        game.getGameState().beginCombinedAttackFiring(_source, _target, _weaponsInOrder);
+                        appendNextWeapon(subAction, game, 0);
                     }
                 }
+        );
+        return subAction;
+    }
 
-                if (_numWeaponsCompleted < _weaponsFiredInOrder.size()) {
-                    _numWeaponsCompleted++;
-                    return new PassthruEffect(action) {
+    private void appendNextWeapon(final SubAction subAction, final SwccgGame game, final int index) {
+        if (index >= _weaponsInOrder.size()) {
+            subAction.appendEffect(
+                    new PassthruEffect(subAction) {
                         @Override
                         protected void doPlayEffect(SwccgGame game) {
-                            PhysicalCard weapon = _weaponsFiredInOrder.get(_numWeaponsCompleted-1);
-                            if (_numDestiniesDrawn>0)
-                                weapon.getBlueprint().weaponDestinyDrawComplete(game, _that, weapon, _target, null, null, null, _totalWeaponDestiny);
-                            game.getActionsEnvironment().emitEffectResult(new FiredWeaponResult(weapon, weapon.getAttachedTo(), _target, false));
+                            resolveCombinedAttack(subAction, game);
+                            game.getGameState().finishCombinedAttackFiring();
                         }
-                    };
-                }
-            }
+                    }
+            );
+            return;
         }
 
-        // End weapon firing state info
-        ((DefaultActionsEnvironment) game.getActionsEnvironment()).removeEndOfBattleActionProxies();
-        ((ModifiersLogic) game.getModifiersEnvironment()).removeEndOfWeaponFiring();
-        game.getGameState().finishWeaponFiring();
-        */
+        final PhysicalCard weapon = _weaponsInOrder.get(index);
+        final Filter targetFilter = Filters.sameCardId(_target);
+        final PhysicalCard targetingComputer = findUsableTargetingComputer(game, weapon);
+
+        subAction.appendEffect(
+                new PassthruEffect(subAction) {
+                    @Override
+                    protected void doPlayEffect(SwccgGame game) {
+                        if (targetingComputer != null) {
+                            // Both TC shots consecutive and both inside Combined Attack (forum p=1111897).
+                            // Cannot split one TC shot in CA and one outside.
+                            subAction.appendEffect(
+                                    new PlayoutDecisionEffect(subAction, _source.getOwner(),
+                                            new YesNoDecision("Use " + GameUtils.getCardLink(targetingComputer)
+                                                    + " to fire " + GameUtils.getCardLink(weapon)
+                                                    + " twice as part of Combined Attack?") {
+                                                @Override
+                                                protected void yes() {
+                                                    subAction.appendEffect(new UseDeviceEffect(subAction, targetingComputer));
+                                                    subAction.appendEffect(createFireEffect(weapon, targetFilter, false));
+                                                    subAction.appendEffect(createFireEffect(weapon, targetFilter, true));
+                                                    appendNextWeapon(subAction, game, index + 1);
+                                                }
+
+                                                @Override
+                                                protected void no() {
+                                                    subAction.appendEffect(createFireEffect(weapon, targetFilter, false));
+                                                    appendNextWeapon(subAction, game, index + 1);
+                                                }
+                                            })
+                            );
+                        }
+                        else {
+                            subAction.appendEffect(createFireEffect(weapon, targetFilter, false));
+                            appendNextWeapon(subAction, game, index + 1);
+                        }
+                    }
+                }
+        );
+    }
+
+    private FireWeaponEffect createFireEffect(PhysicalCard weapon, Filter targetFilter, final boolean ignorePerBattleLimit) {
+        return new FireWeaponEffect(_action, weapon, false, targetFilter) {
+            @Override
+            protected boolean isignorePerAttackOrBattleLimit() {
+                return ignorePerBattleLimit;
+            }
+        };
+    }
+
+    /**
+     * Targeting Computer on the starship firing this weapon, unused this battle, and currently usable.
+     */
+    private PhysicalCard findUsableTargetingComputer(SwccgGame game, PhysicalCard weapon) {
+        PhysicalCard starship = weapon.getAttachedTo();
+        if (starship == null && Filters.starship.accepts(game, weapon)) {
+            starship = weapon;
+        }
+        if (starship == null) {
+            return null;
+        }
+        Collection<PhysicalCard> computers = Filters.filterActive(game, _source,
+                Filters.and(Filters.title(Title.Targeting_Computer), Filters.attachedTo(starship)));
+        for (PhysicalCard tc : computers) {
+            if (GameConditions.canUseDevice(game, tc)
+                    && GameConditions.isOncePerBattle(game, tc, tc.getCardId())) {
+                return tc;
+            }
+        }
         return null;
     }
 
+    /**
+     * After all fire: shared draw-sum applied separately per completed weapon, with that weapon's snapshotted
+     * total modifiers. Hits/ionize happen now, not during the individual destiny draws.
+     */
+    private void resolveCombinedAttack(Action action, SwccgGame game) {
+        CombinedAttackFiringState ca = game.getGameState().getCombinedAttackFiringState();
+        if (ca == null || ca.isResolved() || ca.getCompletedDrawCount() == 0) {
+            return;
+        }
+        PhysicalCard target = ca.getTarget();
+        if (target == null) {
+            return;
+        }
+        float drawSum = ca.getDrawSum();
+        game.getGameState().sendMessage(ca.getAddedDestiniesMessage(GuiUtils.formatAsString(drawSum)));
+        float defenseValue = game.getModifiersQuerying().getDefenseValue(game.getGameState(), target);
+        game.getGameState().sendMessage("Defense value: " + GuiUtils.formatAsString(defenseValue));
 
-    @Override
-    public boolean wasActionCarriedOut() {
-        return _totalWeaponDestinyCalculated;
+        for (CombinedAttackFiringState.WeaponRecord record : ca.getCompletedWeaponRecordsInOrder()) {
+            PhysicalCard weapon = record.getWeapon();
+            float total = Math.max(0, drawSum + record.getTotalModifierSnapshot());
+            game.getGameState().sendMessage(ca.getPerWeaponTotalMessage(weapon, GuiUtils.formatAsString(total)));
+            if (total > defenseValue) {
+                game.getGameState().sendMessage("Result for " + GameUtils.getCardLink(weapon) + ": Succeeded");
+                if (weapon.getBlueprint().hasKeyword(Keyword.ION_CANNON)) {
+                    action.appendEffect(new IonizeStarshipEffect(action, target, weapon, false, true, true));
+                }
+                else {
+                    action.appendEffect(new HitCardEffect(action, target, weapon, record.getPermanentWeapon(), record.getCardFiringWeapon()));
+                }
+            }
+            else {
+                game.getGameState().sendMessage("Result for " + GameUtils.getCardLink(weapon) + ": Failed");
+            }
+        }
+        ca.markResolved();
     }
 
+    @Override
+    protected boolean wasActionCarriedOut() {
+        return true;
+    }
 }

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/FireWeaponsCombinedAction.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/FireWeaponsCombinedAction.java
@@ -37,8 +37,6 @@ import java.util.List;
  * After all destinies: if 2+ weapons completed, the player chooses which weapon result applies first.
  */
 public class FireWeaponsCombinedAction extends AbstractSubActionEffect {
-    private static final String CHOOSE_TARGETING_COMPUTER =
-            "Choose a Targeting Computer to fire this Combined Attack weapon twice, or click 'Done' to cancel";
 
     private final PhysicalCard _source;
     private final List<PhysicalCard> _weaponsInOrder;
@@ -104,7 +102,9 @@ public class FireWeaponsCombinedAction extends AbstractSubActionEffect {
                             final boolean[] usedTargetingComputer = new boolean[] { false };
                             subAction.appendEffect(
                                     new ChooseCardOnTableEffect(subAction, _source.getOwner(),
-                                            CHOOSE_TARGETING_COMPUTER, Filters.in(targetingComputers), 0) {
+                                            "Choose a Targeting Computer to fire " + GameUtils.getCardLink(weapon)
+                                                    + " twice, or click 'Done' to cancel",
+                                            Filters.in(targetingComputers), 0) {
                                         @Override
                                         protected void cardSelected(PhysicalCard chosen) {
                                             usedTargetingComputer[0] = true;

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/FireWeaponsCombinedAction.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/FireWeaponsCombinedAction.java
@@ -11,13 +11,12 @@ import com.gempukku.swccgo.game.SwccgGame;
 import com.gempukku.swccgo.game.state.CombinedAttackFiringState;
 import com.gempukku.swccgo.logic.GameUtils;
 import com.gempukku.swccgo.logic.actions.SubAction;
-import com.gempukku.swccgo.logic.decisions.MultipleChoiceAwaitingDecision;
 import com.gempukku.swccgo.logic.effects.ChooseArbitraryCardsEffect;
 import com.gempukku.swccgo.logic.effects.FireWeaponEffect;
 import com.gempukku.swccgo.logic.effects.HitCardEffect;
 import com.gempukku.swccgo.logic.effects.IonizeStarshipEffect;
 import com.gempukku.swccgo.logic.effects.LoseCardFromTableEffect;
-import com.gempukku.swccgo.logic.effects.PlayoutDecisionEffect;
+import com.gempukku.swccgo.logic.effects.choose.ChooseCardOnTableEffect;
 import com.gempukku.swccgo.logic.timing.AbstractSubActionEffect;
 import com.gempukku.swccgo.logic.timing.Action;
 import com.gempukku.swccgo.logic.timing.GuiUtils;
@@ -38,7 +37,8 @@ import java.util.List;
  * After all destinies: if 2+ weapons completed, the player chooses which weapon result applies first.
  */
 public class FireWeaponsCombinedAction extends AbstractSubActionEffect {
-    private static final String DO_NOT_USE_TARGETING_COMPUTER = "Do not use Targeting Computer";
+    private static final String CHOOSE_TARGETING_COMPUTER =
+            "Choose a Targeting Computer to fire this Combined Attack weapon twice, or click 'Done' to cancel";
 
     private final PhysicalCard _source;
     private final List<PhysicalCard> _weaponsInOrder;
@@ -96,44 +96,46 @@ public class FireWeaponsCombinedAction extends AbstractSubActionEffect {
                     protected void doPlayEffect(SwccgGame game) {
                         final List<PhysicalCard> targetingComputers = findUsableTargetingComputers(game, weapon);
                         if (!targetingComputers.isEmpty()) {
-                            // Optional: use a specific unused Targeting Computer, or use none.
+                            // Click a Targeting Computer card on that starship to use it, or Done to skip.
                             // Combined Attack already adds destinies together, so choosing a Targeting
                             // Computer always takes the combined path. No Separately / Combined / Don't Fire.
-                            List<String> options = new ArrayList<String>();
-                            for (PhysicalCard tc : targetingComputers) {
-                                options.add(GameUtils.getCardLink(tc));
-                            }
-                            options.add(DO_NOT_USE_TARGETING_COMPUTER);
+                            // Minimum 0 so Done skips this Targeting Computer choice only and does not
+                            // cancel Combined Attack or undo already-chosen weapons/target.
+                            final boolean[] usedTargetingComputer = new boolean[] { false };
                             subAction.appendEffect(
-                                    new PlayoutDecisionEffect(subAction, _source.getOwner(),
-                                            new MultipleChoiceAwaitingDecision(
-                                                    "Use Targeting Computer to fire this Combined Attack weapon twice?",
-                                                    options.toArray(new String[options.size()]), true) {
-                                                @Override
-                                                protected void validDecisionMade(int choiceIndex, String result) {
-                                                    if (result != null && result.startsWith("Do not use")) {
-                                                        subAction.appendEffect(createFireEffect(weapon, targetFilter, false));
-                                                        appendNextWeapon(subAction, game, index + 1);
-                                                        return;
+                                    new ChooseCardOnTableEffect(subAction, _source.getOwner(),
+                                            CHOOSE_TARGETING_COMPUTER, Filters.in(targetingComputers), 0) {
+                                        @Override
+                                        protected void cardSelected(PhysicalCard chosen) {
+                                            usedTargetingComputer[0] = true;
+                                            subAction.appendEffect(new UseDeviceEffect(subAction, chosen));
+                                            game.getGameState().beginSeparatelyOrCombinedFiring(chosen, weapon, true);
+                                            game.getGameState().sendMessage(_source.getOwner() + " uses " + GameUtils.getCardLink(chosen)
+                                                    + " to fire " + GameUtils.getCardLink(weapon) + " twice: combined");
+                                            subAction.appendEffect(createFireEffect(weapon, targetFilter, false));
+                                            subAction.appendEffect(createFireEffect(weapon, targetFilter, true));
+                                            subAction.appendEffect(
+                                                    new PassthruEffect(subAction) {
+                                                        @Override
+                                                        protected void doPlayEffect(SwccgGame game) {
+                                                            game.getGameState().finishSeparatelyOrCombinedFiring();
+                                                        }
                                                     }
-                                                    final PhysicalCard chosen = targetingComputers.get(choiceIndex);
-                                                    subAction.appendEffect(new UseDeviceEffect(subAction, chosen));
-                                                    game.getGameState().beginSeparatelyOrCombinedFiring(chosen, weapon, true);
-                                                    game.getGameState().sendMessage(_source.getOwner() + " uses " + GameUtils.getCardLink(chosen)
-                                                            + " to fire " + GameUtils.getCardLink(weapon) + " twice: combined");
-                                                    subAction.appendEffect(createFireEffect(weapon, targetFilter, false));
-                                                    subAction.appendEffect(createFireEffect(weapon, targetFilter, true));
-                                                    subAction.appendEffect(
-                                                            new PassthruEffect(subAction) {
-                                                                @Override
-                                                                protected void doPlayEffect(SwccgGame game) {
-                                                                    game.getGameState().finishSeparatelyOrCombinedFiring();
-                                                                }
-                                                            }
-                                                    );
-                                                    appendNextWeapon(subAction, game, index + 1);
-                                                }
-                                            })
+                                            );
+                                        }
+                                    }
+                            );
+                            subAction.appendEffect(
+                                    new PassthruEffect(subAction) {
+                                        @Override
+                                        protected void doPlayEffect(SwccgGame game) {
+                                            if (!usedTargetingComputer[0]) {
+                                                // Done: do not use Targeting Computer; fire this weapon once.
+                                                subAction.appendEffect(createFireEffect(weapon, targetFilter, false));
+                                            }
+                                            appendNextWeapon(subAction, game, index + 1);
+                                        }
+                                    }
                             );
                         }
                         else {

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/FireWeaponsCombinedAction.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/FireWeaponsCombinedAction.java
@@ -12,29 +12,30 @@ import com.gempukku.swccgo.game.state.CombinedAttackFiringState;
 import com.gempukku.swccgo.logic.GameUtils;
 import com.gempukku.swccgo.logic.actions.SubAction;
 import com.gempukku.swccgo.logic.decisions.YesNoDecision;
+import com.gempukku.swccgo.logic.effects.ChooseArbitraryCardsEffect;
 import com.gempukku.swccgo.logic.effects.FireWeaponEffect;
 import com.gempukku.swccgo.logic.effects.HitCardEffect;
 import com.gempukku.swccgo.logic.effects.IonizeStarshipEffect;
+import com.gempukku.swccgo.logic.effects.LoseCardFromTableEffect;
 import com.gempukku.swccgo.logic.effects.PlayoutDecisionEffect;
 import com.gempukku.swccgo.logic.timing.AbstractSubActionEffect;
 import com.gempukku.swccgo.logic.timing.Action;
 import com.gempukku.swccgo.logic.timing.GuiUtils;
 import com.gempukku.swccgo.logic.timing.PassthruEffect;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 /**
  * Combined Attack result: fire the chosen starship weapons one at a time at the shared target, collect destiny
- * DRAWS, then apply the added total separately for each weapon (AR per-weapon total modifiers).
- *
- * The old stub applied one combined total-modifier pass and reused that number for every weapon. That is weaker
- * than AR (Heavy Turbolaser -6 vs starfighter must apply only when resolving HT). This rewrite prefers AR:
- * shared draw-sum + each weapon's own total modifiers, applied after all fire (Gergall).
+ * DRAWS, then apply the added total separately for each weapon (AR per-weapon total modifiers) using each
+ * weapon's own destinyDraws path (X-wing Laser Cannon can lose the target; Ion Cannon ionizes; others hit).
  *
  * Pending option A: costs paid as each shot initiates; if a later weapon cannot pay, skip it; completed
  * destinies still combine and still get applied to the weapons that did fire.
+ *
+ * After all destinies: if 2+ weapons completed, the player chooses which weapon result applies first.
  */
 public class FireWeaponsCombinedAction extends AbstractSubActionEffect {
     private final PhysicalCard _source;
@@ -60,6 +61,8 @@ public class FireWeaponsCombinedAction extends AbstractSubActionEffect {
                 new PassthruEffect(subAction) {
                     @Override
                     protected void doPlayEffect(SwccgGame game) {
+                        game.getGameState().sendMessage(_source.getOwner() + " plays Combined Attack targeting "
+                                + GameUtils.getCardLink(_target) + " with " + GameUtils.getAppendedNames(_weaponsInOrder));
                         game.getGameState().beginCombinedAttackFiring(_source, _target, _weaponsInOrder);
                         appendNextWeapon(subAction, game, 0);
                     }
@@ -91,8 +94,6 @@ public class FireWeaponsCombinedAction extends AbstractSubActionEffect {
                     @Override
                     protected void doPlayEffect(SwccgGame game) {
                         if (targetingComputer != null) {
-                            // Both TC shots consecutive and both inside Combined Attack (forum p=1111897).
-                            // Cannot split one TC shot in CA and one outside.
                             subAction.appendEffect(
                                     new PlayoutDecisionEffect(subAction, _source.getOwner(),
                                             new YesNoDecision("Use " + GameUtils.getCardLink(targetingComputer)
@@ -155,8 +156,8 @@ public class FireWeaponsCombinedAction extends AbstractSubActionEffect {
     }
 
     /**
-     * After all fire: shared draw-sum applied separately per completed weapon, with that weapon's snapshotted
-     * total modifiers. Hits/ionize happen now, not during the individual destiny draws.
+     * After all fire: shared draw-sum applied separately per completed weapon via that weapon's own
+     * destinyDraws path. Player chooses apply order when 2+ weapons completed.
      */
     private void resolveCombinedAttack(Action action, SwccgGame game) {
         CombinedAttackFiringState ca = game.getGameState().getCombinedAttackFiringState();
@@ -169,27 +170,85 @@ public class FireWeaponsCombinedAction extends AbstractSubActionEffect {
         }
         float drawSum = ca.getDrawSum();
         game.getGameState().sendMessage(ca.getAddedDestiniesMessage(GuiUtils.formatAsString(drawSum)));
-        float defenseValue = game.getModifiersQuerying().getDefenseValue(game.getGameState(), target);
-        game.getGameState().sendMessage("Defense value: " + GuiUtils.formatAsString(defenseValue));
+        List<CombinedAttackFiringState.WeaponRecord> records =
+                new ArrayList<CombinedAttackFiringState.WeaponRecord>(ca.getCompletedWeaponRecordsInOrder());
+        ca.markResolved();
+        promptApplyOrder(action, game, records, drawSum, target);
+    }
 
-        for (CombinedAttackFiringState.WeaponRecord record : ca.getCompletedWeaponRecordsInOrder()) {
-            PhysicalCard weapon = record.getWeapon();
-            float total = Math.max(0, drawSum + record.getTotalModifierSnapshot());
-            game.getGameState().sendMessage(ca.getPerWeaponTotalMessage(weapon, GuiUtils.formatAsString(total)));
+    private void promptApplyOrder(final Action action, final SwccgGame game,
+                                  final List<CombinedAttackFiringState.WeaponRecord> remaining,
+                                  final float drawSum, final PhysicalCard target) {
+        if (remaining.isEmpty()) {
+            return;
+        }
+        if (remaining.size() == 1) {
+            applyWeaponRecord(action, game, remaining.get(0), drawSum, target);
+            return;
+        }
+        List<PhysicalCard> weapons = new ArrayList<PhysicalCard>();
+        for (CombinedAttackFiringState.WeaponRecord record : remaining) {
+            weapons.add(record.getWeapon());
+        }
+        action.appendEffect(
+                new ChooseArbitraryCardsEffect(action, _source.getOwner(),
+                        "Choose which weapon result applies first", weapons, 1, 1) {
+                    @Override
+                    protected void cardsSelected(SwccgGame game, Collection<PhysicalCard> selectedCards) {
+                        PhysicalCard chosen = selectedCards.iterator().next();
+                        CombinedAttackFiringState.WeaponRecord chosenRecord = null;
+                        List<CombinedAttackFiringState.WeaponRecord> leftover =
+                                new ArrayList<CombinedAttackFiringState.WeaponRecord>();
+                        for (CombinedAttackFiringState.WeaponRecord record : remaining) {
+                            if (chosenRecord == null && record.getWeapon().getCardId() == chosen.getCardId()) {
+                                chosenRecord = record;
+                            }
+                            else {
+                                leftover.add(record);
+                            }
+                        }
+                        if (chosenRecord != null) {
+                            applyWeaponRecord(action, game, chosenRecord, drawSum, target);
+                        }
+                        if (!leftover.isEmpty()) {
+                            promptApplyOrder(action, game, leftover, drawSum, target);
+                        }
+                    }
+                }
+        );
+    }
+
+    private void applyWeaponRecord(Action action, SwccgGame game, CombinedAttackFiringState.WeaponRecord record,
+                                   float drawSum, PhysicalCard target) {
+        PhysicalCard weapon = record.getWeapon();
+        float total = Math.max(0, drawSum + record.getTotalModifierSnapshot());
+        game.getGameState().sendMessage(CombinedAttackFiringState.getPerWeaponTotalMessage(
+                weapon, drawSum, record.getTotalModifierSnapshot(), total));
+        boolean queued = false;
+        if (record.getDrawDestinyEffect() != null) {
+            queued = record.getDrawDestinyEffect().applyDeferredWeaponResult(game, action, weapon,
+                    record.getCardFiringWeapon(), record.getPermanentWeapon(), target,
+                    record.getVariableXSnapshot(), total);
+        }
+        if (!queued) {
+            float defenseValue = game.getModifiersQuerying().getDefenseValue(game.getGameState(), target);
             if (total > defenseValue) {
-                game.getGameState().sendMessage("Result for " + GameUtils.getCardLink(weapon) + ": Succeeded");
+                game.getGameState().sendMessage("Result: Succeeded");
                 if (weapon.getBlueprint().hasKeyword(Keyword.ION_CANNON)) {
                     action.appendEffect(new IonizeStarshipEffect(action, target, weapon, false, true, true));
                 }
+                else if (record.getVariableXSnapshot() == 3f) {
+                    action.appendEffect(new LoseCardFromTableEffect(action, target));
+                }
                 else {
-                    action.appendEffect(new HitCardEffect(action, target, weapon, record.getPermanentWeapon(), record.getCardFiringWeapon()));
+                    action.appendEffect(new HitCardEffect(action, target, weapon,
+                            record.getPermanentWeapon(), record.getCardFiringWeapon()));
                 }
             }
             else {
-                game.getGameState().sendMessage("Result for " + GameUtils.getCardLink(weapon) + ": Failed");
+                game.getGameState().sendMessage("Result: Failed");
             }
         }
-        ca.markResolved();
     }
 
     @Override

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
@@ -215,7 +215,7 @@ public class Card1_039 extends AbstractDevice {
                 game.getGameState(), soc.getCardFiringWeapon(), weapon, null,
                 Collections.singletonList(target), combined);
         soc.markResolved();
-        game.getGameState().sendMessage("Combined total weapon destiny (completed firings only): " + GuiUtils.formatAsString(totalDestiny));
+        game.getGameState().sendMessage(soc.getCombinedTotalDestinyMessage(GuiUtils.formatAsString(totalDestiny)));
         float defenseValue = game.getModifiersQuerying().getDefenseValue(game.getGameState(), target);
         game.getGameState().sendMessage("Defense value: " + GuiUtils.formatAsString(defenseValue));
         if (totalDestiny > defenseValue) {

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
@@ -287,7 +287,7 @@ public class Card1_039 extends AbstractDevice {
         @Override
         protected FullEffectResult playEffectReturningResult(SwccgGame game) {
             game.getUserFeedback().sendAwaitingDecision(_playerId,
-                    new MultipleChoiceAwaitingDecision("Fire a weapon twice", new String[]{"Separately", "Combined", "Don't Fire (Cancel)"}) {
+                    new MultipleChoiceAwaitingDecision("Fire a weapon twice", new String[]{"Separately", "Combined", "Don't Fire (Cancel)"}, true) {
                         @Override
                         protected void validDecisionMade(int index, String result) {
                             modeChosen(result);

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
@@ -139,6 +139,17 @@ public class Card1_039 extends AbstractDevice {
                                             action.appendUsage(
                                                     new UseDeviceEffect(action, self));
                                             game.getGameState().beginSeparatelyOrCombinedFiring(self, weapon, combined);
+                                            // Always clear separately-or-combined firing when this action leaves the stack.
+                                            // Nested finish after shot 2 can be skipped if a required response (Defiance)
+                                            // completes the nested fire without running remaining parent effects.
+                                            action.appendAfterEffect(
+                                                    new PassthruEffect(action) {
+                                                        @Override
+                                                        protected void doPlayEffect(SwccgGame game) {
+                                                            game.getGameState().finishSeparatelyOrCombinedFiring();
+                                                        }
+                                                    }
+                                            );
                                             final String mode = result.toLowerCase();
                                             action.appendEffect(
                                                     new PassthruEffect(action) {

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
@@ -3,8 +3,8 @@ package com.gempukku.swccgo.cards.set1.light;
 import com.gempukku.swccgo.cards.AbstractDevice;
 import com.gempukku.swccgo.cards.GameConditions;
 import com.gempukku.swccgo.cards.effects.UseDeviceEffect;
-import com.gempukku.swccgo.cards.effects.usage.OncePerBattleEffect;
 import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.GameTextActionId;
 import com.gempukku.swccgo.common.PlayCardOptionId;
 import com.gempukku.swccgo.common.PlayCardZoneOption;
 import com.gempukku.swccgo.common.Rarity;
@@ -109,9 +109,12 @@ public class Card1_039 extends AbstractDevice {
                 Filters.attachedTo(Filters.and(Filters.hasAttached(self), Filters.participatingInBattle)),
                 Filters.canBeFired(self, 0, Filters.canBeTargetedBy(self)));
 
-        // Only usable during battle (forum p=1195641). Each copy is limited to one usage per battle (forum p=961994).
+        // Only usable during battle (forum p=1195641). Each copy is limited to one usage per turn
+        // (One Rule / Targeting Computer game text). OncePerBattle alone would re-offer the same copy
+        // in a later battle the same turn.
         if (GameConditions.isDuringBattle(game)
-                && GameConditions.isOncePerBattle(game, self, gameTextSourceCardId)
+                && GameConditions.isOncePerTurn(game, self, playerId, gameTextSourceCardId)
+                && GameConditions.isOncePerBattle(game, self, playerId, gameTextSourceCardId)
                 && GameConditions.canUseDevice(game, self)
                 && GameConditions.isDuringBattleWithParticipant(game, Filters.hasAttached(self))
                 && GameConditions.canSpot(game, self, weaponFilter)) {
@@ -119,7 +122,7 @@ public class Card1_039 extends AbstractDevice {
             final TopLevelGameTextAction action = new TopLevelGameTextAction(self, gameTextSourceCardId);
             action.setText("Fire a weapon twice");
             action.setActionMsg("use " + GameUtils.getCardLink(self) + " to fire a weapon twice");
-            // OncePerBattle / UseDevice wait until Separately or Combined so Don't Fire can abort unused.
+            // OncePerTurn / OncePerBattle / UseDevice wait until Separately or Combined so Don't Fire can abort unused.
             action.appendTargeting(
                     new ChooseCardOnTableEffect(action, playerId, "Choose weapon to fire twice", weaponFilter) {
                         @Override
@@ -139,9 +142,12 @@ public class Card1_039 extends AbstractDevice {
                                                 return;
                                             }
                                             final boolean combined = "Combined".equals(result);
-                                            action.appendUsage(
-                                                    new OncePerBattleEffect(action));
-                                            action.appendUsage(
+                                            // Increment here (not appendUsage): targeting has already started, so a
+                                            // usage-phase queue would never run OncePerTurn/OncePerBattle. Don't Fire
+                                            // returns before this, so cancel still leaves the copy unused.
+                                            game.getModifiersQuerying().getUntilEndOfTurnLimitCounter(self, playerId, gameTextSourceCardId, GameTextActionId.OTHER_CARD_ACTION_DEFAULT).incrementToLimit(1, 1);
+                                            game.getModifiersQuerying().getUntilEndOfBattleLimitCounter(self, playerId, gameTextSourceCardId, GameTextActionId.OTHER_CARD_ACTION_DEFAULT).incrementToLimit(1, 1);
+                                            action.appendEffect(
                                                     new UseDeviceEffect(action, self));
                                             game.getGameState().beginSeparatelyOrCombinedFiring(self, weapon, combined);
                                             // Clear separately-or-combined firing after shots, not at targeting-complete.

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
@@ -89,7 +89,12 @@ public class Card1_039 extends AbstractDevice {
             @Override
             public boolean isFulfilled(GameState gameState, ModifiersQuerying modifiersQuerying) {
                 SeparatelyOrCombinedFiringState soc = gameState.getSeparatelyOrCombinedFiringState();
-                return soc != null && soc.getDevice() != null && soc.getDevice().getCardId() == self.getCardId();
+                if (soc != null && soc.getDevice() != null && soc.getDevice().getCardId() == self.getCardId()) {
+                    return true;
+                }
+                // Fire-twice action can still be resolving if separately-or-combined state was cleared
+                // as soon as targeting completed. Keep -1 on both draws in that case.
+                return gameState.isDuringGameTextActionFrom(self);
             }
         };
         modifiers.add(new EachWeaponDestinyModifier(self, Filters.any, usingThisDeviceToFire, hasAttached, -1));
@@ -139,14 +144,19 @@ public class Card1_039 extends AbstractDevice {
                                             action.appendUsage(
                                                     new UseDeviceEffect(action, self));
                                             game.getGameState().beginSeparatelyOrCombinedFiring(self, weapon, combined);
-                                            // Always clear separately-or-combined firing when this action leaves the stack.
+                                            // Clear separately-or-combined firing after shots, not at targeting-complete.
                                             // Nested finish after shot 2 can be skipped if a required response (Defiance)
                                             // completes the nested fire without running remaining parent effects.
                                             action.appendAfterEffect(
                                                     new PassthruEffect(action) {
                                                         @Override
                                                         protected void doPlayEffect(SwccgGame game) {
-                                                            game.getGameState().finishSeparatelyOrCombinedFiring();
+                                                            // Do not clear at targeting-complete: destinies still need this state for -1.
+                                                            SeparatelyOrCombinedFiringState soc = game.getGameState().getSeparatelyOrCombinedFiringState();
+                                                            if (soc != null && soc.getCurrentFiringNumber() > 0
+                                                                    && !game.getGameState().isDuringWeaponFiring()) {
+                                                                game.getGameState().finishSeparatelyOrCombinedFiring();
+                                                            }
                                                         }
                                                     }
                                             );

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
@@ -11,16 +11,19 @@ import com.gempukku.swccgo.common.Rarity;
 import com.gempukku.swccgo.common.Side;
 import com.gempukku.swccgo.common.Title;
 import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.common.Keyword;
 import com.gempukku.swccgo.filters.Filter;
 import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.game.SwccgGame;
 import com.gempukku.swccgo.game.state.SeparatelyOrCombinedFiringState;
 import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.actions.FireWeaponAction;
 import com.gempukku.swccgo.logic.actions.TopLevelGameTextAction;
 import com.gempukku.swccgo.logic.decisions.MultipleChoiceAwaitingDecision;
 import com.gempukku.swccgo.logic.effects.FireWeaponEffect;
 import com.gempukku.swccgo.logic.effects.HitCardEffect;
+import com.gempukku.swccgo.logic.effects.IonizeStarshipEffect;
 import com.gempukku.swccgo.logic.effects.PlayoutDecisionEffect;
 import com.gempukku.swccgo.logic.effects.choose.ChooseCardOnTableEffect;
 import com.gempukku.swccgo.logic.modifiers.DefinedByGameTextDeployCostModifier;
@@ -131,8 +134,11 @@ public class Card1_039 extends AbstractDevice {
 
     /**
      * Fires the chosen weapon twice as sub-actions of this device action (no top-level action between shots).
-     * Pending rules: pay each firing's Force when that shot initiates. If the second shot cannot pay, the first
-     * still resolved when separately; when combined, completed firings still combine.
+     * Appendix B option A: Force is used for BOTH firings, but costs are paid as EACH shot initiates
+     * (not all upfront). After shot 1 completes, attempt shot 2; if the fire action cannot be built
+     * (typically remaining Force cannot pay that shot's cost), skip shot 2. Do not rewind shot 1 and
+     * do not fail the overall action. Combined: destinies from completed firings still combine, with
+     * total-modifiers applied once vs the single target.
      */
     private void appendFireTwice(final TopLevelGameTextAction action, final SwccgGame game, final PhysicalCard self,
                                  final PhysicalCard weapon, final boolean combined) {
@@ -145,6 +151,15 @@ public class Card1_039 extends AbstractDevice {
                         SeparatelyOrCombinedFiringState soc = game.getGameState().getSeparatelyOrCombinedFiringState();
                         if (combined && soc != null && soc.getCombinedTarget() != null) {
                             secondTargetFilter = Filters.sameCardId(soc.getCombinedTarget());
+                        }
+                        // Same check FireWeaponEffect uses: builder returns null when this shot cannot initiate.
+                        // Nested FireWeaponEffect already no-ops in that case (does not abort the parent);
+                        // skip appending shot 2 so combined can resolve from completed firings only.
+                        if (!canInitiateSocShot(game, self, weapon, secondTargetFilter)) {
+                            game.getGameState().sendMessage("Second firing does not initiate (cannot pay fire cost). Completed firings still count.");
+                            resolveCombinedIfStillPending(action, game, weapon);
+                            game.getGameState().finishSeparatelyOrCombinedFiring();
+                            return;
                         }
                         action.appendEffect(createFireTwiceShotEffect(action, weapon, secondTargetFilter));
                         action.appendEffect(
@@ -159,6 +174,17 @@ public class Card1_039 extends AbstractDevice {
                     }
                 }
         );
+    }
+
+    /**
+     * True if the weapon can currently begin a fire-weapon action for this SOC shot
+     * (Force remaining, legal target, per-battle limit ignored).
+     */
+    private boolean canInitiateSocShot(SwccgGame game, PhysicalCard self, PhysicalCard weapon, Filter fireAtTargetFilter) {
+        FireWeaponAction fireWeaponAction = weapon.getBlueprint().getFireWeaponAction(
+                weapon.getOwner(), game, weapon, false, 0, self, false,
+                Filters.none, null, fireAtTargetFilter, true);
+        return fireWeaponAction != null;
     }
 
     private FireWeaponEffect createFireTwiceShotEffect(Action action, PhysicalCard weapon, Filter fireAtTargetFilter) {
@@ -194,7 +220,13 @@ public class Card1_039 extends AbstractDevice {
         game.getGameState().sendMessage("Defense value: " + GuiUtils.formatAsString(defenseValue));
         if (totalDestiny > defenseValue) {
             game.getGameState().sendMessage("Result: Succeeded");
-            action.appendEffect(new HitCardEffect(action, target, weapon));
+            // Apply the weapon's actual result (Ion Cannon ionizes; most starship weapons hit).
+            if (weapon.getBlueprint().hasKeyword(Keyword.ION_CANNON)) {
+                action.appendEffect(new IonizeStarshipEffect(action, target, weapon, false, true, true));
+            }
+            else {
+                action.appendEffect(new HitCardEffect(action, target, weapon));
+            }
         }
         else {
             game.getGameState().sendMessage("Result: Failed");

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
@@ -24,15 +24,16 @@ import com.gempukku.swccgo.logic.decisions.MultipleChoiceAwaitingDecision;
 import com.gempukku.swccgo.logic.effects.FireWeaponEffect;
 import com.gempukku.swccgo.logic.effects.HitCardEffect;
 import com.gempukku.swccgo.logic.effects.IonizeStarshipEffect;
-import com.gempukku.swccgo.logic.effects.PlayoutDecisionEffect;
 import com.gempukku.swccgo.logic.effects.choose.ChooseCardOnTableEffect;
 import com.gempukku.swccgo.logic.modifiers.DefinedByGameTextDeployCostModifier;
 import com.gempukku.swccgo.logic.modifiers.EachWeaponDestinyModifier;
 import com.gempukku.swccgo.logic.modifiers.ManeuverModifier;
 import com.gempukku.swccgo.logic.modifiers.Modifier;
+import com.gempukku.swccgo.logic.timing.AbstractStandardEffect;
 import com.gempukku.swccgo.logic.timing.Action;
 import com.gempukku.swccgo.logic.timing.GuiUtils;
 import com.gempukku.swccgo.logic.timing.PassthruEffect;
+import com.gempukku.swccgo.logic.timing.TargetingEffect;
 
 import java.util.Collections;
 import java.util.LinkedList;
@@ -101,28 +102,45 @@ public class Card1_039 extends AbstractDevice {
 
             final TopLevelGameTextAction action = new TopLevelGameTextAction(self, gameTextSourceCardId);
             action.setText("Fire a weapon twice");
-            action.setActionMsg("Use " + GameUtils.getCardLink(self) + " to fire a weapon twice, separately or combined");
-            action.appendUsage(
-                    new OncePerBattleEffect(action));
-            action.appendUsage(
-                    new UseDeviceEffect(action, self));
-            action.appendEffect(
+            action.setActionMsg("use " + GameUtils.getCardLink(self) + " to fire a weapon twice");
+            // OncePerBattle / UseDevice wait until Separately or Combined so Don't Fire can abort unused.
+            action.appendTargeting(
                     new ChooseCardOnTableEffect(action, playerId, "Choose weapon to fire twice", weaponFilter) {
                         @Override
+                        protected boolean getUseShortcut() {
+                            // Auto-select the only legal weapon even though top-level actions allow abort.
+                            return true;
+                        }
+                        @Override
                         protected void cardSelected(final PhysicalCard weapon) {
-                            action.appendEffect(
-                                    new PlayoutDecisionEffect(action, playerId,
-                                            new MultipleChoiceAwaitingDecision("Fire twice separately or combined?", new String[]{"Separately", "Combined"}) {
-                                                @Override
-                                                protected void validDecisionMade(int index, String result) {
-                                                    final boolean combined = "Combined".equals(result);
-                                                    game.getGameState().beginSeparatelyOrCombinedFiring(self, weapon, combined);
-                                                    game.getGameState().sendMessage(playerId + " uses " + GameUtils.getCardLink(self)
-                                                            + " to fire " + GameUtils.getCardLink(weapon) + " twice " + result);
-                                                    appendFireTwice(action, game, self, weapon, combined);
-                                                }
+                            action.appendTargeting(
+                                    new FireTwiceModeEffect(action, playerId) {
+                                        @Override
+                                        protected void modeChosen(String result) {
+                                            if (result != null && result.startsWith("Don't Fire")) {
+                                                action.setActionMsg(null);
+                                                cancel();
+                                                return;
                                             }
-                                    )
+                                            final boolean combined = "Combined".equals(result);
+                                            action.appendUsage(
+                                                    new OncePerBattleEffect(action));
+                                            action.appendUsage(
+                                                    new UseDeviceEffect(action, self));
+                                            game.getGameState().beginSeparatelyOrCombinedFiring(self, weapon, combined);
+                                            final String mode = result.toLowerCase();
+                                            action.appendEffect(
+                                                    new PassthruEffect(action) {
+                                                        @Override
+                                                        protected void doPlayEffect(SwccgGame game) {
+                                                            game.getGameState().sendMessage(playerId + " uses " + GameUtils.getCardLink(self)
+                                                                    + " to fire " + GameUtils.getCardLink(weapon) + " twice: " + mode);
+                                                        }
+                                                    }
+                                            );
+                                            appendFireTwice(action, game, self, weapon, combined);
+                                        }
+                                    }
                             );
                         }
                     }
@@ -234,6 +252,48 @@ public class Card1_039 extends AbstractDevice {
         }
         else {
             game.getGameState().sendMessage("Result: Failed");
+        }
+    }
+
+    /**
+     * Targeting decision for Separately / Combined / Don't Fire.
+     * Don't Fire fails this cost so the parent action aborts unused (same as clicking Done).
+     */
+    private abstract static class FireTwiceModeEffect extends AbstractStandardEffect implements TargetingEffect {
+        private final String _playerId;
+        private boolean _cancelled;
+
+        private FireTwiceModeEffect(Action action, String playerId) {
+            super(action);
+            _playerId = playerId;
+        }
+
+        protected void cancel() {
+            _cancelled = true;
+        }
+
+        protected abstract void modeChosen(String result);
+
+        @Override
+        public boolean isPlayableInFull(SwccgGame game) {
+            return true;
+        }
+
+        @Override
+        public boolean wasCarriedOut() {
+            return super.wasCarriedOut() && !_cancelled;
+        }
+
+        @Override
+        protected FullEffectResult playEffectReturningResult(SwccgGame game) {
+            game.getUserFeedback().sendAwaitingDecision(_playerId,
+                    new MultipleChoiceAwaitingDecision("Fire a weapon twice", new String[]{"Separately", "Combined", "Don't Fire (Cancel)"}) {
+                        @Override
+                        protected void validDecisionMade(int index, String result) {
+                            modeChosen(result);
+                        }
+                    });
+            return new FullEffectResult(true);
         }
     }
 }

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
@@ -16,7 +16,10 @@ import com.gempukku.swccgo.filters.Filter;
 import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.game.state.GameState;
 import com.gempukku.swccgo.game.state.SeparatelyOrCombinedFiringState;
+import com.gempukku.swccgo.logic.conditions.Condition;
+import com.gempukku.swccgo.logic.modifiers.querying.ModifiersQuerying;
 import com.gempukku.swccgo.logic.GameUtils;
 import com.gempukku.swccgo.logic.actions.FireWeaponAction;
 import com.gempukku.swccgo.logic.actions.TopLevelGameTextAction;
@@ -80,8 +83,16 @@ public class Card1_039 extends AbstractDevice {
 
         List<Modifier> modifiers = new LinkedList<Modifier>();
         modifiers.add(new ManeuverModifier(self, hasAttached, 1));
-        // Continuous: -1 from each destiny draw when this starship fires, including fire-twice usage.
-        modifiers.add(new EachWeaponDestinyModifier(self, Filters.any, hasAttached, -1));
+        // Subtract 1 from each destiny draw only while this copy is used to fire a weapon twice.
+        // Attached but unused Targeting Computer does not modify ordinary weapon fire.
+        Condition usingThisDeviceToFire = new Condition() {
+            @Override
+            public boolean isFulfilled(GameState gameState, ModifiersQuerying modifiersQuerying) {
+                SeparatelyOrCombinedFiringState soc = gameState.getSeparatelyOrCombinedFiringState();
+                return soc != null && soc.getDevice() != null && soc.getDevice().getCardId() == self.getCardId();
+            }
+        };
+        modifiers.add(new EachWeaponDestinyModifier(self, Filters.any, usingThisDeviceToFire, hasAttached, -1));
         return modifiers;
     }
 

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
@@ -118,7 +118,7 @@ public class Card1_039 extends AbstractDevice {
                                                     final boolean combined = "Combined".equals(result);
                                                     game.getGameState().beginSeparatelyOrCombinedFiring(self, weapon, combined);
                                                     game.getGameState().sendMessage(playerId + " uses " + GameUtils.getCardLink(self)
-                                                            + " to fire " + GameUtils.getCardLink(weapon) + " twice " + result.toLowerCase());
+                                                            + " to fire " + GameUtils.getCardLink(weapon) + " twice " + result);
                                                     appendFireTwice(action, game, self, weapon, combined);
                                                 }
                                             }
@@ -215,12 +215,16 @@ public class Card1_039 extends AbstractDevice {
                 game.getGameState(), soc.getCardFiringWeapon(), weapon, null,
                 Collections.singletonList(target), combined);
         soc.markResolved();
-        game.getGameState().sendMessage(soc.getCombinedTotalDestinyMessage(GuiUtils.formatAsString(totalDestiny)));
         float defenseValue = game.getModifiersQuerying().getDefenseValue(game.getGameState(), target);
-        game.getGameState().sendMessage("Defense value: " + GuiUtils.formatAsString(defenseValue));
-        if (totalDestiny > defenseValue) {
+        game.getGameState().sendMessage(soc.getCombinedDestiniesMathMessage(
+                GuiUtils.formatAsString(combined), GuiUtils.formatAsString(totalDestiny),
+                GuiUtils.formatAsString(defenseValue)));
+        if (soc.getDrawDestinyEffect() != null) {
+            soc.getDrawDestinyEffect().applyDeferredWeaponResult(game, action, weapon,
+                    soc.getCardFiringWeapon(), null, target, soc.getVariableXSnapshot(), totalDestiny);
+        }
+        else if (totalDestiny > defenseValue) {
             game.getGameState().sendMessage("Result: Succeeded");
-            // Apply the weapon's actual result (Ion Cannon ionizes; most starship weapons hit).
             if (weapon.getBlueprint().hasKeyword(Keyword.ION_CANNON)) {
                 action.appendEffect(new IonizeStarshipEffect(action, target, weapon, false, true, true));
             }

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_039.java
@@ -1,0 +1,203 @@
+package com.gempukku.swccgo.cards.set1.light;
+
+import com.gempukku.swccgo.cards.AbstractDevice;
+import com.gempukku.swccgo.cards.GameConditions;
+import com.gempukku.swccgo.cards.effects.UseDeviceEffect;
+import com.gempukku.swccgo.cards.effects.usage.OncePerBattleEffect;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.PlayCardOptionId;
+import com.gempukku.swccgo.common.PlayCardZoneOption;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.filters.Filter;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.game.state.SeparatelyOrCombinedFiringState;
+import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.actions.TopLevelGameTextAction;
+import com.gempukku.swccgo.logic.decisions.MultipleChoiceAwaitingDecision;
+import com.gempukku.swccgo.logic.effects.FireWeaponEffect;
+import com.gempukku.swccgo.logic.effects.HitCardEffect;
+import com.gempukku.swccgo.logic.effects.PlayoutDecisionEffect;
+import com.gempukku.swccgo.logic.effects.choose.ChooseCardOnTableEffect;
+import com.gempukku.swccgo.logic.modifiers.DefinedByGameTextDeployCostModifier;
+import com.gempukku.swccgo.logic.modifiers.EachWeaponDestinyModifier;
+import com.gempukku.swccgo.logic.modifiers.ManeuverModifier;
+import com.gempukku.swccgo.logic.modifiers.Modifier;
+import com.gempukku.swccgo.logic.timing.Action;
+import com.gempukku.swccgo.logic.timing.GuiUtils;
+import com.gempukku.swccgo.logic.timing.PassthruEffect;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Set: Premiere
+ * Type: Device
+ * Title: Targeting Computer
+ */
+public class Card1_039 extends AbstractDevice {
+    public Card1_039() {
+        super(Side.LIGHT, 3, PlayCardZoneOption.ATTACHED, Title.Targeting_Computer, Uniqueness.UNRESTRICTED, ExpansionSet.PREMIERE, Rarity.U1);
+        setLore("Specially designed for use on Rebel starfighters. Assists pilots on torpedo runs. Automatically locks on pre-programmed target points.");
+        setGameText("Use 2 Force to deploy on any starship. Adds 1 to starship's maneuver. If this starship is using a weapon during a battle, you may fire that weapon twice, separately or combined. Subtract 1 from each destiny draw when firing.");
+    }
+
+    @Override
+    protected List<Modifier> getGameTextAlwaysOnModifiers(SwccgGame game, final PhysicalCard self) {
+        List<Modifier> modifiers = new LinkedList<Modifier>();
+        modifiers.add(new DefinedByGameTextDeployCostModifier(self, 2));
+        return modifiers;
+    }
+
+    @Override
+    protected Filter getGameTextValidDeployTargetFilter(SwccgGame game, PhysicalCard self, PlayCardOptionId playCardOptionId, boolean asReact) {
+        // "any starship" = any of your starships (fighter or capital), not opponent's
+        return Filters.and(Filters.your(self), Filters.starship);
+    }
+
+    @Override
+    protected Filter getGameTextValidToUseDeviceFilter(final SwccgGame game, final PhysicalCard self) {
+        return Filters.starship;
+    }
+
+    @Override
+    protected Filter getGameTextValidTargetFilterToRemainAttachedTo(final SwccgGame game, final PhysicalCard self) {
+        return Filters.starship;
+    }
+
+    @Override
+    protected List<Modifier> getGameTextWhileActiveInPlayModifiers(SwccgGame game, final PhysicalCard self) {
+        Filter hasAttached = Filters.hasAttached(self);
+
+        List<Modifier> modifiers = new LinkedList<Modifier>();
+        modifiers.add(new ManeuverModifier(self, hasAttached, 1));
+        // Continuous: -1 from each destiny draw when this starship fires, including fire-twice usage.
+        modifiers.add(new EachWeaponDestinyModifier(self, Filters.any, hasAttached, -1));
+        return modifiers;
+    }
+
+    @Override
+    protected List<TopLevelGameTextAction> getGameTextTopLevelActions(final String playerId, final SwccgGame game, final PhysicalCard self, int gameTextSourceCardId) {
+        final Filter weaponFilter = Filters.and(
+                Filters.your(self),
+                Filters.weapon,
+                Filters.attachedTo(Filters.and(Filters.hasAttached(self), Filters.participatingInBattle)),
+                Filters.canBeFired(self, 0, Filters.canBeTargetedBy(self)));
+
+        // Only usable during battle (forum p=1195641). Each copy is limited to one usage per battle (forum p=961994).
+        if (GameConditions.isDuringBattle(game)
+                && GameConditions.isOncePerBattle(game, self, gameTextSourceCardId)
+                && GameConditions.canUseDevice(game, self)
+                && GameConditions.isDuringBattleWithParticipant(game, Filters.hasAttached(self))
+                && GameConditions.canSpot(game, self, weaponFilter)) {
+
+            final TopLevelGameTextAction action = new TopLevelGameTextAction(self, gameTextSourceCardId);
+            action.setText("Fire a weapon twice");
+            action.setActionMsg("Use " + GameUtils.getCardLink(self) + " to fire a weapon twice, separately or combined");
+            action.appendUsage(
+                    new OncePerBattleEffect(action));
+            action.appendUsage(
+                    new UseDeviceEffect(action, self));
+            action.appendEffect(
+                    new ChooseCardOnTableEffect(action, playerId, "Choose weapon to fire twice", weaponFilter) {
+                        @Override
+                        protected void cardSelected(final PhysicalCard weapon) {
+                            action.appendEffect(
+                                    new PlayoutDecisionEffect(action, playerId,
+                                            new MultipleChoiceAwaitingDecision("Fire twice separately or combined?", new String[]{"Separately", "Combined"}) {
+                                                @Override
+                                                protected void validDecisionMade(int index, String result) {
+                                                    final boolean combined = "Combined".equals(result);
+                                                    game.getGameState().beginSeparatelyOrCombinedFiring(self, weapon, combined);
+                                                    game.getGameState().sendMessage(playerId + " uses " + GameUtils.getCardLink(self)
+                                                            + " to fire " + GameUtils.getCardLink(weapon) + " twice " + result.toLowerCase());
+                                                    appendFireTwice(action, game, self, weapon, combined);
+                                                }
+                                            }
+                                    )
+                            );
+                        }
+                    }
+            );
+            return Collections.singletonList(action);
+        }
+        return null;
+    }
+
+    /**
+     * Fires the chosen weapon twice as sub-actions of this device action (no top-level action between shots).
+     * Pending rules: pay each firing's Force when that shot initiates. If the second shot cannot pay, the first
+     * still resolved when separately; when combined, completed firings still combine.
+     */
+    private void appendFireTwice(final TopLevelGameTextAction action, final SwccgGame game, final PhysicalCard self,
+                                 final PhysicalCard weapon, final boolean combined) {
+        action.appendEffect(createFireTwiceShotEffect(action, weapon, Filters.any));
+        action.appendEffect(
+                new PassthruEffect(action) {
+                    @Override
+                    protected void doPlayEffect(SwccgGame game) {
+                        Filter secondTargetFilter = Filters.any;
+                        SeparatelyOrCombinedFiringState soc = game.getGameState().getSeparatelyOrCombinedFiringState();
+                        if (combined && soc != null && soc.getCombinedTarget() != null) {
+                            secondTargetFilter = Filters.sameCardId(soc.getCombinedTarget());
+                        }
+                        action.appendEffect(createFireTwiceShotEffect(action, weapon, secondTargetFilter));
+                        action.appendEffect(
+                                new PassthruEffect(action) {
+                                    @Override
+                                    protected void doPlayEffect(SwccgGame game) {
+                                        resolveCombinedIfStillPending(action, game, weapon);
+                                        game.getGameState().finishSeparatelyOrCombinedFiring();
+                                    }
+                                }
+                        );
+                    }
+                }
+        );
+    }
+
+    private FireWeaponEffect createFireTwiceShotEffect(Action action, PhysicalCard weapon, Filter fireAtTargetFilter) {
+        return new FireWeaponEffect(action, weapon, false, fireAtTargetFilter) {
+            @Override
+            protected boolean isignorePerAttackOrBattleLimit() {
+                // Second shot of the same overall action must ignore the weapon's once-per-battle firing.
+                return true;
+            }
+        };
+    }
+
+    /**
+     * If combined firing stored destinies but never resolved (second shot unpaid/canceled), apply total modifiers
+     * once to the completed firings and resolve against the stored target.
+     */
+    private void resolveCombinedIfStillPending(Action action, SwccgGame game, PhysicalCard weapon) {
+        SeparatelyOrCombinedFiringState soc = game.getGameState().getSeparatelyOrCombinedFiringState();
+        if (soc == null || !soc.isCombined() || soc.isResolved() || soc.getCompletedFiringCount() == 0) {
+            return;
+        }
+        PhysicalCard target = soc.getCombinedTarget();
+        if (target == null) {
+            return;
+        }
+        float combined = soc.getCombinedFiringDestinySum();
+        float totalDestiny = game.getModifiersQuerying().getTotalWeaponDestiny(
+                game.getGameState(), soc.getCardFiringWeapon(), weapon, null,
+                Collections.singletonList(target), combined);
+        soc.markResolved();
+        game.getGameState().sendMessage("Combined total weapon destiny (completed firings only): " + GuiUtils.formatAsString(totalDestiny));
+        float defenseValue = game.getModifiersQuerying().getDefenseValue(game.getGameState(), target);
+        game.getGameState().sendMessage("Defense value: " + GuiUtils.formatAsString(defenseValue));
+        if (totalDestiny > defenseValue) {
+            game.getGameState().sendMessage("Result: Succeeded");
+            action.appendEffect(new HitCardEffect(action, target, weapon));
+        }
+        else {
+            game.getGameState().sendMessage("Result: Failed");
+        }
+    }
+}

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_075.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_075.java
@@ -72,7 +72,7 @@ public class Card1_075 extends AbstractLostInterrupt {
                         final Filter weaponFilter = getStarshipWeaponFilter(self, targetedStarship);
                         action.appendTargeting(
                                 new ChooseCardsOnTableEffect(action, playerId,
-                                        "Choose two or more starship weapons (selection order is fire/apply order)",
+                                        "Choose two or more starship weapons",
                                         2, Integer.MAX_VALUE, weaponFilter) {
                                     @Override
                                     protected void cardsSelected(final Collection<PhysicalCard> selectedWeapons) {

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_075.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_075.java
@@ -1,0 +1,135 @@
+package com.gempukku.swccgo.cards.set1.light;
+
+import com.gempukku.swccgo.cards.AbstractLostInterrupt;
+import com.gempukku.swccgo.cards.GameConditions;
+import com.gempukku.swccgo.cards.actions.FireWeaponsCombinedAction;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.filters.Filter;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.actions.PlayInterruptAction;
+import com.gempukku.swccgo.logic.effects.RespondablePlayCardEffect;
+import com.gempukku.swccgo.logic.effects.TargetCardOnTableEffect;
+import com.gempukku.swccgo.logic.effects.choose.ChooseCardsOnTableEffect;
+import com.gempukku.swccgo.logic.timing.Action;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Set: Premiere
+ * Type: Interrupt
+ * Subtype: Lost
+ * Title: Combined Attack
+ */
+public class Card1_075 extends AbstractLostInterrupt {
+    public Card1_075() {
+        super(Side.LIGHT, 4, Title.Combined_Attack, Uniqueness.UNRESTRICTED, ExpansionSet.PREMIERE, Rarity.C2);
+        setLore("Efficient cooperation allowed the Rebels to coordinate the attack of their small starfighters effectively at the Battle of Yavin.");
+        setGameText("During a battle, target opponent's starship present with two (or more) of your starship weapons. Add all weapon destiny draws together. Apply that total separately for each weapon in an order of your choosing.");
+    }
+
+    @Override
+    protected List<PlayInterruptAction> getGameTextTopLevelActions(final String playerId, final SwccgGame game, final PhysicalCard self) {
+        // Weapons segment / default during-battle (AR ~line 3717), not only at battle initiation.
+        if (!GameConditions.isDuringBattle(game)) {
+            return null;
+        }
+
+        final Filter starshipFilter = Filters.and(
+                Filters.opponents(self),
+                Filters.starship,
+                Filters.presentInBattle,
+                new Filter() {
+                    @Override
+                    public boolean accepts(com.gempukku.swccgo.game.state.GameState gameState,
+                                          com.gempukku.swccgo.logic.modifiers.querying.ModifiersQuerying modifiersQuerying,
+                                          PhysicalCard physicalCard) {
+                        return Filters.filterActive(game, self, getStarshipWeaponFilter(self, physicalCard)).size() >= 2;
+                    }
+                });
+
+        if (!GameConditions.canTarget(game, self, starshipFilter)) {
+            return null;
+        }
+
+        final PlayInterruptAction action = new PlayInterruptAction(game, self);
+        action.setText("Combine starship weapon firings");
+        // Initiation: target 2+ eligible weapons + one starship. Interrupt itself has no Force cost;
+        // each weapon pays its own fire cost as that shot initiates (Gergall / pending option A).
+        action.appendTargeting(
+                new TargetCardOnTableEffect(action, playerId, "Choose opponent's starship", starshipFilter) {
+                    @Override
+                    protected void cardTargeted(final int targetGroupId, final PhysicalCard targetedStarship) {
+                        final Filter weaponFilter = getStarshipWeaponFilter(self, targetedStarship);
+                        action.appendTargeting(
+                                new ChooseCardsOnTableEffect(action, playerId,
+                                        "Choose two or more starship weapons (selection order is fire/apply order)",
+                                        2, Integer.MAX_VALUE, weaponFilter) {
+                                    @Override
+                                    protected void cardsSelected(final Collection<PhysicalCard> selectedWeapons) {
+                                        action.addAnimationGroup(targetedStarship);
+                                        action.addAnimationGroup(selectedWeapons);
+                                        // Responses (Sense, Boring Conversation Anyway, etc.). If canceled,
+                                        // weapons have not fired and may still fire normally.
+                                        action.allowResponses("Combine weapon firings at " + GameUtils.getCardLink(targetedStarship),
+                                                new RespondablePlayCardEffect(action) {
+                                                    @Override
+                                                    protected void performActionResults(Action targetingAction) {
+                                                        PhysicalCard finalTarget = targetingAction.getPrimaryTargetCard(targetGroupId);
+                                                        if (finalTarget == null) {
+                                                            finalTarget = targetedStarship;
+                                                        }
+                                                        List<PhysicalCard> weaponsInOrder = new ArrayList<PhysicalCard>(selectedWeapons);
+                                                        action.appendEffect(
+                                                                new FireWeaponsCombinedAction(action, self, weaponsInOrder, finalTarget));
+                                                    }
+                                                }
+                                        );
+                                    }
+                                }
+                        );
+                    }
+                }
+        );
+        return Collections.singletonList(action);
+    }
+
+    /**
+     * Your starship weapons (including permanent weapons on your starships) that can currently fire at the target.
+     */
+    static Filter getStarshipWeaponFilter(final PhysicalCard source, final PhysicalCard target) {
+        final Filter targetFilter = Filters.sameCardId(target);
+        return Filters.and(
+                Filters.your(source),
+                Filters.or(
+                        Filters.and(Filters.starship_weapon, Filters.canBeFiredAt(source, targetFilter, 0)),
+                        new Filter() {
+                            @Override
+                            public boolean accepts(com.gempukku.swccgo.game.state.GameState gameState,
+                                                  com.gempukku.swccgo.logic.modifiers.querying.ModifiersQuerying modifiersQuerying,
+                                                  PhysicalCard physicalCard) {
+                                // Permanent starship weapons live on the starship card (not CardCategory.WEAPON).
+                                if (!Filters.starship.accepts(gameState, modifiersQuerying, physicalCard)) {
+                                    return false;
+                                }
+                                if (physicalCard.getBlueprint().getPermanentWeapon(physicalCard) == null) {
+                                    return false;
+                                }
+                                return physicalCard.getBlueprint().getFireWeaponAction(
+                                        physicalCard.getOwner(), gameState.getGame(), physicalCard, false, 0, source,
+                                        false, Filters.none, null, targetFilter, false) != null;
+                            }
+                        }
+                )
+        );
+    }
+}

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/CombinedAttackFiringState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/CombinedAttackFiringState.java
@@ -1,0 +1,153 @@
+package com.gempukku.swccgo.game.state;
+
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgBuiltInCardBlueprint;
+import com.gempukku.swccgo.logic.GameUtils;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tracks Premiere Combined Attack (1_75) while two or more starship weapons fire as one interrupt action.
+ *
+ * AR 2023 Appendix A: add all weapon destiny DRAWS together, then apply that shared draw-sum separately
+ * for each participating weapon (each weapon brings its own total-weapon-destiny modifiers).
+ * Results (hit / ionize) are applied only after all participating weapons have fired (Gergall / forum t=58557).
+ *
+ * This is NOT Targeting Computer fire-twice. When Targeting Computer is used inside Combined Attack,
+ * those extra destinies are additional draws in this pool; the TC weapon is still one weapon when applying.
+ */
+public class CombinedAttackFiringState {
+    private final PhysicalCard _source;
+    private final PhysicalCard _target;
+    private final List<PhysicalCard> _weaponsInOrder;
+    private final List<Float> _destinyDraws = new ArrayList<Float>();
+    private final Map<Integer, WeaponRecord> _recordsByWeaponId = new LinkedHashMap<Integer, WeaponRecord>();
+    private boolean _resolved;
+
+    public CombinedAttackFiringState(PhysicalCard source, PhysicalCard target, List<PhysicalCard> weaponsInOrder) {
+        _source = source;
+        _target = target;
+        _weaponsInOrder = new ArrayList<PhysicalCard>(weaponsInOrder);
+    }
+
+    public PhysicalCard getSource() {
+        return _source;
+    }
+
+    public PhysicalCard getTarget() {
+        return _target;
+    }
+
+    public List<PhysicalCard> getWeaponsInOrder() {
+        return _weaponsInOrder;
+    }
+
+    /**
+     * Record one weapon-destiny firing (draw modifiers only). Snapshot that weapon's total-modifier
+     * contribution now, while the weapon is still in play / WeaponFiringState is active (Intruder Missile
+     * is placed in Used Pile after firing, which would otherwise drop its +3).
+     */
+    public void addFiring(PhysicalCard weapon, PhysicalCard cardFiringWeapon,
+                          SwccgBuiltInCardBlueprint permanentWeapon, float drawModifiedDestiny,
+                          float totalModifierSnapshot) {
+        if (weapon == null) {
+            return;
+        }
+        _destinyDraws.add(drawModifiedDestiny);
+        int id = weapon.getCardId();
+        WeaponRecord record = _recordsByWeaponId.get(id);
+        if (record == null) {
+            record = new WeaponRecord(weapon, cardFiringWeapon, permanentWeapon);
+            _recordsByWeaponId.put(id, record);
+        }
+        record._drawCount++;
+        record._totalModifierSnapshot = totalModifierSnapshot;
+        record._cardFiringWeapon = cardFiringWeapon != null ? cardFiringWeapon : record._cardFiringWeapon;
+        record._permanentWeapon = permanentWeapon != null ? permanentWeapon : record._permanentWeapon;
+    }
+
+    public int getCompletedDrawCount() {
+        return _destinyDraws.size();
+    }
+
+    public float getDrawSum() {
+        float total = 0f;
+        for (Float value : _destinyDraws) {
+            if (value != null) {
+                total += value;
+            }
+        }
+        return total;
+    }
+
+    public List<WeaponRecord> getCompletedWeaponRecordsInOrder() {
+        List<WeaponRecord> ordered = new ArrayList<WeaponRecord>();
+        for (PhysicalCard weapon : _weaponsInOrder) {
+            WeaponRecord record = _recordsByWeaponId.get(weapon.getCardId());
+            if (record != null) {
+                ordered.add(record);
+            }
+        }
+        // Include any completed weapon that was not in the original list (should not happen).
+        for (WeaponRecord record : _recordsByWeaponId.values()) {
+            if (!ordered.contains(record)) {
+                ordered.add(record);
+            }
+        }
+        return ordered;
+    }
+
+    public String getAddedDestiniesMessage(String drawSumFormatted) {
+        return "Combined Attack destinies added together: " + drawSumFormatted
+                + " (" + _destinyDraws.size() + " weapon destin" + (_destinyDraws.size() == 1 ? "y" : "ies") + ")";
+    }
+
+    public String getPerWeaponTotalMessage(PhysicalCard weapon, String totalFormatted) {
+        return "Combined Attack total for " + GameUtils.getCardLink(weapon) + ": " + totalFormatted;
+    }
+
+    public void markResolved() {
+        _resolved = true;
+    }
+
+    public boolean isResolved() {
+        return _resolved;
+    }
+
+    public static class WeaponRecord {
+        private final PhysicalCard _weapon;
+        private PhysicalCard _cardFiringWeapon;
+        private SwccgBuiltInCardBlueprint _permanentWeapon;
+        private int _drawCount;
+        private float _totalModifierSnapshot;
+
+        private WeaponRecord(PhysicalCard weapon, PhysicalCard cardFiringWeapon, SwccgBuiltInCardBlueprint permanentWeapon) {
+            _weapon = weapon;
+            _cardFiringWeapon = cardFiringWeapon;
+            _permanentWeapon = permanentWeapon;
+        }
+
+        public PhysicalCard getWeapon() {
+            return _weapon;
+        }
+
+        public PhysicalCard getCardFiringWeapon() {
+            return _cardFiringWeapon;
+        }
+
+        public SwccgBuiltInCardBlueprint getPermanentWeapon() {
+            return _permanentWeapon;
+        }
+
+        public int getDrawCount() {
+            return _drawCount;
+        }
+
+        public float getTotalModifierSnapshot() {
+            return _totalModifierSnapshot;
+        }
+    }
+}

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/CombinedAttackFiringState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/CombinedAttackFiringState.java
@@ -14,13 +14,13 @@ import java.util.Map;
 /**
  * Tracks Premiere Combined Attack (1_75) while two or more starship weapons fire as one interrupt action.
  *
- * AR 2023 Appendix A: add all weapon destiny DRAWS together, then apply that shared draw-sum separately
- * for each participating weapon (each weapon brings its own total-weapon-destiny modifiers).
+ * Each Combined Attack / Targeting Computer firing is its own complete total weapon destiny subtotal:
+ * sum that firing's destiny draws (including each-draw mods), then apply that weapon's
+ * TOTAL_WEAPON_DESTINY modifiers (Heavy Turbolaser Battery -1 vs capital / -6 otherwise).
+ * Combined Attack adds those subtotals. Targeting Computer twice on one Heavy Turbolaser Battery
+ * is two subtotals, so -1 is subtracted twice. Do not apply total modifiers again at resolve.
  * Results are applied only after all participating weapons have fired (Gergall / forum t=58557),
  * via each weapon's own destinyDraws path (hit, lost, ionize, etc.).
- *
- * This is NOT Targeting Computer fire-twice. When Targeting Computer is used inside Combined Attack,
- * those extra destinies are additional draws in this pool; the TC weapon is still one weapon when applying.
  */
 public class CombinedAttackFiringState {
     private final PhysicalCard _source;
@@ -49,9 +49,10 @@ public class CombinedAttackFiringState {
     }
 
     /**
-     * Record one weapon-destiny firing (draw modifiers only). Snapshot that weapon's total-modifier
-     * contribution and Variable X now, while WeaponFiringState is still active (Intruder Missile
-     * is placed in Used Pile after firing; X is until-end-of-weapon-firing).
+     * Record one firing's complete total weapon destiny subtotal (draws plus that firing's
+     * total-weapon-destiny modifiers, already clamped at max(0, ...)). Snapshot Variable X
+     * now, while WeaponFiringState is still active (Intruder Missile is placed in Used Pile
+     * after firing; X is until-end-of-weapon-firing).
      */
     public void addFiring(PhysicalCard weapon, PhysicalCard cardFiringWeapon,
                           SwccgBuiltInCardBlueprint permanentWeapon, float drawModifiedDestiny,
@@ -121,10 +122,9 @@ public class CombinedAttackFiringState {
                 + sign + GuiUtils.formatAsString(totalModifier) + "=" + GuiUtils.formatAsString(total);
     }
 
-    public String getDrawModifiersOnlyMessage(PhysicalCard weapon, float firingDestiny) {
+    public String getFiringSubtotalMessage(PhysicalCard weapon, float subtotal) {
         String weaponLink = weapon != null ? GameUtils.getCardLink(weapon) : "weapon";
-        return "Combined Attack: " + weaponLink + " destiny " + GuiUtils.formatAsString(firingDestiny)
-                + " (draw modifiers only)";
+        return "Combined Attack: " + weaponLink + " destiny " + GuiUtils.formatAsString(subtotal);
     }
 
     public static String formatAddends(List<Float> values) {

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/CombinedAttackFiringState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/CombinedAttackFiringState.java
@@ -108,8 +108,7 @@ public class CombinedAttackFiringState {
     }
 
     public String getAddedDestiniesMessage(String drawSumFormatted) {
-        return "Combined Attack destinies: " + formatAddends(_destinyDraws) + " = " + drawSumFormatted
-                + ". Apply that total to each weapon in an order of your choosing.";
+        return "Combined Attack destinies: " + formatAddends(_destinyDraws) + " = " + drawSumFormatted + ".";
     }
 
     public static String getPerWeaponTotalMessage(PhysicalCard weapon, float drawSum, float totalModifier, float total) {

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/CombinedAttackFiringState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/CombinedAttackFiringState.java
@@ -3,6 +3,8 @@ package com.gempukku.swccgo.game.state;
 import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.game.SwccgBuiltInCardBlueprint;
 import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.effects.DrawDestinyEffect;
+import com.gempukku.swccgo.logic.timing.GuiUtils;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -14,7 +16,8 @@ import java.util.Map;
  *
  * AR 2023 Appendix A: add all weapon destiny DRAWS together, then apply that shared draw-sum separately
  * for each participating weapon (each weapon brings its own total-weapon-destiny modifiers).
- * Results (hit / ionize) are applied only after all participating weapons have fired (Gergall / forum t=58557).
+ * Results are applied only after all participating weapons have fired (Gergall / forum t=58557),
+ * via each weapon's own destinyDraws path (hit, lost, ionize, etc.).
  *
  * This is NOT Targeting Computer fire-twice. When Targeting Computer is used inside Combined Attack,
  * those extra destinies are additional draws in this pool; the TC weapon is still one weapon when applying.
@@ -47,12 +50,13 @@ public class CombinedAttackFiringState {
 
     /**
      * Record one weapon-destiny firing (draw modifiers only). Snapshot that weapon's total-modifier
-     * contribution now, while the weapon is still in play / WeaponFiringState is active (Intruder Missile
-     * is placed in Used Pile after firing, which would otherwise drop its +3).
+     * contribution and Variable X now, while WeaponFiringState is still active (Intruder Missile
+     * is placed in Used Pile after firing; X is until-end-of-weapon-firing).
      */
     public void addFiring(PhysicalCard weapon, PhysicalCard cardFiringWeapon,
                           SwccgBuiltInCardBlueprint permanentWeapon, float drawModifiedDestiny,
-                          float totalModifierSnapshot) {
+                          float totalModifierSnapshot, float variableXSnapshot,
+                          DrawDestinyEffect drawDestinyEffect) {
         if (weapon == null) {
             return;
         }
@@ -65,8 +69,12 @@ public class CombinedAttackFiringState {
         }
         record._drawCount++;
         record._totalModifierSnapshot = totalModifierSnapshot;
+        record._variableXSnapshot = variableXSnapshot;
         record._cardFiringWeapon = cardFiringWeapon != null ? cardFiringWeapon : record._cardFiringWeapon;
         record._permanentWeapon = permanentWeapon != null ? permanentWeapon : record._permanentWeapon;
+        if (drawDestinyEffect != null) {
+            record._drawDestinyEffect = drawDestinyEffect;
+        }
     }
 
     public int getCompletedDrawCount() {
@@ -91,7 +99,6 @@ public class CombinedAttackFiringState {
                 ordered.add(record);
             }
         }
-        // Include any completed weapon that was not in the original list (should not happen).
         for (WeaponRecord record : _recordsByWeaponId.values()) {
             if (!ordered.contains(record)) {
                 ordered.add(record);
@@ -101,12 +108,39 @@ public class CombinedAttackFiringState {
     }
 
     public String getAddedDestiniesMessage(String drawSumFormatted) {
-        return "Combined Attack destinies added together: " + drawSumFormatted
-                + " (" + _destinyDraws.size() + " weapon destin" + (_destinyDraws.size() == 1 ? "y" : "ies") + ")";
+        return "Combined Attack destinies: " + formatAddends(_destinyDraws) + " = " + drawSumFormatted
+                + ". Apply that total to each weapon in an order of your choosing.";
     }
 
-    public String getPerWeaponTotalMessage(PhysicalCard weapon, String totalFormatted) {
-        return "Combined Attack total for " + GameUtils.getCardLink(weapon) + ": " + totalFormatted;
+    public static String getPerWeaponTotalMessage(PhysicalCard weapon, float drawSum, float totalModifier, float total) {
+        String weaponLink = GameUtils.getCardLink(weapon);
+        if (totalModifier == 0f) {
+            return "Combined Attack total for " + weaponLink + ": " + GuiUtils.formatAsString(total);
+        }
+        String sign = totalModifier > 0f ? "+" : "";
+        return "Combined Attack total for " + weaponLink + ": " + GuiUtils.formatAsString(drawSum)
+                + sign + GuiUtils.formatAsString(totalModifier) + "=" + GuiUtils.formatAsString(total);
+    }
+
+    public String getDrawModifiersOnlyMessage(PhysicalCard weapon, float firingDestiny) {
+        String weaponLink = weapon != null ? GameUtils.getCardLink(weapon) : "weapon";
+        return "Combined Attack: " + weaponLink + " destiny " + GuiUtils.formatAsString(firingDestiny)
+                + " (draw modifiers only)";
+    }
+
+    public static String formatAddends(List<Float> values) {
+        if (values == null || values.isEmpty()) {
+            return "0";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < values.size(); i++) {
+            if (i > 0) {
+                sb.append(" + ");
+            }
+            Float value = values.get(i);
+            sb.append(GuiUtils.formatAsString(value != null ? value : 0f));
+        }
+        return sb.toString();
     }
 
     public void markResolved() {
@@ -123,6 +157,8 @@ public class CombinedAttackFiringState {
         private SwccgBuiltInCardBlueprint _permanentWeapon;
         private int _drawCount;
         private float _totalModifierSnapshot;
+        private float _variableXSnapshot;
+        private DrawDestinyEffect _drawDestinyEffect;
 
         private WeaponRecord(PhysicalCard weapon, PhysicalCard cardFiringWeapon, SwccgBuiltInCardBlueprint permanentWeapon) {
             _weapon = weapon;
@@ -148,6 +184,14 @@ public class CombinedAttackFiringState {
 
         public float getTotalModifierSnapshot() {
             return _totalModifierSnapshot;
+        }
+
+        public float getVariableXSnapshot() {
+            return _variableXSnapshot;
+        }
+
+        public DrawDestinyEffect getDrawDestinyEffect() {
+            return _drawDestinyEffect;
         }
     }
 }

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/CombinedAttackFiringState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/CombinedAttackFiringState.java
@@ -14,19 +14,17 @@ import java.util.Map;
 /**
  * Tracks Premiere Combined Attack (1_75) while two or more starship weapons fire as one interrupt action.
  *
- * Each Combined Attack / Targeting Computer firing is its own complete total weapon destiny subtotal:
- * sum that firing's destiny draws (including each-draw mods), then apply that weapon's
- * TOTAL_WEAPON_DESTINY modifiers (Heavy Turbolaser Battery -1 vs capital / -6 otherwise).
- * Combined Attack adds those subtotals. Targeting Computer twice on one Heavy Turbolaser Battery
- * is two subtotals, so -1 is subtracted twice. Do not apply total modifiers again at resolve.
- * Results are applied only after all participating weapons have fired (Gergall / forum t=58557),
- * via each weapon's own destinyDraws path (hit, lost, ionize, etc.).
+ * Gergall 2015 + 2023 Advanced Rulebook: fire weapons one at a time (pay then draw each). Hits are not
+ * checked until all firings complete. Sum destinies (draw modifiers stay on each draw) and apply TOTAL
+ * weapon destiny modifiers once to that grand total. Same title modifying the combined total counts once
+ * unless the card says cumulatively. Apply that grand total separately to each non-canceled weapon.
  */
 public class CombinedAttackFiringState {
     private final PhysicalCard _source;
     private final PhysicalCard _target;
     private final List<PhysicalCard> _weaponsInOrder;
     private final List<Float> _destinyDraws = new ArrayList<Float>();
+    private final List<TotalModContribution> _totalMods = new ArrayList<TotalModContribution>();
     private final Map<Integer, WeaponRecord> _recordsByWeaponId = new LinkedHashMap<Integer, WeaponRecord>();
     private boolean _resolved;
 
@@ -49,10 +47,9 @@ public class CombinedAttackFiringState {
     }
 
     /**
-     * Record one firing's complete total weapon destiny subtotal (draws plus that firing's
-     * total-weapon-destiny modifiers, already clamped at max(0, ...)). Snapshot Variable X
-     * now, while WeaponFiringState is still active (Intruder Missile is placed in Used Pile
-     * after firing; X is until-end-of-weapon-firing).
+     * Record one firing's destiny draws (including each-draw modifiers such as Targeting Computer -1
+     * and Defiance +2). Total-weapon-destiny modifiers are snapshotted separately and applied once
+     * to the grand total. Snapshot Variable X now, while WeaponFiringState is still active.
      */
     public void addFiring(PhysicalCard weapon, PhysicalCard cardFiringWeapon,
                           SwccgBuiltInCardBlueprint permanentWeapon, float drawModifiedDestiny,
@@ -78,6 +75,17 @@ public class CombinedAttackFiringState {
         }
     }
 
+    /**
+     * Snapshot one TOTAL_WEAPON_DESTINY contribution from this firing. Zero amounts are ignored.
+     * Same title is collapsed once at resolve unless the modifier is cumulative.
+     */
+    public void addTotalModContribution(String title, float amount, boolean cumulative) {
+        if (amount == 0f) {
+            return;
+        }
+        _totalMods.add(new TotalModContribution(title, amount, cumulative));
+    }
+
     public int getCompletedDrawCount() {
         return _destinyDraws.size();
     }
@@ -90,6 +98,35 @@ public class CombinedAttackFiringState {
             }
         }
         return total;
+    }
+
+    /**
+     * TOTAL_WEAPON_DESTINY modifiers applied once to the Combined Attack grand total.
+     * Multiple copies of the same title count once unless the modifier is cumulative.
+     */
+    public float getSameTitleOnceTotalModifier() {
+        // TotalWeaponDestinyModifier(source, amount, targetFilter) passes cumulative=true by default,
+        // because in a normal firing each copy only affects its own weapon. Combined Attack collects
+        // those copies onto one grand total, so same title still counts once unless we later teach
+        // this path about cards that actually say "cumulatively".
+        Map<String, Float> onceByTitle = new LinkedHashMap<String, Float>();
+        for (TotalModContribution contribution : _totalMods) {
+            String title = contribution._title != null ? contribution._title : "";
+            if (!onceByTitle.containsKey(title)) {
+                onceByTitle.put(title, contribution._amount);
+            }
+        }
+        float total = 0f;
+        for (Float value : onceByTitle.values()) {
+            if (value != null) {
+                total += value;
+            }
+        }
+        return total;
+    }
+
+    public float getGrandTotal() {
+        return Math.max(0, getDrawSum() + getSameTitleOnceTotalModifier());
     }
 
     public List<WeaponRecord> getCompletedWeaponRecordsInOrder() {
@@ -108,8 +145,21 @@ public class CombinedAttackFiringState {
         return ordered;
     }
 
+    public String getAddedDestiniesMessage(String drawSumFormatted, String totalModsFormatted, String grandTotalFormatted) {
+        float totalMods = getSameTitleOnceTotalModifier();
+        String mods = "";
+        if (totalMods != 0f) {
+            String sign = totalMods > 0f ? "+" : "";
+            mods = ". Total modifiers " + sign + totalModsFormatted;
+        }
+        return "Combined Attack destinies: " + formatAddends(_destinyDraws) + " = " + drawSumFormatted
+                + mods + ". Total weapon destiny " + grandTotalFormatted + ".";
+    }
+
     public String getAddedDestiniesMessage(String drawSumFormatted) {
-        return "Combined Attack destinies: " + formatAddends(_destinyDraws) + " = " + drawSumFormatted + ".";
+        return getAddedDestiniesMessage(drawSumFormatted,
+                GuiUtils.formatAsString(getSameTitleOnceTotalModifier()),
+                GuiUtils.formatAsString(getGrandTotal()));
     }
 
     public static String getPerWeaponTotalMessage(PhysicalCard weapon, float drawSum, float totalModifier, float total) {
@@ -122,9 +172,14 @@ public class CombinedAttackFiringState {
                 + sign + GuiUtils.formatAsString(totalModifier) + "=" + GuiUtils.formatAsString(total);
     }
 
-    public String getFiringSubtotalMessage(PhysicalCard weapon, float subtotal) {
+    public String getFiringDrawsMessage(PhysicalCard weapon, float drawDestiny) {
         String weaponLink = weapon != null ? GameUtils.getCardLink(weapon) : "weapon";
-        return "Combined Attack: " + weaponLink + " destiny " + GuiUtils.formatAsString(subtotal);
+        return "Combined Attack: " + weaponLink + " destiny " + GuiUtils.formatAsString(drawDestiny)
+                + " (draw modifiers only)";
+    }
+
+    public String getFiringSubtotalMessage(PhysicalCard weapon, float subtotal) {
+        return getFiringDrawsMessage(weapon, subtotal);
     }
 
     public static String formatAddends(List<Float> values) {
@@ -148,6 +203,18 @@ public class CombinedAttackFiringState {
 
     public boolean isResolved() {
         return _resolved;
+    }
+
+    public static class TotalModContribution {
+        private final String _title;
+        private final float _amount;
+        private final boolean _cumulative;
+
+        private TotalModContribution(String title, float amount, boolean cumulative) {
+            _title = title;
+            _amount = amount;
+            _cumulative = cumulative;
+        }
     }
 
     public static class WeaponRecord {

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/GameState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/GameState.java
@@ -96,6 +96,7 @@ public class GameState implements Snapshotable<GameState> {
     private SabaccState _sabaccState;
     private SearchPartyState _searchPartyState;
     private WeaponFiringState _weaponFiringState;
+    private SeparatelyOrCombinedFiringState _separatelyOrCombinedFiringState;
     private UsingTractorBeamState _usingTractorBeamState;
     private Stack<ForceLossState> _forceLossState = new Stack<ForceLossState>();
     private Stack<ForceRetrievalState> _forceRetrievalState = new Stack<ForceRetrievalState>();
@@ -297,6 +298,9 @@ public class GameState implements Snapshotable<GameState> {
         }
         if (_weaponFiringState != null) {
             throw new UnsupportedOperationException("Cannot generate snapshot of " + getClass().getSimpleName() + " with WeaponFiringState");
+        }
+        if (_separatelyOrCombinedFiringState != null) {
+            throw new UnsupportedOperationException("Cannot generate snapshot of " + getClass().getSimpleName() + " with SeparatelyOrCombinedFiringState");
         }
         if (!_forceLossState.isEmpty()) {
             throw new UnsupportedOperationException("Cannot generate snapshot of " + getClass().getSimpleName() + " with ForceLossState");
@@ -4362,6 +4366,22 @@ public class GameState implements Snapshotable<GameState> {
             _game.getActionsEnvironment().removeEndOfWeaponFiringActionProxies();
             _weaponFiringState = null;
         }
+    }
+
+    /**
+     * Begins a Targeting Computer-style fire-twice separately-or-combined action.
+     * Both shots are one overall action (no top-level actions between shots).
+     */
+    public void beginSeparatelyOrCombinedFiring(PhysicalCard device, PhysicalCard weapon, boolean combined) {
+        _separatelyOrCombinedFiringState = new SeparatelyOrCombinedFiringState(device, weapon, combined);
+    }
+
+    public SeparatelyOrCombinedFiringState getSeparatelyOrCombinedFiringState() {
+        return _separatelyOrCombinedFiringState;
+    }
+
+    public void finishSeparatelyOrCombinedFiring() {
+        _separatelyOrCombinedFiringState = null;
     }
 
     //

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/GameState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/GameState.java
@@ -4346,6 +4346,9 @@ public class GameState implements Snapshotable<GameState> {
     //
     public void beginWeaponFiring(PhysicalCard weaponFiring, SwccgBuiltInCardBlueprint permanentWeapon) {
         _weaponFiringState = new WeaponFiringState(_game, weaponFiring, permanentWeapon);
+        if (_separatelyOrCombinedFiringState != null) {
+            _separatelyOrCombinedFiringState.markFiringInitiated();
+        }
     }
 
     public void beginCombinedWeaponFiring() {

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/GameState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/GameState.java
@@ -97,6 +97,7 @@ public class GameState implements Snapshotable<GameState> {
     private SearchPartyState _searchPartyState;
     private WeaponFiringState _weaponFiringState;
     private SeparatelyOrCombinedFiringState _separatelyOrCombinedFiringState;
+    private CombinedAttackFiringState _combinedAttackFiringState;
     private UsingTractorBeamState _usingTractorBeamState;
     private Stack<ForceLossState> _forceLossState = new Stack<ForceLossState>();
     private Stack<ForceRetrievalState> _forceRetrievalState = new Stack<ForceRetrievalState>();
@@ -301,6 +302,9 @@ public class GameState implements Snapshotable<GameState> {
         }
         if (_separatelyOrCombinedFiringState != null) {
             throw new UnsupportedOperationException("Cannot generate snapshot of " + getClass().getSimpleName() + " with SeparatelyOrCombinedFiringState");
+        }
+        if (_combinedAttackFiringState != null) {
+            throw new UnsupportedOperationException("Cannot generate snapshot of " + getClass().getSimpleName() + " with CombinedAttackFiringState");
         }
         if (!_forceLossState.isEmpty()) {
             throw new UnsupportedOperationException("Cannot generate snapshot of " + getClass().getSimpleName() + " with ForceLossState");
@@ -4407,6 +4411,23 @@ public class GameState implements Snapshotable<GameState> {
 
     public void finishSeparatelyOrCombinedFiring() {
         _separatelyOrCombinedFiringState = null;
+    }
+
+    /**
+     * Begins Premiere Combined Attack (1_75): two or more starship weapons fire as one interrupt action.
+     * Destiny DRAWS are added together; each weapon then applies that shared total with its own
+     * total-weapon-destiny modifiers. Results are applied only after all participating weapons have fired.
+     */
+    public void beginCombinedAttackFiring(PhysicalCard source, PhysicalCard target, java.util.List<PhysicalCard> weaponsInOrder) {
+        _combinedAttackFiringState = new CombinedAttackFiringState(source, target, weaponsInOrder);
+    }
+
+    public CombinedAttackFiringState getCombinedAttackFiringState() {
+        return _combinedAttackFiringState;
+    }
+
+    public void finishCombinedAttackFiring() {
+        _combinedAttackFiringState = null;
     }
 
     //

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/GameState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/GameState.java
@@ -4062,6 +4062,24 @@ public class GameState implements Snapshotable<GameState> {
     }
 
     /**
+     * True if a game-text action from this card is still on the stack.
+     * Targeting Computer uses this so -1 still applies if separately-or-combined state was cleared too soon.
+     */
+    public boolean isDuringGameTextActionFrom(PhysicalCard card) {
+        if (card == null) {
+            return false;
+        }
+        for (GameTextActionState state : _gameTextActionState) {
+            GameTextAction action = state.getGameTextAction();
+            if (action != null && action.getActionSource() != null
+                    && action.getActionSource().getCardId() == card.getCardId()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Gets the game text action state for the specific game text action.
      * @return the current game text action state, or null
      */

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/GameState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/GameState.java
@@ -626,6 +626,10 @@ public class GameState implements Snapshotable<GameState> {
             listener.sendMessage(message);
     }
 
+    public java.util.List<String> getLastMessages() {
+        return java.util.Collections.unmodifiableList(_lastMessages);
+    }
+
     public void playerDecisionStarted(String playerId, AwaitingDecision awaitingDecision) {
         _playerDecisions.put(playerId, awaitingDecision);
         for (GameStateListener listener : getAllGameStateListeners())

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/SeparatelyOrCombinedFiringState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/SeparatelyOrCombinedFiringState.java
@@ -130,7 +130,10 @@ public class SeparatelyOrCombinedFiringState {
     }
 
     public String getFiringLabel() {
-        return "Firing " + _firingsInitiated;
+        String deviceTitle = _device != null ? _device.getTitle() : "Targeting Computer";
+        String mode = _combined ? "Combined" : "Separately";
+        String weaponText = _weapon != null ? GameUtils.getCardLink(_weapon) : "weapon";
+        return deviceTitle + " " + mode + " firing " + _firingsInitiated + " (" + weaponText + ")";
     }
 
     public String getCombinedDrawModifiersOnlyMessage(PhysicalCard weapon, float firingDestiny) {

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/SeparatelyOrCombinedFiringState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/SeparatelyOrCombinedFiringState.java
@@ -164,6 +164,34 @@ public class SeparatelyOrCombinedFiringState {
         return sb.toString();
     }
 
+    public String getCombinedDrawModifiersOnlyMessage(PhysicalCard weapon, float firingDestiny) {
+        String weaponLink = weapon != null ? GameUtils.getCardLink(weapon) : "weapon";
+        return "Combined firing " + getCompletedFiringCount() + ": " + weaponLink
+                + " destiny " + GuiUtils.formatAsString(firingDestiny) + " (draw modifiers only)";
+    }
+
+    public String getCombinedDestiniesMathMessage(String drawSumFormatted, String totalFormatted, String defenseFormatted) {
+        String addends = formatAddends(_firingDestinies);
+        String deviceTitle = _device != null ? _device.getTitle() : "Targeting Computer";
+        return deviceTitle + " combined destinies: " + addends + " = " + drawSumFormatted
+                + ". Total weapon destiny " + totalFormatted + " vs defense value " + defenseFormatted;
+    }
+
+    private static String formatAddends(List<Float> values) {
+        if (values == null || values.isEmpty()) {
+            return "0";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < values.size(); i++) {
+            if (i > 0) {
+                sb.append(" + ");
+            }
+            Float value = values.get(i);
+            sb.append(GuiUtils.formatAsString(value != null ? value : 0f));
+        }
+        return sb.toString();
+    }
+
     public String getCombinedTotalDestinyMessage(String totalFormatted) {
         if (getCompletedFiringCount() <= 1) {
             return "Combined total weapon destiny (firing 1 only): " + totalFormatted;

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/SeparatelyOrCombinedFiringState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/SeparatelyOrCombinedFiringState.java
@@ -1,6 +1,9 @@
 package com.gempukku.swccgo.game.state;
 
 import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.effects.DrawDestinyEffect;
+import com.gempukku.swccgo.logic.timing.GuiUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +31,8 @@ public class SeparatelyOrCombinedFiringState {
     private final List<Float> _firingDestinies = new ArrayList<Float>();
     private boolean _resolved;
     private int _firingsInitiated;
+    private DrawDestinyEffect _drawDestinyEffect;
+    private float _variableXSnapshot;
 
     public SeparatelyOrCombinedFiringState(PhysicalCard device, PhysicalCard weapon, boolean combined) {
         _device = device;
@@ -90,6 +95,24 @@ public class SeparatelyOrCombinedFiringState {
         return total;
     }
 
+    public void setDrawDestinyEffect(DrawDestinyEffect drawDestinyEffect) {
+        if (drawDestinyEffect != null) {
+            _drawDestinyEffect = drawDestinyEffect;
+        }
+    }
+
+    public DrawDestinyEffect getDrawDestinyEffect() {
+        return _drawDestinyEffect;
+    }
+
+    public void setVariableXSnapshot(float variableXSnapshot) {
+        _variableXSnapshot = variableXSnapshot;
+    }
+
+    public float getVariableXSnapshot() {
+        return _variableXSnapshot;
+    }
+
     public void markResolved() {
         _resolved = true;
     }
@@ -108,6 +131,34 @@ public class SeparatelyOrCombinedFiringState {
 
     public String getFiringLabel() {
         return "Firing " + _firingsInitiated;
+    }
+
+    public String getCombinedDrawModifiersOnlyMessage(PhysicalCard weapon, float firingDestiny) {
+        String weaponLink = weapon != null ? GameUtils.getCardLink(weapon) : "weapon";
+        return "Combined firing " + getCompletedFiringCount() + ": " + weaponLink
+                + " destiny " + GuiUtils.formatAsString(firingDestiny) + " (draw modifiers only)";
+    }
+
+    public String getCombinedDestiniesMathMessage(String drawSumFormatted, String totalFormatted, String defenseFormatted) {
+        String addends = formatAddends(_firingDestinies);
+        String deviceTitle = _device != null ? _device.getTitle() : "Targeting Computer";
+        return deviceTitle + " combined destinies: " + addends + " = " + drawSumFormatted
+                + ". Total weapon destiny " + totalFormatted + " vs defense value " + defenseFormatted;
+    }
+
+    private static String formatAddends(List<Float> values) {
+        if (values == null || values.isEmpty()) {
+            return "0";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < values.size(); i++) {
+            if (i > 0) {
+                sb.append(" + ");
+            }
+            Float value = values.get(i);
+            sb.append(GuiUtils.formatAsString(value != null ? value : 0f));
+        }
+        return sb.toString();
     }
 
     public String getCombinedTotalDestinyMessage(String totalFormatted) {

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/SeparatelyOrCombinedFiringState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/SeparatelyOrCombinedFiringState.java
@@ -13,9 +13,10 @@ import java.util.List;
  * Combined: treat each firing as a single weapon destiny (draw modifiers only, even if
  * multiple draws), add them, then apply total weapon destiny modifiers once and resolve.
  *
- * Pending rules (sensible AR reading, coded here): Force for each shot is paid when that
- * shot initiates, not all upfront. If the second shot cannot pay, the first still resolved
- * when firing separately; when combined, completed firings still combine.
+ * Appendix B option A (coded here): Force is used for BOTH firings, but each shot's cost
+ * is paid when THAT shot initiates (not all upfront). If the second shot cannot pay, skip
+ * it; do not rewind the first shot and do not fail the overall action. Combined: destinies
+ * from completed firings still combine (total-modifiers applied once) vs the single target.
  */
 public class SeparatelyOrCombinedFiringState {
     private final PhysicalCard _device;

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/SeparatelyOrCombinedFiringState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/SeparatelyOrCombinedFiringState.java
@@ -164,34 +164,6 @@ public class SeparatelyOrCombinedFiringState {
         return sb.toString();
     }
 
-    public String getCombinedDrawModifiersOnlyMessage(PhysicalCard weapon, float firingDestiny) {
-        String weaponLink = weapon != null ? GameUtils.getCardLink(weapon) : "weapon";
-        return "Combined firing " + getCompletedFiringCount() + ": " + weaponLink
-                + " destiny " + GuiUtils.formatAsString(firingDestiny) + " (draw modifiers only)";
-    }
-
-    public String getCombinedDestiniesMathMessage(String drawSumFormatted, String totalFormatted, String defenseFormatted) {
-        String addends = formatAddends(_firingDestinies);
-        String deviceTitle = _device != null ? _device.getTitle() : "Targeting Computer";
-        return deviceTitle + " combined destinies: " + addends + " = " + drawSumFormatted
-                + ". Total weapon destiny " + totalFormatted + " vs defense value " + defenseFormatted;
-    }
-
-    private static String formatAddends(List<Float> values) {
-        if (values == null || values.isEmpty()) {
-            return "0";
-        }
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < values.size(); i++) {
-            if (i > 0) {
-                sb.append(" + ");
-            }
-            Float value = values.get(i);
-            sb.append(GuiUtils.formatAsString(value != null ? value : 0f));
-        }
-        return sb.toString();
-    }
-
     public String getCombinedTotalDestinyMessage(String totalFormatted) {
         if (getCompletedFiringCount() <= 1) {
             return "Combined total weapon destiny (firing 1 only): " + totalFormatted;

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/SeparatelyOrCombinedFiringState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/SeparatelyOrCombinedFiringState.java
@@ -1,0 +1,98 @@
+package com.gempukku.swccgo.game.state;
+
+import com.gempukku.swccgo.game.PhysicalCard;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tracks a "fire twice, separately or combined" action such as Targeting Computer (1_39).
+ * This is NOT Maul-style repeated firing and is NOT Combined/Precise Attack.
+ *
+ * AR (Weapons - Firing Separately Or Combined): both shots are one overall action.
+ * Combined: treat each firing as a single weapon destiny (draw modifiers only, even if
+ * multiple draws), add them, then apply total weapon destiny modifiers once and resolve.
+ *
+ * Pending rules (sensible AR reading, coded here): Force for each shot is paid when that
+ * shot initiates, not all upfront. If the second shot cannot pay, the first still resolved
+ * when firing separately; when combined, completed firings still combine.
+ */
+public class SeparatelyOrCombinedFiringState {
+    private final PhysicalCard _device;
+    private final PhysicalCard _weapon;
+    private final boolean _combined;
+    private final int _expectedFirings;
+    private PhysicalCard _cardFiringWeapon;
+    private PhysicalCard _combinedTarget;
+    private final List<Float> _firingDestinies = new ArrayList<Float>();
+    private boolean _resolved;
+
+    public SeparatelyOrCombinedFiringState(PhysicalCard device, PhysicalCard weapon, boolean combined) {
+        _device = device;
+        _weapon = weapon;
+        _combined = combined;
+        _expectedFirings = 2;
+    }
+
+    public PhysicalCard getDevice() {
+        return _device;
+    }
+
+    public PhysicalCard getWeapon() {
+        return _weapon;
+    }
+
+    public boolean isCombined() {
+        return _combined;
+    }
+
+    public void setCardFiringWeapon(PhysicalCard cardFiringWeapon) {
+        if (cardFiringWeapon != null) {
+            _cardFiringWeapon = cardFiringWeapon;
+        }
+    }
+
+    public PhysicalCard getCardFiringWeapon() {
+        return _cardFiringWeapon;
+    }
+
+    public void setCombinedTarget(PhysicalCard target) {
+        if (_combinedTarget == null && target != null) {
+            _combinedTarget = target;
+        }
+    }
+
+    public PhysicalCard getCombinedTarget() {
+        return _combinedTarget;
+    }
+
+    public void addFiringDestiny(float firingDestiny) {
+        _firingDestinies.add(firingDestiny);
+    }
+
+    public int getCompletedFiringCount() {
+        return _firingDestinies.size();
+    }
+
+    public boolean hasCompletedExpectedFirings() {
+        return _firingDestinies.size() >= _expectedFirings;
+    }
+
+    public float getCombinedFiringDestinySum() {
+        float total = 0f;
+        for (Float value : _firingDestinies) {
+            if (value != null) {
+                total += value;
+            }
+        }
+        return total;
+    }
+
+    public void markResolved() {
+        _resolved = true;
+    }
+
+    public boolean isResolved() {
+        return _resolved;
+    }
+}

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/SeparatelyOrCombinedFiringState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/SeparatelyOrCombinedFiringState.java
@@ -133,7 +133,7 @@ public class SeparatelyOrCombinedFiringState {
         String deviceTitle = _device != null ? _device.getTitle() : "Targeting Computer";
         String mode = _combined ? "Combined" : "Separately";
         String weaponText = _weapon != null ? GameUtils.getCardLink(_weapon) : "weapon";
-        return deviceTitle + " " + mode + " firing " + _firingsInitiated + " (" + weaponText + ")";
+        return deviceTitle + " " + mode + " firing " + _firingsInitiated + " " + weaponText;
     }
 
     public String getCombinedDrawModifiersOnlyMessage(PhysicalCard weapon, float firingDestiny) {

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/SeparatelyOrCombinedFiringState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/SeparatelyOrCombinedFiringState.java
@@ -27,6 +27,7 @@ public class SeparatelyOrCombinedFiringState {
     private PhysicalCard _combinedTarget;
     private final List<Float> _firingDestinies = new ArrayList<Float>();
     private boolean _resolved;
+    private int _firingsInitiated;
 
     public SeparatelyOrCombinedFiringState(PhysicalCard device, PhysicalCard weapon, boolean combined) {
         _device = device;
@@ -95,5 +96,24 @@ public class SeparatelyOrCombinedFiringState {
 
     public boolean isResolved() {
         return _resolved;
+    }
+
+    public void markFiringInitiated() {
+        _firingsInitiated++;
+    }
+
+    public int getCurrentFiringNumber() {
+        return _firingsInitiated;
+    }
+
+    public String getFiringLabel() {
+        return "Firing " + _firingsInitiated;
+    }
+
+    public String getCombinedTotalDestinyMessage(String totalFormatted) {
+        if (getCompletedFiringCount() <= 1) {
+            return "Combined total weapon destiny (firing 1 only): " + totalFormatted;
+        }
+        return "Combined total weapon destiny (firing 1 + firing 2): " + totalFormatted;
     }
 }

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/WeaponFiringState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/WeaponFiringState.java
@@ -58,6 +58,11 @@ public class WeaponFiringState {
             else
                 _game.getModifiersQuerying().targetedByWeapon(target, _weaponFiring);
         }
+        SeparatelyOrCombinedFiringState soc = _game.getGameState().getSeparatelyOrCombinedFiringState();
+        if (soc != null && soc.isCombined() && !targets.isEmpty()) {
+            soc.setCombinedTarget(targets.iterator().next());
+            soc.setCardFiringWeapon(_cardFiringWeapon);
+        }
     }
 
     public Collection<PhysicalCard> getTargets() {

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/actions/AbstractAction.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/actions/AbstractAction.java
@@ -333,6 +333,17 @@ public abstract class AbstractAction implements Action {
     }
 
     /**
+     * Removes and returns effects queued on this action that have not started yet.
+     * Used so Combined Attack / TC-combined can run a weapon's destinyDraws later and
+     * execute the resulting hit/lost/ionize effects on a different parent action.
+     */
+    public List<StandardEffect> drainPendingEffects() {
+        List<StandardEffect> drained = new ArrayList<StandardEffect>(_effects);
+        _effects.clear();
+        return drained;
+    }
+
+    /**
      * Inserts the specified effects as the next after effects to be executed.  It will be executed after all the other
      * effects currently in the queue. These effects do not need to be successful for the action to be considered carried out.
      *
@@ -577,7 +588,11 @@ public abstract class AbstractAction implements Action {
      */
     @Override
     public final Collection<PhysicalCard> getPrimaryTargetCards(int targetGroupId) {
-        return _targetGroupMap.get(targetGroupId).keySet();
+        Map<PhysicalCard, Set<TargetingReason>> map = _targetGroupMap.get(targetGroupId);
+        if (map == null) {
+            return Collections.emptyList();
+        }
+        return new ArrayList<PhysicalCard>(map.keySet());
     }
 
     /**

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/actions/AbstractRespondableAction.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/actions/AbstractRespondableAction.java
@@ -3,6 +3,7 @@ package com.gempukku.swccgo.logic.actions;
 import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.game.SwccgGame;
 import com.gempukku.swccgo.game.state.GameState;
+import com.gempukku.swccgo.game.state.SeparatelyOrCombinedFiringState;
 import com.gempukku.swccgo.logic.GameUtils;
 import com.gempukku.swccgo.logic.effects.RespondableEffect;
 import com.gempukku.swccgo.logic.timing.Action;
@@ -193,7 +194,12 @@ public abstract class AbstractRespondableAction extends AbstractAction {
 
                 // Send message and show animation of targets now that action initiation is complete
                 if (_actionMessage != null) {
-                    gameState.sendMessage(_actionMessage);
+                    String actionMsg = _actionMessage;
+                    SeparatelyOrCombinedFiringState soc = gameState.getSeparatelyOrCombinedFiringState();
+                    if (soc != null && soc.getCurrentFiringNumber() > 0 && this instanceof AbstractFireWeaponAction) {
+                        actionMsg = soc.getFiringLabel() + ": " + actionMsg;
+                    }
+                    gameState.sendMessage(actionMsg);
                 }
 
                 // Assert that RespondableEffect is set (which is required if any cards were targeted and this is not a sub-action)

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/actions/FireSingleWeaponAction.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/actions/FireSingleWeaponAction.java
@@ -111,6 +111,9 @@ public class FireSingleWeaponAction extends AbstractFireWeaponAction {
                     !_weaponToFire.getBlueprint().isFiredByCharacterPresentOrHere() && !Filters.artillery_weapon.accepts(game, _weaponToFire)) {
                 setCardFiringWeapon(_weaponToFire.getAttachedTo());
             }
+            if (getCardFiringWeapon() != null && game.getGameState().getWeaponFiringState() != null) {
+                game.getGameState().getWeaponFiringState().setCardFiringWeapon(getCardFiringWeapon());
+            }
         }
 
         // Add any extra cost to fire the weapon

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/decisions/MultipleChoiceAwaitingDecision.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/decisions/MultipleChoiceAwaitingDecision.java
@@ -20,6 +20,19 @@ public abstract class MultipleChoiceAwaitingDecision extends AbstractAwaitingDec
     /**
      * Creates a decision that involves choosing from a choice of string values on the User Interface.
      * @param text the text to show the player making the decision
+     * @param possibleResults the strings to choose from
+     * @param asButtons true to show the choices as buttons instead of a dropdown
+     */
+    public MultipleChoiceAwaitingDecision(String text, String[] possibleResults, boolean asButtons) {
+        this(text, possibleResults, -1);
+        if (asButtons) {
+            setParam("asButtons", "true");
+        }
+    }
+
+    /**
+     * Creates a decision that involves choosing from a choice of string values on the User Interface.
+     * @param text the text to show the player making the decision
      * @param possibleResults the strings to choose from, as ArrayList
      */
     public MultipleChoiceAwaitingDecision(String text, ArrayList<String> possibleResults) {

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
@@ -9,6 +9,7 @@ import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.game.SwccgGame;
 import com.gempukku.swccgo.game.state.DrawDestinyState;
 import com.gempukku.swccgo.game.state.GameState;
+import com.gempukku.swccgo.game.state.SeparatelyOrCombinedFiringState;
 import com.gempukku.swccgo.logic.GameUtils;
 import com.gempukku.swccgo.logic.actions.OptionalGameTextTriggerAction;
 import com.gempukku.swccgo.logic.actions.SubAction;
@@ -503,7 +504,11 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
 
         // Add modifiers to total weapon destiny (unless this is combined firing)
         if (_destinyType==DestinyType.WEAPON_DESTINY || _destinyType==DestinyType.EPIC_EVENT_AND_WEAPON_DESTINY) {
-            totalDestiny = game.getModifiersQuerying().getTotalWeaponDestiny(gameState, _performingPlayerId, totalDestiny);
+            SeparatelyOrCombinedFiringState soc = gameState.getSeparatelyOrCombinedFiringState();
+            // Combined: each firing is a single weapon destiny (draw modifiers only), not a weapon destiny total.
+            if (soc == null || !soc.isCombined()) {
+                totalDestiny = game.getModifiersQuerying().getTotalWeaponDestiny(gameState, _performingPlayerId, totalDestiny);
+            }
         }
         else if (_destinyType==DestinyType.BATTLE_DESTINY) {
             totalDestiny = game.getModifiersQuerying().getTotalBattleDestiny(gameState, _performingPlayerId, totalDestiny);
@@ -694,6 +699,33 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
                         Float totalDestiny = getTotalDestiny(game);
 
                         gameState.endDrawDestiny();
+
+                        SeparatelyOrCombinedFiringState soc = gameState.getSeparatelyOrCombinedFiringState();
+                        if (soc != null && soc.isCombined()
+                                && (_destinyType == DestinyType.WEAPON_DESTINY || _destinyType == DestinyType.EPIC_EVENT_AND_WEAPON_DESTINY)) {
+                            float firingDestiny = 0f;
+                            for (Float value : _destinyDrawValues) {
+                                if (value != null) {
+                                    firingDestiny += value;
+                                }
+                            }
+                            soc.addFiringDestiny(firingDestiny);
+                            if (gameState.getWeaponFiringState() != null) {
+                                soc.setCardFiringWeapon(gameState.getWeaponFiringState().getCardFiringWeapon());
+                            }
+                            gameState.sendMessage("Combined firing weapon destiny (draw modifiers only): " + GuiUtils.formatAsString(firingDestiny));
+
+                            if (!soc.hasCompletedExpectedFirings()) {
+                                // Defer hit resolution until remaining combined firings complete.
+                                // Pending rules: costs paid as each shot initiates; completed firings still combine.
+                                return;
+                            }
+
+                            float combined = soc.getCombinedFiringDestinySum();
+                            totalDestiny = game.getModifiersQuerying().getTotalWeaponDestiny(gameState, _performingPlayerId, combined);
+                            soc.markResolved();
+                            gameState.sendMessage("Combined total weapon destiny: " + GuiUtils.formatAsString(totalDestiny));
+                        }
 
                         // Callback
                         destinyDraws(game, _destinyCardDraws, _destinyDrawValues, totalDestiny);

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
@@ -713,7 +713,7 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
                             if (gameState.getWeaponFiringState() != null) {
                                 soc.setCardFiringWeapon(gameState.getWeaponFiringState().getCardFiringWeapon());
                             }
-                            gameState.sendMessage("Combined firing weapon destiny (draw modifiers only): " + GuiUtils.formatAsString(firingDestiny));
+                            gameState.sendMessage("Combined " + soc.getFiringLabel().toLowerCase() + " weapon destiny (draw modifiers only): " + GuiUtils.formatAsString(firingDestiny));
 
                             if (!soc.hasCompletedExpectedFirings()) {
                                 // Defer hit resolution until remaining combined firings complete.
@@ -725,7 +725,7 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
                             float combined = soc.getCombinedFiringDestinySum();
                             totalDestiny = game.getModifiersQuerying().getTotalWeaponDestiny(gameState, _performingPlayerId, combined);
                             soc.markResolved();
-                            gameState.sendMessage("Combined total weapon destiny: " + GuiUtils.formatAsString(totalDestiny));
+                            gameState.sendMessage(soc.getCombinedTotalDestinyMessage(GuiUtils.formatAsString(totalDestiny)));
                         }
 
                         // Callback
@@ -1447,7 +1447,13 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
                                 return;
 
                             if (_destinyType != DestinyType.RACE_DESTINY) {
-                                game.getGameState().sendMessage(_performingPlayerId + "'s total " + _destinyType.getHumanReadable() + " is " + GuiUtils.formatAsString(totalDestiny));
+                                String totalMsg = _performingPlayerId + "'s total " + _destinyType.getHumanReadable() + " is " + GuiUtils.formatAsString(totalDestiny);
+                                SeparatelyOrCombinedFiringState soc = game.getGameState().getSeparatelyOrCombinedFiringState();
+                                if (soc != null && soc.getCurrentFiringNumber() > 0
+                                        && (_destinyType == DestinyType.WEAPON_DESTINY || _destinyType == DestinyType.EPIC_EVENT_AND_WEAPON_DESTINY)) {
+                                    totalMsg = soc.getFiringLabel() + ": " + totalMsg;
+                                }
+                                game.getGameState().sendMessage(totalMsg);
                             }
 
                             actionsEnvironment.emitEffectResult(

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
@@ -717,7 +717,8 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
 
                             if (!soc.hasCompletedExpectedFirings()) {
                                 // Defer hit resolution until remaining combined firings complete.
-                                // Pending rules: costs paid as each shot initiates; completed firings still combine.
+                                // Appendix B option A: if a later shot cannot initiate, completed firings still combine
+                                // (Card1_039 skips unpaid shot 2 and resolves combined from completed firings only).
                                 return;
                             }
 

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
@@ -724,7 +724,6 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
                             if (gameState.getWeaponFiringState() != null) {
                                 soc.setCardFiringWeapon(gameState.getWeaponFiringState().getCardFiringWeapon());
                             }
-                            gameState.sendMessage(soc.getCombinedDrawModifiersOnlyMessage(socWeapon, firingDestiny));
 
                             if (!soc.hasCompletedExpectedFirings()) {
                                 // Defer hit resolution until remaining combined firings complete.
@@ -1525,18 +1524,12 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
                             if (_destinyType != DestinyType.RACE_DESTINY) {
                                 GameState gameState = game.getGameState();
                                 SeparatelyOrCombinedFiringState soc = gameState.getSeparatelyOrCombinedFiringState();
-                                boolean combinedDrawModsOnly = (soc != null && soc.isCombined());
-                                // TC-combined: do not print a finished-looking "total weapon destiny"
-                                // per shot. Draw-modifiers-only lines plus the combined math block
-                                // are the resolve log.
-                                if (!combinedDrawModsOnly) {
-                                    String totalMsg = _performingPlayerId + "'s total " + _destinyType.getHumanReadable() + " is " + GuiUtils.formatAsString(totalDestiny);
-                                    if (soc != null && soc.getCurrentFiringNumber() > 0
-                                            && (_destinyType == DestinyType.WEAPON_DESTINY || _destinyType == DestinyType.EPIC_EVENT_AND_WEAPON_DESTINY)) {
-                                        totalMsg = soc.getFiringLabel() + ": " + totalMsg;
-                                    }
-                                    gameState.sendMessage(totalMsg);
+                                String totalMsg = _performingPlayerId + "'s total " + _destinyType.getHumanReadable() + " is " + GuiUtils.formatAsString(totalDestiny);
+                                if (soc != null && soc.getCurrentFiringNumber() > 0
+                                        && (_destinyType == DestinyType.WEAPON_DESTINY || _destinyType == DestinyType.EPIC_EVENT_AND_WEAPON_DESTINY)) {
+                                    totalMsg = soc.getFiringLabel() + ": " + totalMsg;
                                 }
+                                gameState.sendMessage(totalMsg);
                             }
 
                             actionsEnvironment.emitEffectResult(

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
@@ -797,7 +797,10 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
                                           PhysicalCard target, float variableX, Float combinedTotal) {
         GameState gameState = game.getGameState();
         boolean beganFiring = false;
-        if (gameState.getWeaponFiringState() == null && weapon != null) {
+        if (gameState.getWeaponFiringState() != null) {
+            gameState.finishWeaponFiring();
+        }
+        if (weapon != null) {
             gameState.beginWeaponFiring(weapon, permanentWeapon);
             beganFiring = true;
             WeaponFiringState wfs = gameState.getWeaponFiringState();

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
@@ -9,6 +9,7 @@ import com.gempukku.swccgo.game.ActionsEnvironment;
 import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.game.SwccgBuiltInCardBlueprint;
 import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.game.state.CombinedAttackFiringState;
 import com.gempukku.swccgo.game.state.DrawDestinyState;
 import com.gempukku.swccgo.game.state.GameState;
 import com.gempukku.swccgo.game.state.SeparatelyOrCombinedFiringState;
@@ -511,8 +512,9 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
         // Add modifiers to total weapon destiny (unless this is combined firing)
         if (_destinyType==DestinyType.WEAPON_DESTINY || _destinyType==DestinyType.EPIC_EVENT_AND_WEAPON_DESTINY) {
             SeparatelyOrCombinedFiringState soc = gameState.getSeparatelyOrCombinedFiringState();
-            // TC-combined: each firing is draw modifiers only, not a weapon destiny total.
-            if (soc == null || !soc.isCombined()) {
+            CombinedAttackFiringState ca = gameState.getCombinedAttackFiringState();
+            // Combined Attack and TC-combined: each firing is draw modifiers only, not a weapon destiny total.
+            if ((soc == null || !soc.isCombined()) && ca == null) {
                 totalDestiny = game.getModifiersQuerying().getTotalWeaponDestiny(gameState, _performingPlayerId, totalDestiny);
             }
         }
@@ -705,6 +707,32 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
                         Float totalDestiny = getTotalDestiny(game);
 
                         gameState.endDrawDestiny();
+
+                        CombinedAttackFiringState ca = gameState.getCombinedAttackFiringState();
+                        if (ca != null
+                                && (_destinyType == DestinyType.WEAPON_DESTINY || _destinyType == DestinyType.EPIC_EVENT_AND_WEAPON_DESTINY)) {
+                            float firingDestiny = 0f;
+                            for (Float value : _destinyDrawValues) {
+                                if (value != null) {
+                                    firingDestiny += value;
+                                }
+                            }
+                            com.gempukku.swccgo.game.state.WeaponFiringState wfs = gameState.getWeaponFiringState();
+                            PhysicalCard weapon = wfs != null ? wfs.getCardFiring() : null;
+                            PhysicalCard cardFiring = wfs != null ? wfs.getCardFiringWeapon() : null;
+                            com.gempukku.swccgo.game.SwccgBuiltInCardBlueprint perm = wfs != null ? wfs.getPermanentWeaponFiring() : null;
+                            float totalMod = 0f;
+                            if (wfs != null) {
+                                totalMod = game.getModifiersQuerying().getTotalWeaponDestiny(
+                                        gameState, cardFiring, weapon, perm, wfs.getTargets(), 0f);
+                            }
+                            ca.addFiring(weapon, cardFiring, perm, firingDestiny, totalMod);
+                            String weaponLink = weapon != null ? GameUtils.getCardLink(weapon) : "weapon";
+                            gameState.sendMessage("Combined Attack weapon destiny (draw modifiers only) for "
+                                    + weaponLink + ": " + GuiUtils.formatAsString(firingDestiny));
+                            // Defer hit/ionize until all Combined Attack weapons have fired (Gergall).
+                            return;
+                        }
 
                         SeparatelyOrCombinedFiringState soc = gameState.getSeparatelyOrCombinedFiringState();
                         if (soc != null && soc.isCombined()

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
@@ -514,10 +514,10 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
         if (_destinyType==DestinyType.WEAPON_DESTINY || _destinyType==DestinyType.EPIC_EVENT_AND_WEAPON_DESTINY) {
             SeparatelyOrCombinedFiringState soc = gameState.getSeparatelyOrCombinedFiringState();
             CombinedAttackFiringState ca = gameState.getCombinedAttackFiringState();
-            // Combined Attack: include this firing's total-weapon-destiny modifiers in the displayed total
-            // (Heavy Turbolaser Battery -1/-6). That same number is the Combined Attack subtotal addend.
-            // Standalone Targeting Computer combined: skip here; apply once after both shots.
-            if (ca != null || soc == null || !soc.isCombined()) {
+            // Combined Attack and Targeting Computer combined: draw modifiers stay on each draw.
+            // TOTAL_WEAPON_DESTINY modifiers apply once to the grand total after all draws.
+            boolean skipTotalMods = (ca != null) || (soc != null && soc.isCombined());
+            if (!skipTotalMods) {
                 totalDestiny = game.getModifiersQuerying().getTotalWeaponDestiny(gameState, _performingPlayerId, totalDestiny);
             }
         }
@@ -724,16 +724,14 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
                             PhysicalCard weapon = wfs != null ? wfs.getCardFiring() : null;
                             PhysicalCard cardFiring = wfs != null ? wfs.getCardFiringWeapon() : null;
                             com.gempukku.swccgo.game.SwccgBuiltInCardBlueprint perm = wfs != null ? wfs.getPermanentWeaponFiring() : null;
-                            // Each firing is a complete total-weapon-destiny subtotal: draws (with each-draw
-                            // mods) then this weapon's TOTAL_WEAPON_DESTINY (Heavy Turbolaser Battery -1/-6).
-                            // Unclamped modifier extract so a 0-base + negative is not lost. Clamp once here.
-                            float totalMod = snapshotUnclampedTotalWeaponDestinyModifier(game, gameState, wfs, cardFiring, weapon, perm);
-                            float subtotal = Math.max(0, firingDestiny + totalMod);
+                            // Draw modifiers are already in firingDestiny. Snapshot TOTAL_WEAPON_DESTINY
+                            // contributions so Combined Attack can apply same-title-once to the grand total.
+                            snapshotCombinedAttackTotalMods(game, gameState, ca, wfs, cardFiring, weapon, perm);
                             float variableX = weapon != null
                                     ? game.getModifiersQuerying().getVariableValue(gameState, weapon, Variable.X, 0f)
                                     : 0f;
-                            ca.addFiring(weapon, cardFiring, perm, subtotal, 0f, variableX, _drawDestinyEffect);
-                            gameState.sendMessage(ca.getFiringSubtotalMessage(weapon, subtotal));
+                            ca.addFiring(weapon, cardFiring, perm, firingDestiny, 0f, variableX, _drawDestinyEffect);
+                            gameState.sendMessage(ca.getFiringDrawsMessage(weapon, firingDestiny));
                             // Defer hit/lost/ionize until all Combined Attack weapons have fired (Gergall).
                             return;
                         }
@@ -819,27 +817,30 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
 
     /**
      * Combined Attack snapshot of this firing's TOTAL_WEAPON_DESTINY modifiers, without Math.max(0, ...).
-     * Heavy Turbolaser Battery -1 vs capital / -6 otherwise must stay negative. getTotalWeaponDestiny
-     * clamps a 0 + negative mod to 0, which would drop the penalty. Do not subtract
-     * getTotalWeaponDestiny(draw) - draw; that also clamps.
+     * Heavy Turbolaser Battery -1 vs capital / -6 otherwise must stay negative. Same title is collapsed
+     * once when Combined Attack builds the grand total (PR 1007 is not stacked on the Cumulative Rule engine).
      */
-    private float snapshotUnclampedTotalWeaponDestinyModifier(SwccgGame game, GameState gameState,
-                                                              WeaponFiringState wfs, PhysicalCard cardFiring,
-                                                              PhysicalCard weapon, SwccgBuiltInCardBlueprint perm) {
-        if (wfs == null) {
-            return 0f;
+    private void snapshotCombinedAttackTotalMods(SwccgGame game, GameState gameState, CombinedAttackFiringState ca,
+                                                 WeaponFiringState wfs, PhysicalCard cardFiring,
+                                                 PhysicalCard weapon, SwccgBuiltInCardBlueprint perm) {
+        if (ca == null || wfs == null) {
+            return;
         }
         PhysicalCard firer = cardFiring;
         if (weapon != null && weapon.getAttachedTo() != null
                 && (firer == null || firer.getCardId() == weapon.getCardId())) {
             firer = weapon.getAttachedTo();
         }
-        float totalMod = 0f;
         for (Modifier modifier : game.getModifiersQuerying().getModifiers(gameState, ModifierType.TOTAL_WEAPON_DESTINY)) {
-            totalMod += modifier.getTotalWeaponDestinyModifier(gameState, game.getModifiersQuerying(),
+            float amount = modifier.getTotalWeaponDestinyModifier(gameState, game.getModifiersQuerying(),
                     firer, weapon, perm, wfs.getTargets());
+            if (amount == 0f) {
+                continue;
+            }
+            PhysicalCard source = modifier.getSource(gameState);
+            String title = source != null ? source.getTitle() : "";
+            ca.addTotalModContribution(title, amount, modifier.isCumulative());
         }
-        return totalMod;
     }
 
     /**
@@ -1586,8 +1587,8 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
                                         && (_destinyType == DestinyType.WEAPON_DESTINY || _destinyType == DestinyType.EPIC_EVENT_AND_WEAPON_DESTINY)) {
                                     totalMsg = soc.getFiringLabel() + ": " + totalMsg;
                                 }
-                                // Combined Attack: show this firing's total weapon destiny including that weapon's
-                                // total modifiers (Heavy Turbolaser Battery -1/-6). Targeting Computer firing 1/2 still prefixes the line.
+                                // Combined Attack / Targeting Computer combined skip total mods in getTotalDestiny,
+                                // so this line is draws only. Targeting Computer firing 1/2 still prefixes the line.
                                 gameState.sendMessage(totalMsg);
                             }
 

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
@@ -23,6 +23,7 @@ import com.gempukku.swccgo.logic.decisions.DecisionResultInvalidException;
 import com.gempukku.swccgo.logic.decisions.YesNoDecision;
 import com.gempukku.swccgo.logic.modifiers.Modifier;
 import com.gempukku.swccgo.logic.modifiers.ModifierFlag;
+import com.gempukku.swccgo.logic.modifiers.ModifierType;
 import com.gempukku.swccgo.logic.modifiers.SetInitialCalculationVariableModifier;
 import com.gempukku.swccgo.logic.modifiers.querying.ModifiersEnvironment;
 import com.gempukku.swccgo.logic.modifiers.querying.ModifiersQuerying;
@@ -513,8 +514,10 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
         if (_destinyType==DestinyType.WEAPON_DESTINY || _destinyType==DestinyType.EPIC_EVENT_AND_WEAPON_DESTINY) {
             SeparatelyOrCombinedFiringState soc = gameState.getSeparatelyOrCombinedFiringState();
             CombinedAttackFiringState ca = gameState.getCombinedAttackFiringState();
-            // Combined Attack and TC-combined: each firing is draw modifiers only, not a weapon destiny total.
-            if ((soc == null || !soc.isCombined()) && ca == null) {
+            // Combined Attack: include this firing's total-weapon-destiny modifiers in the displayed total
+            // (Heavy Turbolaser Battery -1/-6). That same number is the Combined Attack subtotal addend.
+            // Standalone Targeting Computer combined: skip here; apply once after both shots.
+            if (ca != null || soc == null || !soc.isCombined()) {
                 totalDestiny = game.getModifiersQuerying().getTotalWeaponDestiny(gameState, _performingPlayerId, totalDestiny);
             }
         }
@@ -721,16 +724,16 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
                             PhysicalCard weapon = wfs != null ? wfs.getCardFiring() : null;
                             PhysicalCard cardFiring = wfs != null ? wfs.getCardFiringWeapon() : null;
                             com.gempukku.swccgo.game.SwccgBuiltInCardBlueprint perm = wfs != null ? wfs.getPermanentWeaponFiring() : null;
-                            float totalMod = 0f;
-                            if (wfs != null) {
-                                totalMod = game.getModifiersQuerying().getTotalWeaponDestiny(
-                                        gameState, cardFiring, weapon, perm, wfs.getTargets(), 0f);
-                            }
+                            // Each firing is a complete total-weapon-destiny subtotal: draws (with each-draw
+                            // mods) then this weapon's TOTAL_WEAPON_DESTINY (Heavy Turbolaser Battery -1/-6).
+                            // Unclamped modifier extract so a 0-base + negative is not lost. Clamp once here.
+                            float totalMod = snapshotUnclampedTotalWeaponDestinyModifier(game, gameState, wfs, cardFiring, weapon, perm);
+                            float subtotal = Math.max(0, firingDestiny + totalMod);
                             float variableX = weapon != null
                                     ? game.getModifiersQuerying().getVariableValue(gameState, weapon, Variable.X, 0f)
                                     : 0f;
-                            ca.addFiring(weapon, cardFiring, perm, firingDestiny, totalMod, variableX, _drawDestinyEffect);
-                            gameState.sendMessage(ca.getDrawModifiersOnlyMessage(weapon, firingDestiny));
+                            ca.addFiring(weapon, cardFiring, perm, subtotal, 0f, variableX, _drawDestinyEffect);
+                            gameState.sendMessage(ca.getFiringSubtotalMessage(weapon, subtotal));
                             // Defer hit/lost/ionize until all Combined Attack weapons have fired (Gergall).
                             return;
                         }
@@ -813,6 +816,31 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
      * @param totalDestiny the total destiny value, or null if all destiny draws failed or were canceled
      */
     protected abstract void destinyDraws(SwccgGame game, List<PhysicalCard> destinyCardDraws, List<Float> destinyDrawValues, Float totalDestiny);
+
+    /**
+     * Combined Attack snapshot of this firing's TOTAL_WEAPON_DESTINY modifiers, without Math.max(0, ...).
+     * Heavy Turbolaser Battery -1 vs capital / -6 otherwise must stay negative. getTotalWeaponDestiny
+     * clamps a 0 + negative mod to 0, which would drop the penalty. Do not subtract
+     * getTotalWeaponDestiny(draw) - draw; that also clamps.
+     */
+    private float snapshotUnclampedTotalWeaponDestinyModifier(SwccgGame game, GameState gameState,
+                                                              WeaponFiringState wfs, PhysicalCard cardFiring,
+                                                              PhysicalCard weapon, SwccgBuiltInCardBlueprint perm) {
+        if (wfs == null) {
+            return 0f;
+        }
+        PhysicalCard firer = cardFiring;
+        if (weapon != null && weapon.getAttachedTo() != null
+                && (firer == null || firer.getCardId() == weapon.getCardId())) {
+            firer = weapon.getAttachedTo();
+        }
+        float totalMod = 0f;
+        for (Modifier modifier : game.getModifiersQuerying().getModifiers(gameState, ModifierType.TOTAL_WEAPON_DESTINY)) {
+            totalMod += modifier.getTotalWeaponDestinyModifier(gameState, game.getModifiersQuerying(),
+                    firer, weapon, perm, wfs.getTargets());
+        }
+        return totalMod;
+    }
 
     /**
      * After Combined Attack / unpaid TC-combined destinies are collected, run this firing's
@@ -1552,19 +1580,15 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
 
                             if (_destinyType != DestinyType.RACE_DESTINY) {
                                 GameState gameState = game.getGameState();
-                                CombinedAttackFiringState ca = gameState.getCombinedAttackFiringState();
                                 SeparatelyOrCombinedFiringState soc = gameState.getSeparatelyOrCombinedFiringState();
                                 String totalMsg = _performingPlayerId + "'s total " + _destinyType.getHumanReadable() + " is " + GuiUtils.formatAsString(totalDestiny);
                                 if (soc != null && soc.getCurrentFiringNumber() > 0
                                         && (_destinyType == DestinyType.WEAPON_DESTINY || _destinyType == DestinyType.EPIC_EVENT_AND_WEAPON_DESTINY)) {
                                     totalMsg = soc.getFiringLabel() + ": " + totalMsg;
                                 }
-                                // Combined Attack non-TC shots stay unlabeled; CA math is the resolve log.
-                                // TC separately/combined (including TC-in-CA) print the firing 1/2 line.
-                                boolean unlabeledCaShot = ca != null && (soc == null || soc.getCurrentFiringNumber() <= 0);
-                                if (!unlabeledCaShot) {
-                                    gameState.sendMessage(totalMsg);
-                                }
+                                // Combined Attack: show this firing's total weapon destiny including that weapon's
+                                // total modifiers (Heavy Turbolaser Battery -1/-6). Targeting Computer firing 1/2 still prefixes the line.
+                                gameState.sendMessage(totalMsg);
                             }
 
                             actionsEnvironment.emitEffectResult(

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
@@ -2,15 +2,18 @@ package com.gempukku.swccgo.logic.effects;
 
 import com.gempukku.swccgo.common.DestinyType;
 import com.gempukku.swccgo.common.GameTextActionId;
+import com.gempukku.swccgo.common.Variable;
 import com.gempukku.swccgo.common.Zone;
 import com.gempukku.swccgo.game.ActionProxy;
 import com.gempukku.swccgo.game.ActionsEnvironment;
 import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgBuiltInCardBlueprint;
 import com.gempukku.swccgo.game.SwccgGame;
 import com.gempukku.swccgo.game.state.DrawDestinyState;
 import com.gempukku.swccgo.game.state.GameState;
 import com.gempukku.swccgo.game.state.SeparatelyOrCombinedFiringState;
 import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.actions.AbstractAction;
 import com.gempukku.swccgo.logic.actions.OptionalGameTextTriggerAction;
 import com.gempukku.swccgo.logic.actions.SubAction;
 import com.gempukku.swccgo.logic.actions.TriggerAction;
@@ -19,6 +22,7 @@ import com.gempukku.swccgo.logic.decisions.DecisionResultInvalidException;
 import com.gempukku.swccgo.logic.decisions.YesNoDecision;
 import com.gempukku.swccgo.logic.modifiers.Modifier;
 import com.gempukku.swccgo.logic.modifiers.ModifierFlag;
+import com.gempukku.swccgo.logic.modifiers.SetInitialCalculationVariableModifier;
 import com.gempukku.swccgo.logic.modifiers.querying.ModifiersEnvironment;
 import com.gempukku.swccgo.logic.modifiers.querying.ModifiersQuerying;
 import com.gempukku.swccgo.logic.modifiers.TotalBattleDestinyModifier;
@@ -27,6 +31,8 @@ import com.gempukku.swccgo.logic.timing.Action;
 import com.gempukku.swccgo.logic.timing.EffectResult;
 import com.gempukku.swccgo.logic.timing.GuiUtils;
 import com.gempukku.swccgo.logic.timing.PassthruEffect;
+import com.gempukku.swccgo.logic.timing.StandardEffect;
+import com.gempukku.swccgo.game.state.WeaponFiringState;
 import com.gempukku.swccgo.logic.timing.results.AboutToCompleteDrawingDestinyResult;
 import com.gempukku.swccgo.logic.timing.results.AboutToDrawDestinyCardResult;
 import com.gempukku.swccgo.logic.timing.results.CostToDrawDestinyCardResult;
@@ -505,7 +511,7 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
         // Add modifiers to total weapon destiny (unless this is combined firing)
         if (_destinyType==DestinyType.WEAPON_DESTINY || _destinyType==DestinyType.EPIC_EVENT_AND_WEAPON_DESTINY) {
             SeparatelyOrCombinedFiringState soc = gameState.getSeparatelyOrCombinedFiringState();
-            // Combined: each firing is a single weapon destiny (draw modifiers only), not a weapon destiny total.
+            // TC-combined: each firing is draw modifiers only, not a weapon destiny total.
             if (soc == null || !soc.isCombined()) {
                 totalDestiny = game.getModifiersQuerying().getTotalWeaponDestiny(gameState, _performingPlayerId, totalDestiny);
             }
@@ -710,10 +716,15 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
                                 }
                             }
                             soc.addFiringDestiny(firingDestiny);
+                            soc.setDrawDestinyEffect(_drawDestinyEffect);
+                            PhysicalCard socWeapon = soc.getWeapon();
+                            if (socWeapon != null) {
+                                soc.setVariableXSnapshot(game.getModifiersQuerying().getVariableValue(gameState, socWeapon, Variable.X, 0f));
+                            }
                             if (gameState.getWeaponFiringState() != null) {
                                 soc.setCardFiringWeapon(gameState.getWeaponFiringState().getCardFiringWeapon());
                             }
-                            gameState.sendMessage("Combined " + soc.getFiringLabel().toLowerCase() + " weapon destiny (draw modifiers only): " + GuiUtils.formatAsString(firingDestiny));
+                            gameState.sendMessage(soc.getCombinedDrawModifiersOnlyMessage(socWeapon, firingDestiny));
 
                             if (!soc.hasCompletedExpectedFirings()) {
                                 // Defer hit resolution until remaining combined firings complete.
@@ -725,7 +736,13 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
                             float combined = soc.getCombinedFiringDestinySum();
                             totalDestiny = game.getModifiersQuerying().getTotalWeaponDestiny(gameState, _performingPlayerId, combined);
                             soc.markResolved();
-                            gameState.sendMessage(soc.getCombinedTotalDestinyMessage(GuiUtils.formatAsString(totalDestiny)));
+                            PhysicalCard socTarget = soc.getCombinedTarget();
+                            float socDefense = socTarget != null
+                                    ? game.getModifiersQuerying().getDefenseValue(gameState, socTarget)
+                                    : 0f;
+                            gameState.sendMessage(soc.getCombinedDestiniesMathMessage(
+                                    GuiUtils.formatAsString(combined), GuiUtils.formatAsString(totalDestiny),
+                                    GuiUtils.formatAsString(socDefense)));
                         }
 
                         // Callback
@@ -768,6 +785,62 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
      * @param totalDestiny the total destiny value, or null if all destiny draws failed or were canceled
      */
     protected abstract void destinyDraws(SwccgGame game, List<PhysicalCard> destinyCardDraws, List<Float> destinyDrawValues, Float totalDestiny);
+
+    /**
+     * After unpaid TC-combined destinies are collected, run this firing's
+     * weapon-specific destinyDraws (hit, lost if X=3, ionize, etc.) against the combined total.
+     * Restores Variable X and a short-lived WeaponFiringState because those last only until
+     * the original fire action ended. Result effects are moved onto applyToAction.
+     */
+    public boolean applyDeferredWeaponResult(SwccgGame game, Action applyToAction, PhysicalCard weapon,
+                                          PhysicalCard cardFiringWeapon, SwccgBuiltInCardBlueprint permanentWeapon,
+                                          PhysicalCard target, float variableX, Float combinedTotal) {
+        GameState gameState = game.getGameState();
+        boolean beganFiring = false;
+        if (gameState.getWeaponFiringState() == null && weapon != null) {
+            gameState.beginWeaponFiring(weapon, permanentWeapon);
+            beganFiring = true;
+            WeaponFiringState wfs = gameState.getWeaponFiringState();
+            if (cardFiringWeapon != null) {
+                wfs.setCardFiringWeapon(cardFiringWeapon);
+            }
+            if (target != null) {
+                wfs.setTarget(target);
+            }
+            if (variableX != 0f) {
+                game.getModifiersEnvironment().addUntilEndOfWeaponFiringModifier(
+                        new SetInitialCalculationVariableModifier(weapon, weapon, variableX, Variable.X));
+            }
+        }
+        boolean queued = false;
+        try {
+            destinyDraws(game, _destinyCardDraws, _destinyDrawValues, combinedTotal);
+            if (_action instanceof AbstractAction && applyToAction instanceof AbstractAction
+                    && _action != applyToAction) {
+                for (StandardEffect effect : ((AbstractAction) _action).drainPendingEffects()) {
+                    applyToAction.appendEffect(effect);
+                    queued = true;
+                }
+            }
+        }
+        finally {
+            if (beganFiring) {
+                if (queued && applyToAction != null) {
+                    applyToAction.appendEffect(
+                            new PassthruEffect(applyToAction) {
+                                @Override
+                                protected void doPlayEffect(SwccgGame game) {
+                                    game.getGameState().finishWeaponFiring();
+                                }
+                            });
+                }
+                else {
+                    gameState.finishWeaponFiring();
+                }
+            }
+        }
+        return queued;
+    }
 
     @Override
     protected boolean wasActionCarriedOut() {
@@ -1447,13 +1520,20 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
                                 return;
 
                             if (_destinyType != DestinyType.RACE_DESTINY) {
-                                String totalMsg = _performingPlayerId + "'s total " + _destinyType.getHumanReadable() + " is " + GuiUtils.formatAsString(totalDestiny);
-                                SeparatelyOrCombinedFiringState soc = game.getGameState().getSeparatelyOrCombinedFiringState();
-                                if (soc != null && soc.getCurrentFiringNumber() > 0
-                                        && (_destinyType == DestinyType.WEAPON_DESTINY || _destinyType == DestinyType.EPIC_EVENT_AND_WEAPON_DESTINY)) {
-                                    totalMsg = soc.getFiringLabel() + ": " + totalMsg;
+                                GameState gameState = game.getGameState();
+                                SeparatelyOrCombinedFiringState soc = gameState.getSeparatelyOrCombinedFiringState();
+                                boolean combinedDrawModsOnly = (soc != null && soc.isCombined());
+                                // TC-combined: do not print a finished-looking "total weapon destiny"
+                                // per shot. Draw-modifiers-only lines plus the combined math block
+                                // are the resolve log.
+                                if (!combinedDrawModsOnly) {
+                                    String totalMsg = _performingPlayerId + "'s total " + _destinyType.getHumanReadable() + " is " + GuiUtils.formatAsString(totalDestiny);
+                                    if (soc != null && soc.getCurrentFiringNumber() > 0
+                                            && (_destinyType == DestinyType.WEAPON_DESTINY || _destinyType == DestinyType.EPIC_EVENT_AND_WEAPON_DESTINY)) {
+                                        totalMsg = soc.getFiringLabel() + ": " + totalMsg;
+                                    }
+                                    gameState.sendMessage(totalMsg);
                                 }
-                                game.getGameState().sendMessage(totalMsg);
                             }
 
                             actionsEnvironment.emitEffectResult(

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
@@ -1554,17 +1554,15 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
                                 GameState gameState = game.getGameState();
                                 CombinedAttackFiringState ca = gameState.getCombinedAttackFiringState();
                                 SeparatelyOrCombinedFiringState soc = gameState.getSeparatelyOrCombinedFiringState();
-                                boolean combinedDrawModsOnly = ca != null
-                                        || (soc != null && soc.isCombined());
-                                // Combined Attack / TC-combined: do not print a finished-looking
-                                // "total weapon destiny" per shot. Draw-modifiers-only lines plus
-                                // the combined math block are the resolve log.
-                                if (!combinedDrawModsOnly) {
-                                    String totalMsg = _performingPlayerId + "'s total " + _destinyType.getHumanReadable() + " is " + GuiUtils.formatAsString(totalDestiny);
-                                    if (soc != null && soc.getCurrentFiringNumber() > 0
-                                            && (_destinyType == DestinyType.WEAPON_DESTINY || _destinyType == DestinyType.EPIC_EVENT_AND_WEAPON_DESTINY)) {
-                                        totalMsg = soc.getFiringLabel() + ": " + totalMsg;
-                                    }
+                                String totalMsg = _performingPlayerId + "'s total " + _destinyType.getHumanReadable() + " is " + GuiUtils.formatAsString(totalDestiny);
+                                if (soc != null && soc.getCurrentFiringNumber() > 0
+                                        && (_destinyType == DestinyType.WEAPON_DESTINY || _destinyType == DestinyType.EPIC_EVENT_AND_WEAPON_DESTINY)) {
+                                    totalMsg = soc.getFiringLabel() + ": " + totalMsg;
+                                }
+                                // Combined Attack non-TC shots stay unlabeled; CA math is the resolve log.
+                                // TC separately/combined (including TC-in-CA) print the firing 1/2 line.
+                                boolean unlabeledCaShot = ca != null && (soc == null || soc.getCurrentFiringNumber() <= 0);
+                                if (!unlabeledCaShot) {
                                     gameState.sendMessage(totalMsg);
                                 }
                             }

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
@@ -726,11 +726,12 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
                                 totalMod = game.getModifiersQuerying().getTotalWeaponDestiny(
                                         gameState, cardFiring, weapon, perm, wfs.getTargets(), 0f);
                             }
-                            ca.addFiring(weapon, cardFiring, perm, firingDestiny, totalMod);
-                            String weaponLink = weapon != null ? GameUtils.getCardLink(weapon) : "weapon";
-                            gameState.sendMessage("Combined Attack weapon destiny (draw modifiers only) for "
-                                    + weaponLink + ": " + GuiUtils.formatAsString(firingDestiny));
-                            // Defer hit/ionize until all Combined Attack weapons have fired (Gergall).
+                            float variableX = weapon != null
+                                    ? game.getModifiersQuerying().getVariableValue(gameState, weapon, Variable.X, 0f)
+                                    : 0f;
+                            ca.addFiring(weapon, cardFiring, perm, firingDestiny, totalMod, variableX, _drawDestinyEffect);
+                            gameState.sendMessage(ca.getDrawModifiersOnlyMessage(weapon, firingDestiny));
+                            // Defer hit/lost/ionize until all Combined Attack weapons have fired (Gergall).
                             return;
                         }
 
@@ -814,7 +815,7 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
     protected abstract void destinyDraws(SwccgGame game, List<PhysicalCard> destinyCardDraws, List<Float> destinyDrawValues, Float totalDestiny);
 
     /**
-     * After unpaid TC-combined destinies are collected, run this firing's
+     * After Combined Attack / unpaid TC-combined destinies are collected, run this firing's
      * weapon-specific destinyDraws (hit, lost if X=3, ionize, etc.) against the combined total.
      * Restores Variable X and a short-lived WeaponFiringState because those last only until
      * the original fire action ended. Result effects are moved onto applyToAction.
@@ -1551,13 +1552,21 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
 
                             if (_destinyType != DestinyType.RACE_DESTINY) {
                                 GameState gameState = game.getGameState();
+                                CombinedAttackFiringState ca = gameState.getCombinedAttackFiringState();
                                 SeparatelyOrCombinedFiringState soc = gameState.getSeparatelyOrCombinedFiringState();
-                                String totalMsg = _performingPlayerId + "'s total " + _destinyType.getHumanReadable() + " is " + GuiUtils.formatAsString(totalDestiny);
-                                if (soc != null && soc.getCurrentFiringNumber() > 0
-                                        && (_destinyType == DestinyType.WEAPON_DESTINY || _destinyType == DestinyType.EPIC_EVENT_AND_WEAPON_DESTINY)) {
-                                    totalMsg = soc.getFiringLabel() + ": " + totalMsg;
+                                boolean combinedDrawModsOnly = ca != null
+                                        || (soc != null && soc.isCombined());
+                                // Combined Attack / TC-combined: do not print a finished-looking
+                                // "total weapon destiny" per shot. Draw-modifiers-only lines plus
+                                // the combined math block are the resolve log.
+                                if (!combinedDrawModsOnly) {
+                                    String totalMsg = _performingPlayerId + "'s total " + _destinyType.getHumanReadable() + " is " + GuiUtils.formatAsString(totalDestiny);
+                                    if (soc != null && soc.getCurrentFiringNumber() > 0
+                                            && (_destinyType == DestinyType.WEAPON_DESTINY || _destinyType == DestinyType.EPIC_EVENT_AND_WEAPON_DESTINY)) {
+                                        totalMsg = soc.getFiringLabel() + ": " + totalMsg;
+                                    }
+                                    gameState.sendMessage(totalMsg);
                                 }
-                                gameState.sendMessage(totalMsg);
                             }
 
                             actionsEnvironment.emitEffectResult(

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/Destiny.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/Destiny.java
@@ -510,6 +510,13 @@ public interface Destiny extends BaseQuery {
             SwccgBuiltInCardBlueprint permanentWeapon = weaponFiringState.getPermanentWeaponFiring();
             Collection<PhysicalCard> weaponTargets = weaponFiringState.getTargets();
             PhysicalCard cardFiringWeapon = weaponFiringState.getCardFiringWeapon();
+            // EachWeaponDestinyForWeaponFiredByModifier (Defiance +2) keys off the card firing,
+            // not the weapon card. If state still points at the weapon itself or has no firer,
+            // use the attached host (the starship).
+            if (weapon != null && weapon.getAttachedTo() != null
+                    && (cardFiringWeapon == null || cardFiringWeapon.getCardId() == weapon.getCardId())) {
+                cardFiringWeapon = weapon.getAttachedTo();
+            }
 
             for (Modifier modifier : getModifiers(gameState, ModifierType.EACH_WEAPON_DESTINY)) {
                 if (!mayNotModifyDestinyDraw(gameState, modifier.getSource(gameState) != null ? modifier.getSource(gameState).getOwner() : null)) {

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/Destiny.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/Destiny.java
@@ -1108,21 +1108,21 @@ public interface Destiny extends BaseQuery {
      * @return the total weapon destiny
      */
     default float getTotalWeaponDestiny(GameState gameState, String playerId, float baseTotalDestiny) {
-        float result = baseTotalDestiny;
-
-        // Get from WeaponFiringState
         WeaponFiringState weaponFiringState = gameState.getWeaponFiringState();
-        if (weaponFiringState != null) {
-            PhysicalCard weapon = weaponFiringState.getCardFiring();
-            SwccgBuiltInCardBlueprint permanentWeapon = weaponFiringState.getPermanentWeaponFiring();
-            Collection<PhysicalCard> weaponTargets = weaponFiringState.getTargets();
-            PhysicalCard cardFiringWeapon = weaponFiringState.getCardFiringWeapon();
-
-            for (Modifier modifier : getModifiers(gameState, ModifierType.TOTAL_WEAPON_DESTINY)) {
-                result += modifier.getTotalWeaponDestinyModifier(gameState, query(), cardFiringWeapon, weapon, permanentWeapon, weaponTargets);
-            }
+        if (weaponFiringState == null) {
+            return Math.max(0, baseTotalDestiny);
         }
+        return getTotalWeaponDestiny(gameState, weaponFiringState.getCardFiringWeapon(), weaponFiringState.getCardFiring(),
+                weaponFiringState.getPermanentWeaponFiring(), weaponFiringState.getTargets(), baseTotalDestiny);
+    }
 
+    default float getTotalWeaponDestiny(GameState gameState, PhysicalCard cardFiringWeapon, PhysicalCard weapon,
+                                        SwccgBuiltInCardBlueprint permanentWeapon, Collection<PhysicalCard> weaponTargets,
+                                        float baseTotalDestiny) {
+        float result = baseTotalDestiny;
+        for (Modifier modifier : getModifiers(gameState, ModifierType.TOTAL_WEAPON_DESTINY)) {
+            result += modifier.getTotalWeaponDestinyModifier(gameState, query(), cardFiringWeapon, weapon, permanentWeapon, weaponTargets);
+        }
         return Math.max(0, result);
     }
 

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/ModifiersLogic.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/ModifiersLogic.java
@@ -2152,7 +2152,7 @@ public class ModifiersLogic implements ModifiersEnvironment, ModifiersState, Mod
         List<Integer> otherDevices = new LinkedList<Integer>();
         if (usedDevices != null)
             for (Integer cardId : usedDevices)
-                if (cardId!=device.getCardId())
+                if (cardId!=device.getCardId() && !otherDevices.contains(cardId))
                     otherDevices.add(cardId);
 
         return otherDevices;
@@ -2175,7 +2175,7 @@ public class ModifiersLogic implements ModifiersEnvironment, ModifiersState, Mod
         List<Integer> otherWeapons = new LinkedList<Integer>();
         if (usedWeapons != null)
             for (Integer cardId : usedWeapons)
-                if (cardId!=weapon.getCardId())
+                if (cardId!=weapon.getCardId() && !otherWeapons.contains(cardId))
                     otherWeapons.add(cardId);
 
         return otherWeapons;

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/DefaultSwccgGame.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/DefaultSwccgGame.java
@@ -555,10 +555,11 @@ public class DefaultSwccgGame implements SwccgGame {
         }
         // Skip snapshot while play-card or firing sub-states are open. generateSnapshot throws on those
         // fields; playCardStates must stay skipped so interrupt-initiated battles still work. Skipping a
-        // leaked SeparatelyOrCombinedFiringState / WeaponFiringState also prevents weapons-segment Pass
+        // leaked SeparatelyOrCombinedFiringState / CombinedAttackFiringState / WeaponFiringState also prevents weapons-segment Pass
         // from aborting the game.
         if (_gameState.getPlayCardStates().isEmpty()
                 && _gameState.getSeparatelyOrCombinedFiringState() == null
+                && _gameState.getCombinedAttackFiringState() == null
                 && !_gameState.isDuringWeaponFiring())
             _snapshots.add(GameSnapshot.createGameSnapshot(getNextSnapshotId(), description, _gameState, _modifiersLogic, _actionsEnvironment, _turnProcedure));
     }

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/DefaultSwccgGame.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/DefaultSwccgGame.java
@@ -546,8 +546,13 @@ public class DefaultSwccgGame implements SwccgGame {
     @Override
     public void takeSnapshot(String description) {
         pruneSnapshots();
-        // need to specifically exclude when getPlayCardStates() is not empty to allow for battles to be initiated by interrupts
-        if (_gameState.getPlayCardStates().isEmpty())
+        // Skip snapshot while play-card or firing sub-states are open. generateSnapshot throws on those
+        // fields; playCardStates must stay skipped so interrupt-initiated battles still work. Skipping a
+        // leaked SeparatelyOrCombinedFiringState / WeaponFiringState also prevents weapons-segment Pass
+        // from aborting the game.
+        if (_gameState.getPlayCardStates().isEmpty()
+                && _gameState.getSeparatelyOrCombinedFiringState() == null
+                && !_gameState.isDuringWeaponFiring())
             _snapshots.add(GameSnapshot.createGameSnapshot(getNextSnapshotId(), description, _gameState, _modifiersLogic, _actionsEnvironment, _turnProcedure));
     }
 

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/DefaultSwccgGame.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/DefaultSwccgGame.java
@@ -11,6 +11,7 @@ import com.gempukku.swccgo.communication.UserFeedback;
 import com.gempukku.swccgo.game.*;
 import com.gempukku.swccgo.game.layout.LocationsLayout;
 import com.gempukku.swccgo.game.state.GameState;
+import com.gempukku.swccgo.game.state.SeparatelyOrCombinedFiringState;
 import com.gempukku.swccgo.game.state.actions.DefaultActionsEnvironment;
 import com.gempukku.swccgo.logic.PlayerOrder;
 import com.gempukku.swccgo.logic.decisions.MultipleChoiceAwaitingDecision;
@@ -546,6 +547,12 @@ public class DefaultSwccgGame implements SwccgGame {
     @Override
     public void takeSnapshot(String description) {
         pruneSnapshots();
+        // After a fire-twice shot has started, clear leaked separately-or-combined state before snapshot.
+        // Do not clear during destinies (weapon firing is open) or before the first shot (targeting).
+        SeparatelyOrCombinedFiringState soc = _gameState.getSeparatelyOrCombinedFiringState();
+        if (soc != null && soc.getCurrentFiringNumber() > 0 && !_gameState.isDuringWeaponFiring()) {
+            _gameState.finishSeparatelyOrCombinedFiring();
+        }
         // Skip snapshot while play-card or firing sub-states are open. generateSnapshot throws on those
         // fields; playCardStates must stay skipped so interrupt-initiated battles still work. Skipping a
         // leaked SeparatelyOrCombinedFiringState / WeaponFiringState also prevents weapons-segment Pass

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
@@ -1,0 +1,313 @@
+package com.gempukku.swccgo.cards.set1.light;
+
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.game.PhysicalCardImpl;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Card_1_39_Tests {
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>()
+                {{
+                    put("tc", "1_39");
+                    put("karie", "9_18");
+                    put("pilot", "1_27");
+                    put("red7", "7_146");
+                    put("xwing", "1_146");
+                    put("ept", "9_88");
+                }},
+                new HashMap<>()
+                {{
+                    put("stalker", "3_152");
+                    put("tie", "1_304");
+                    put("tie2", "1_304");
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSSpaceSystem,
+                StartingSetup.DefaultDSSpaceSystem,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void TargetingComputerStatsAndKeywordsAreCorrect() {
+        /**
+         * Title: Targeting Computer
+         * Uniqueness: Unrestricted
+         * Side: Light
+         * Type: Device
+         * Destiny: 3
+         * Game Text: Use 2 Force to deploy on any starship. Adds 1 to starship's maneuver. If this starship is using a
+         *      weapon during a battle, you may fire that weapon twice, separately or combined. Subtract 1 from each
+         *      destiny draw when firing.
+         * Lore: Specially designed for use on Rebel starfighters. Assists pilots on torpedo runs. Automatically locks
+         *      on pre-programmed target points.
+         * Set: Premiere
+         * Rarity: U1
+         */
+        var scn = GetScenario();
+        var card = scn.GetLSCard("tc").getBlueprint();
+
+        assertEquals("Targeting Computer", card.getTitle());
+        assertEquals(Uniqueness.UNRESTRICTED, card.getUniqueness());
+        assertEquals(Side.LIGHT, card.getSide());
+        assertTrue(card.isCardType(CardType.DEVICE));
+        assertEquals(3, card.getDestiny(), scn.epsilon);
+        assertEquals(Rarity.U1, card.getRarity());
+    }
+
+    @Test
+    public void TargetingComputerDeploysOnStarshipForTwoForceAndAddsOneManeuver() {
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var red7 = scn.GetLSCard("red7");
+        var karie = scn.GetLSCard("karie");
+        scn.MoveCardsToHand(tc);
+
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        scn.MoveCardsToLocation(system, red7);
+        scn.BoardAsPilot(red7, karie);
+
+        assertEquals(4, scn.GetManeuver(red7));
+
+        scn.SkipToLSTurn(Phase.DEPLOY);
+        assertTrue(scn.LSDeployAvailable(tc));
+        scn.LSDeployCard(tc);
+        assertTrue(scn.LSHasCardChoiceAvailable(red7));
+        scn.LSChooseCard(red7);
+        scn.PassAllResponses();
+
+        assertTrue(scn.IsAttachedTo(red7, tc));
+        assertEquals(2, scn.GetDeployCost(tc));
+        assertEquals(5, scn.GetManeuver(red7));
+    }
+
+    @Test
+    public void TargetingComputerCannotBeUsedOutsideBattle() {
+        var scn = GetScenario();
+        setupRed7(scn, true);
+
+        scn.SkipToLSTurn(Phase.CONTROL);
+        assertFalse(scn.LSCardActionAvailable(scn.GetLSCard("tc"), "Fire a weapon twice"));
+
+        scn.SkipToPhase(Phase.DEPLOY);
+        assertFalse(scn.LSCardActionAvailable(scn.GetLSCard("tc"), "Fire a weapon twice"));
+    }
+
+    @Test
+    public void TargetingComputerIsLimitedToOneUsagePerDevicePerBattle() {
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var ept = scn.GetLSCard("ept");
+        var stalker = scn.GetDSCard("stalker");
+        setupRed7(scn, true);
+
+        startWeaponsSegment(scn);
+
+        assertTrue(scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseWeaponIfPrompted(scn, ept);
+        scn.LSChoose("Separately");
+        fireOneShot(scn, stalker, 1);
+        fireOneShot(scn, stalker, 1);
+
+        passOptionalResponses(scn);
+        // After the weapon has been fired twice, LS may have no remaining weapons actions
+        // and the engine auto-passes to DS. Either way the device must not be usable again.
+        if (scn.AwaitingLSWeaponsSegmentActions()) {
+            assertFalse(scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
+        }
+        else {
+            assertTrue("Expected a weapons segment after TC usage. Current decision: "
+                            + (scn.GetCurrentDecision() == null ? "null" : scn.GetCurrentDecision().getText()),
+                    scn.AwaitingDSWeaponsSegmentActions());
+        }
+    }
+
+    @Test
+    public void TargetingComputerFiresTwiceSeparatelyPayingForceTwiceAndCanRetarget() {
+        // Red 7 fires Proton Torpedoes for free, so use a generic X-wing (permanent pilot) + EPT.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var ept = scn.GetLSCard("ept");
+        var tie = scn.GetDSCard("tie");
+        var tie2 = scn.GetDSCard("tie2");
+        setupXwing(scn);
+
+        startWeaponsSegment(scn);
+
+        int forceBefore = scn.GetLSForcePileCount();
+        assertTrue(scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseWeaponIfPrompted(scn, ept);
+        scn.LSChoose("Separately");
+
+        // Without Karie, dest 7 vs TIE: 7 -1 TC -1 EPT (non-capital) = 5 vs maneuver 3 = hit.
+        fireOneShot(scn, tie, 7);
+        assertTrue(tie.isHit());
+        assertFalse(tie2.isHit());
+
+        fireOneShot(scn, tie2, 7);
+        assertTrue(tie2.isHit());
+
+        // EPT costs 1 Force per firing; both shots of the overall action must pay.
+        assertEquals(forceBefore - 2, scn.GetLSForcePileCount());
+    }
+
+    @Test
+    public void TargetingComputerCombinedAddsDrawsThenAppliesTotalModifiersOnce() {
+        /**
+         * AR Example 1 structure (Karie + EPT + TC vs Stalker armor 7):
+         * Each draw: printed + Karie +1 + TC -1. Combined sum, then EPT +1 vs capital, then compare to DV.
+         * AR lists destinies 4 then 2 "for a total of 7" then +1 = 8 vs 7. Rule-text math for 4 then 2 is
+         * (4+1-1)+(2+1-1)=6, then +1 total = 7 vs 7, which does not hit (need > DV). Destinies 4 then 3
+         * produce the intended hit: (4+1-1)+(3+1-1)=7, +1 total = 8 vs 7.
+         */
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var ept = scn.GetLSCard("ept");
+        var stalker = scn.GetDSCard("stalker");
+        setupRed7(scn, true);
+
+        startWeaponsSegment(scn);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseWeaponIfPrompted(scn, ept);
+        scn.LSChoose("Combined");
+
+        fireOneShot(scn, stalker, 4);
+        assertFalse("First combined shot must not resolve a hit by itself", stalker.isHit());
+
+        fireOneShot(scn, stalker, 3);
+        assertTrue(stalker.isHit());
+        assertEquals(7, scn.GetDefense(stalker));
+    }
+
+    @Test
+    public void TargetingComputerSubtractsOneFromEachDrawNotFromCombinedTotal() {
+        // Without Karie: destinies 4 and 4 combined.
+        // Per-draw TC -1: (4-1)+(4-1)=6, EPT +1 vs capital = 7 vs Stalker 7 = miss.
+        // If -1 were applied once to the total: 4+4-1+1 = 8 vs 7 = hit.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var ept = scn.GetLSCard("ept");
+        var stalker = scn.GetDSCard("stalker");
+        setupRed7(scn, false);
+
+        startWeaponsSegment(scn);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseWeaponIfPrompted(scn, ept);
+        scn.LSChoose("Combined");
+
+        fireOneShot(scn, stalker, 4);
+        fireOneShot(scn, stalker, 4);
+
+        assertFalse("TC -1 must apply to each draw, not once to the combined total", stalker.isHit());
+    }
+
+    @Test
+    public void TargetingComputerCombinedCanHitWhenSeparateShotsWouldMiss() {
+        // With Karie, destinies 4 and 4:
+        // Separately each shot is (4+1-1)+1 EPT = 5 vs 7 miss.
+        // Combined: (4+1-1)+(4+1-1)+1 EPT = 9 vs 7 hit.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var ept = scn.GetLSCard("ept");
+        var stalker = scn.GetDSCard("stalker");
+        setupRed7(scn, true);
+
+        startWeaponsSegment(scn);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseWeaponIfPrompted(scn, ept);
+        scn.LSChoose("Combined");
+
+        fireOneShot(scn, stalker, 4);
+        assertFalse(stalker.isHit());
+        fireOneShot(scn, stalker, 4);
+        assertTrue(stalker.isHit());
+    }
+
+    private void setupRed7(VirtualTableScenario scn, boolean includeKarie) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var red7 = scn.GetLSCard("red7");
+        var ept = scn.GetLSCard("ept");
+        var tc = scn.GetLSCard("tc");
+        var stalker = scn.GetDSCard("stalker");
+        var tie = scn.GetDSCard("tie");
+        var tie2 = scn.GetDSCard("tie2");
+
+        scn.MoveCardsToLocation(system, red7, stalker, tie, tie2);
+        if (includeKarie) {
+            scn.BoardAsPilot(red7, scn.GetLSCard("karie"));
+        }
+        else {
+            scn.BoardAsPilot(red7, scn.GetLSCard("pilot"));
+        }
+        scn.AttachCardsTo(red7, ept, tc);
+    }
+
+    private void setupXwing(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var xwing = scn.GetLSCard("xwing");
+        var ept = scn.GetLSCard("ept");
+        var tc = scn.GetLSCard("tc");
+        var stalker = scn.GetDSCard("stalker");
+        var tie = scn.GetDSCard("tie");
+        var tie2 = scn.GetDSCard("tie2");
+
+        scn.MoveCardsToLocation(system, xwing, stalker, tie, tie2);
+        scn.AttachCardsTo(xwing, ept, tc);
+    }
+
+    private void startWeaponsSegment(VirtualTableScenario scn) {
+        scn.SkipToLSTurn(Phase.BATTLE);
+        scn.LSInitiateBattle(scn.GetLSStartingLocation());
+        passOptionalResponses(scn);
+        assertTrue(scn.AwaitingLSWeaponsSegmentActions());
+    }
+
+    private void chooseWeaponIfPrompted(VirtualTableScenario scn, PhysicalCardImpl weapon) {
+        if (scn.LSDecisionAvailable("Choose weapon")) {
+            scn.LSChooseCard(weapon);
+        }
+    }
+
+    private void fireOneShot(VirtualTableScenario scn, PhysicalCardImpl target, int destiny) {
+        // Combined second shots auto-target and may already be at Force/Fire responses.
+        // Prepare destiny before passing those responses so the next draw is stubbed.
+        if (scn.LSGetDecision() != null && scn.LSHasCardChoiceAvailable(target)) {
+            scn.LSChooseCard(target);
+        }
+        scn.PrepareLSDestiny(destiny);
+        scn.PassForceUseResponses();
+        scn.PassWeaponFireWithDestinyDraw();
+    }
+
+    private void passOptionalResponses(VirtualTableScenario scn) {
+        if (scn.GetCurrentDecision() != null) {
+            scn.PassAllResponses();
+        }
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
@@ -1,7 +1,6 @@
 package com.gempukku.swccgo.cards.set1.light;
 
 import com.gempukku.swccgo.common.CardType;
-import com.gempukku.swccgo.common.IonizationType;
 import com.gempukku.swccgo.common.Phase;
 import com.gempukku.swccgo.common.Rarity;
 import com.gempukku.swccgo.common.Side;
@@ -126,16 +125,15 @@ public class Card_1_39_Tests {
         var stalker = scn.GetDSCard("stalker");
         setupRed7(scn, true);
 
-        startWeaponsSegment(scn);
+        scn.StartBattleAndSkipToWeaponsSegment();
 
         assertTrue(scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
         scn.LSUseCardAction(tc, "Fire a weapon twice");
-        chooseWeaponIfPrompted(scn, ept);
-        scn.LSChoose("Separately");
+        chooseSeparatelyOrCombined(scn, "Separately");
         fireOneShot(scn, stalker, 1);
         fireOneShot(scn, stalker, 1);
 
-        passOptionalResponses(scn);
+        scn.PassAllResponses();
         // After the weapon has been fired twice, LS may have no remaining weapons actions
         // and the engine auto-passes to DS. Either way the device must not be usable again.
         if (scn.AwaitingLSWeaponsSegmentActions()) {
@@ -158,13 +156,12 @@ public class Card_1_39_Tests {
         var tie2 = scn.GetDSCard("tie2");
         setupXwing(scn);
 
-        startWeaponsSegment(scn);
+        scn.StartBattleAndSkipToWeaponsSegment();
 
         int forceBefore = scn.GetLSForcePileCount();
         assertTrue(scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
         scn.LSUseCardAction(tc, "Fire a weapon twice");
-        chooseWeaponIfPrompted(scn, ept);
-        scn.LSChoose("Separately");
+        chooseSeparatelyOrCombined(scn, "Separately");
 
         // Without Karie, dest 7 vs TIE: 7 -1 TC -1 EPT (non-capital) = 5 vs maneuver 3 = hit.
         fireOneShot(scn, tie, 7);
@@ -193,11 +190,10 @@ public class Card_1_39_Tests {
         var stalker = scn.GetDSCard("stalker");
         setupRed7(scn, true);
 
-        startWeaponsSegment(scn);
+        scn.StartBattleAndSkipToWeaponsSegment();
 
         scn.LSUseCardAction(tc, "Fire a weapon twice");
-        chooseWeaponIfPrompted(scn, ept);
-        scn.LSChoose("Combined");
+        chooseSeparatelyOrCombined(scn, "Combined");
 
         fireOneShot(scn, stalker, 4);
         assertFalse("First combined shot must not resolve a hit by itself", stalker.isHit());
@@ -218,11 +214,10 @@ public class Card_1_39_Tests {
         var stalker = scn.GetDSCard("stalker");
         setupRed7(scn, false);
 
-        startWeaponsSegment(scn);
+        scn.StartBattleAndSkipToWeaponsSegment();
 
         scn.LSUseCardAction(tc, "Fire a weapon twice");
-        chooseWeaponIfPrompted(scn, ept);
-        scn.LSChoose("Combined");
+        chooseSeparatelyOrCombined(scn, "Combined");
 
         fireOneShot(scn, stalker, 4);
         fireOneShot(scn, stalker, 4);
@@ -241,11 +236,10 @@ public class Card_1_39_Tests {
         var stalker = scn.GetDSCard("stalker");
         setupRed7(scn, true);
 
-        startWeaponsSegment(scn);
+        scn.StartBattleAndSkipToWeaponsSegment();
 
         scn.LSUseCardAction(tc, "Fire a weapon twice");
-        chooseWeaponIfPrompted(scn, ept);
-        scn.LSChoose("Combined");
+        chooseSeparatelyOrCombined(scn, "Combined");
 
         fireOneShot(scn, stalker, 4);
         assertFalse(stalker.isHit());
@@ -265,12 +259,11 @@ public class Card_1_39_Tests {
         var tie2 = scn.GetDSCard("tie2");
         setupXwingLaser(scn);
 
-        startWeaponsSegment(scn);
+        scn.StartBattleAndSkipToWeaponsSegment();
 
         assertTrue(scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
         scn.LSUseCardAction(tc, "Fire a weapon twice");
-        chooseWeaponIfPrompted(scn, xwlc);
-        scn.LSChoose("Separately");
+        chooseSeparatelyOrCombined(scn, "Separately");
 
         fireOneShot(scn, tie, 5, 0);
         assertTrue(tie.isHit());
@@ -290,11 +283,10 @@ public class Card_1_39_Tests {
         var tie = scn.GetDSCard("tie");
         setupXwingLaser(scn);
 
-        startWeaponsSegment(scn);
+        scn.StartBattleAndSkipToWeaponsSegment();
 
         scn.LSUseCardAction(tc, "Fire a weapon twice");
-        chooseWeaponIfPrompted(scn, xwlc);
-        scn.LSChoose("Combined");
+        chooseSeparatelyOrCombined(scn, "Combined");
 
         fireOneShot(scn, tie, 4, 0);
         assertFalse("First combined X-wing Laser Cannon shot must not resolve a hit by itself", tie.isHit());
@@ -315,20 +307,19 @@ public class Card_1_39_Tests {
         var tie2 = scn.GetDSCard("tie2");
         setupYwingIon(scn);
 
-        startWeaponsSegment(scn);
+        scn.StartBattleAndSkipToWeaponsSegment();
 
         int forceBefore = scn.GetLSForcePileCount();
         scn.LSUseCardAction(tc, "Fire a weapon twice");
-        chooseWeaponIfPrompted(scn, sw4);
-        scn.LSChoose("Separately");
+        chooseSeparatelyOrCombined(scn, "Separately");
 
         fireOneShot(scn, tie, 5);
-        assertTrue(isIonized(tie));
+        assertTrue(scn.IsIonized(tie));
         assertFalse(tie.isHit());
-        assertFalse(isIonized(tie2));
+        assertFalse(scn.IsIonized(tie2));
 
         fireOneShot(scn, tie2, 5);
-        assertTrue(isIonized(tie2));
+        assertTrue(scn.IsIonized(tie2));
         assertFalse(tie2.isHit());
         assertEquals(forceBefore - 2, scn.GetLSForcePileCount());
     }
@@ -342,18 +333,17 @@ public class Card_1_39_Tests {
         var tie = scn.GetDSCard("tie");
         setupYwingIon(scn);
 
-        startWeaponsSegment(scn);
+        scn.StartBattleAndSkipToWeaponsSegment();
 
         scn.LSUseCardAction(tc, "Fire a weapon twice");
-        chooseWeaponIfPrompted(scn, sw4);
-        scn.LSChoose("Combined");
+        chooseSeparatelyOrCombined(scn, "Combined");
 
         fireOneShot(scn, tie, 4);
-        assertFalse(isIonized(tie));
+        assertFalse(scn.IsIonized(tie));
         assertFalse(tie.isHit());
 
         fireOneShot(scn, tie, 4);
-        assertTrue(isIonized(tie));
+        assertTrue(scn.IsIonized(tie));
         assertFalse("Ion Cannon must ionize, not hit", tie.isHit());
     }
 
@@ -368,28 +358,27 @@ public class Card_1_39_Tests {
         var tie2 = scn.GetDSCard("tie2");
         setupYwingIon(scn);
 
-        startWeaponsSegment(scn);
-        drainLSForcePileTo(scn, 1);
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.DrainLSForcePileTo(1);
         assertEquals(1, scn.GetLSForcePileCount());
 
         scn.LSUseCardAction(tc, "Fire a weapon twice");
-        chooseWeaponIfPrompted(scn, sw4);
-        scn.LSChoose("Separately");
+        chooseSeparatelyOrCombined(scn, "Separately");
 
         fireOneShot(scn, tie, 5);
-        assertTrue(isIonized(tie));
+        assertTrue(scn.IsIonized(tie));
         assertFalse(tie.isHit());
-        assertFalse(isIonized(tie2));
+        assertFalse(scn.IsIonized(tie2));
         assertEquals(0, scn.GetLSForcePileCount());
 
-        passOptionalResponses(scn);
+        scn.PassAllResponses();
         if (scn.AwaitingLSWeaponsSegmentActions()) {
             assertFalse(scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
         }
         else {
             assertTrue(scn.AwaitingDSWeaponsSegmentActions() || scn.GetCurrentDecision() != null);
         }
-        assertFalse("Second TIE must not be ionized when shot 2 cannot pay", isIonized(tie2));
+        assertFalse("Second TIE must not be ionized when shot 2 cannot pay", scn.IsIonized(tie2));
     }
 
     @Test
@@ -402,18 +391,17 @@ public class Card_1_39_Tests {
         var tie = scn.GetDSCard("tie");
         setupYwingIon(scn);
 
-        startWeaponsSegment(scn);
-        drainLSForcePileTo(scn, 1);
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.DrainLSForcePileTo(1);
         assertEquals(1, scn.GetLSForcePileCount());
 
         scn.LSUseCardAction(tc, "Fire a weapon twice");
-        chooseWeaponIfPrompted(scn, sw4);
-        scn.LSChoose("Combined");
+        chooseSeparatelyOrCombined(scn, "Combined");
 
         fireOneShot(scn, tie, 5);
-        passOptionalResponses(scn);
+        scn.PassAllResponses();
 
-        assertTrue("Completed combined firing must still apply vs the target", isIonized(tie));
+        assertTrue("Completed combined firing must still apply vs the target", scn.IsIonized(tie));
         assertFalse(tie.isHit());
         assertEquals(0, scn.GetLSForcePileCount());
         if (scn.AwaitingLSWeaponsSegmentActions()) {
@@ -431,11 +419,10 @@ public class Card_1_39_Tests {
         var stalker = scn.GetDSCard("stalker");
         setupHomeOne(scn);
 
-        startWeaponsSegment(scn);
+        scn.StartBattleAndSkipToWeaponsSegment();
 
         scn.LSUseCardAction(tc, "Fire a weapon twice");
-        chooseWeaponIfPrompted(scn, htb);
-        scn.LSChoose("Separately");
+        chooseSeparatelyOrCombined(scn, "Separately");
 
         fireTwoDestinyShot(scn, stalker, 7, 7);
         assertTrue(stalker.isHit());
@@ -451,12 +438,11 @@ public class Card_1_39_Tests {
         var stalker = scn.GetDSCard("stalker");
         setupHomeOne(scn);
 
-        startWeaponsSegment(scn);
-        ensureLSForcePile(scn, 4);
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
 
         scn.LSUseCardAction(tc, "Fire a weapon twice");
-        chooseWeaponIfPrompted(scn, htb);
-        scn.LSChoose("Combined");
+        chooseSeparatelyOrCombined(scn, "Combined");
 
         fireTwoDestinyShot(scn, stalker, 4, 4);
         assertFalse("First combined HTB firing must not resolve a hit by itself", stalker.isHit());
@@ -499,17 +485,13 @@ public class Card_1_39_Tests {
         scn.AttachCardsTo(xwing, ept, tc);
     }
 
-    private void startWeaponsSegment(VirtualTableScenario scn) {
-        scn.SkipToLSTurn(Phase.BATTLE);
-        scn.LSInitiateBattle(scn.GetLSStartingLocation());
-        passOptionalResponses(scn);
-        assertTrue(scn.AwaitingLSWeaponsSegmentActions());
-    }
-
-    private void chooseWeaponIfPrompted(VirtualTableScenario scn, PhysicalCardImpl weapon) {
-        if (scn.LSDecisionAvailable("Choose weapon")) {
-            scn.LSChooseCard(weapon);
-        }
+    private void chooseSeparatelyOrCombined(VirtualTableScenario scn, String mode) {
+        assertFalse("These setups attach one legal weapon; GEMP must auto-select it instead of prompting",
+                scn.LSDecisionAvailable("Choose weapon"));
+        assertTrue("Expected Separately/Combined prompt, got: "
+                        + (scn.GetCurrentDecision() == null ? "null" : scn.GetCurrentDecision().getText()),
+                scn.LSDecisionAvailable("separately or combined"));
+        scn.LSChoose(mode);
     }
 
     private void setupXwingLaser(VirtualTableScenario scn) {
@@ -597,30 +579,6 @@ public class Card_1_39_Tests {
         }
         int amount = forceToUse != null ? forceToUse : scn.LSGetChoiceMin();
         scn.LSDecided(amount);
-    }
-
-    private void ensureLSForcePile(VirtualTableScenario scn, int min) {
-        while (scn.GetLSForcePileCount() < min && scn.GetLSReserveDeckCount() > 2) {
-            scn.MoveCardsToTopOfLSForcePile(scn.GetTopOfLSReserveDeck());
-        }
-    }
-
-    private void drainLSForcePileTo(VirtualTableScenario scn, int remaining) {
-        while (scn.GetLSForcePileCount() > remaining) {
-            scn.MoveCardsToHand(scn.GetTopOfLSForcePile());
-        }
-    }
-
-    private boolean isIonized(PhysicalCardImpl card) {
-        return card.getIonization() != null
-                && (card.getIonization().contains(IonizationType.DEFENSE_IONIZED)
-                || card.getIonization().contains(IonizationType.HYPERSPEED_IONIZED));
-    }
-
-    private void passOptionalResponses(VirtualTableScenario scn) {
-        if (scn.GetCurrentDecision() != null) {
-            scn.PassAllResponses();
-        }
     }
 
     private void passPostFiringResponses(VirtualTableScenario scn) {

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
@@ -489,8 +489,10 @@ public class Card_1_39_Tests {
 
     @Test
     public void DefianceHeavyTurbolaserVsVictoryClassAddsTwoToEachDraw() {
-        // HTB draws two destinies. Defiance +2 each. Vs VSD (capital) HTB -1 total, not -6 vs starfighter.
-        // Printed 2,2 without +2: 2+2-1=3 vs armor 5 miss. With +2: 4+4-1=7 vs 5 hit.
+        // HTB draws two destinies vs VSD (capital): HTB -1 total, not -6 vs starfighter. No Targeting Computer.
+        // Printed destinies 2 and 2. No bonus: 2+2-1=3 vs armor 5 miss.
+        // +1 each would be (2+1)+(2+1)-1=5 vs 5 miss (equal fails).
+        // +2 each is (2+2)+(2+2)-1=7 vs 5 hit. +2 per draw is required; a hypothetical +1 cannot pass.
         var scn = GetScenario();
         var htb = scn.GetLSCard("htb");
         var vsd = scn.GetDSCard("vsd");
@@ -506,6 +508,8 @@ public class Card_1_39_Tests {
         assertEquals(5, scn.GetDefense(vsd));
         assertTrue("Each HTB draw from Defiance must include +2 (2+2 + 2+2 -1 vs VSD 5)", vsd.isHit());
         assertWeaponDestinyDrawValues(scn, 4, 4);
+        assertEquals("total weapon destiny must be 7 so +1 each (5 vs 5 miss) cannot pass",
+                7, lastTotalWeaponDestiny(scn));
         assertFalse("Ordinary non-TC shots stay unlabeled", gameLog(scn).contains("firing 1"));
     }
 
@@ -652,6 +656,26 @@ public class Card_1_39_Tests {
 
     private String gameLog(VirtualTableScenario scn) {
         return String.join("\n", scn.gameState().getLastMessages());
+    }
+
+    private int lastTotalWeaponDestiny(VirtualTableScenario scn) {
+        Integer last = null;
+        for (String msg : scn.gameState().getLastMessages()) {
+            String lower = msg.toLowerCase();
+            int idx = lower.lastIndexOf("total weapon destiny is ");
+            if (idx >= 0) {
+                String rest = msg.substring(idx + "total weapon destiny is ".length()).trim();
+                last = (int) Float.parseFloat(rest.split("[^0-9.]")[0]);
+                continue;
+            }
+            idx = msg.indexOf("Total destiny: ");
+            if (idx >= 0) {
+                String rest = msg.substring(idx + "Total destiny: ".length()).trim();
+                last = (int) Float.parseFloat(rest.split("[^0-9.]")[0]);
+            }
+        }
+        assertTrue("Expected a total weapon destiny log, got: " + gameLog(scn), last != null);
+        return last;
     }
 
     private void assertWeaponDestinyDrawValues(VirtualTableScenario scn, int... expected) {

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
@@ -5,6 +5,7 @@ import com.gempukku.swccgo.common.Phase;
 import com.gempukku.swccgo.common.Rarity;
 import com.gempukku.swccgo.common.Side;
 import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.common.Zone;
 import com.gempukku.swccgo.framework.StartingSetup;
 import com.gempukku.swccgo.framework.VirtualTableScenario;
 import com.gempukku.swccgo.game.PhysicalCardImpl;
@@ -293,6 +294,34 @@ public class Card_1_39_Tests {
 
         fireOneShot(scn, tie, 4, 0);
         assertTrue(tie.isHit());
+    }
+
+    @Test
+    public void TargetingComputerCombinedXwingLaserCannonX3LosesTieNotMerelyHit() {
+        // Combined twice at X=3: destinies 4 then 4, TC -1 each => 3+3=6, then +X=3 > TIE DV 3.
+        // XWLC must lose the TIE (not HitCardEffect).
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var xwlc = scn.GetLSCard("xwlc");
+        var tie = scn.GetDSCard("tie");
+        setupXwingLaser(scn);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(6);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseSeparatelyOrCombined(scn, "Combined");
+
+        fireOneShot(scn, tie, 4, 3);
+        assertFalse("First combined XWLC shot must not resolve a hit or loss by itself", tie.isHit());
+        assertEquals(Zone.AT_LOCATION, tie.getZone());
+
+        fireOneShot(scn, tie, 4, 3);
+        scn.PassResponses("ABOUT_TO_BE_LOST");
+        scn.PassAllResponses();
+        assertTrue("Combined X-wing Laser Cannon at X=3 must lose the TIE, not merely hit",
+                tie.getZone() == Zone.LOST_PILE || tie.getZone() == Zone.TOP_OF_LOST_PILE);
+        assertFalse(tie.getZone() == Zone.AT_LOCATION);
     }
 
     @Test
@@ -585,6 +614,9 @@ public class Card_1_39_Tests {
         // Ion Cannon resets attributes then ionizes; do not PassAllResponses or combined shot 2's Fire window is consumed.
         scn.PassResponses("ATTRIBUTE_RESET_OR_MODIFIED");
         scn.PassResponses("Ionized");
+        scn.PassResponses("ABOUT_TO_BE_LOST");
+        scn.PassResponses("ABOUT_TO_BE_HIT");
+        scn.PassResponses("HIT -");
         scn.PassResponses("FIRED_WEAPON");
     }
 }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
@@ -11,7 +11,10 @@ import com.gempukku.swccgo.framework.VirtualTableScenario;
 import com.gempukku.swccgo.game.PhysicalCardImpl;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -33,12 +36,14 @@ public class Card_1_39_Tests {
                     put("homeone", "9_74");
                     put("htb", "9_89");
                     put("ept", "9_88");
+                    put("defiance", "9_67");
                 }},
                 new HashMap<>()
                 {{
                     put("stalker", "3_152");
                     put("tie", "1_304");
                     put("tie2", "1_304");
+                    put("vsd", "2_155");
                 }},
                 10,
                 10,
@@ -458,6 +463,84 @@ public class Card_1_39_Tests {
     }
 
     @Test
+    public void TargetingComputerDontFireLeavesDeviceUnusedSoItCanBeUsedLaterThisBattle() {
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var tie = scn.GetDSCard("tie");
+        setupXwingLaser(scn);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+
+        assertTrue(scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseSeparatelyOrCombined(scn, "Don't Fire (Cancel)");
+
+        assertTrue("Don't Fire must return to weapons-segment actions, got: "
+                        + (scn.GetCurrentDecision() == null ? "null" : scn.GetCurrentDecision().getText()),
+                scn.AwaitingLSWeaponsSegmentActions());
+        assertTrue("Don't Fire must not consume Targeting Computer",
+                scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseSeparatelyOrCombined(scn, "Separately");
+        fireOneShot(scn, tie, 5, 0);
+        assertTrue(tie.isHit());
+    }
+
+    @Test
+    public void DefianceHeavyTurbolaserVsVictoryClassAddsTwoToEachDraw() {
+        // HTB draws two destinies. Defiance +2 each. Vs VSD (capital) HTB -1 total, not -6 vs starfighter.
+        // Printed 2,2 without +2: 2+2-1=3 vs armor 5 miss. With +2: 4+4-1=7 vs 5 hit.
+        var scn = GetScenario();
+        var htb = scn.GetLSCard("htb");
+        var vsd = scn.GetDSCard("vsd");
+        setupDefiance(scn, false);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
+
+        assertTrue(scn.LSCardActionAvailable(htb, "Fire"));
+        scn.LSUseCardAction(htb, "Fire");
+        fireTwoDestinyShot(scn, vsd, 2, 2);
+
+        assertEquals(5, scn.GetDefense(vsd));
+        assertTrue("Each HTB draw from Defiance must include +2 (2+2 + 2+2 -1 vs VSD 5)", vsd.isHit());
+        assertWeaponDestinyDrawValues(scn, 4, 4);
+        assertFalse("Ordinary non-TC shots stay unlabeled", gameLog(scn).contains("firing 1"));
+    }
+
+    @Test
+    public void DefianceTargetingComputerCombinedAppliesMinusOneAndPlusTwoPerDraw() {
+        // TC -1 and Defiance +2 per draw (net +1 vs printed). HTB two draws per firing.
+        // Printed 2,2 then 2,2: each firing (2-1+2)*2=6. Combined 12, HTB -1 vs capital = 11 vs VSD 5 hit.
+        // Without Defiance +2: (2-1)*2 per firing, combined 4, -1 = 3 vs 5 miss.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var vsd = scn.GetDSCard("vsd");
+        setupDefiance(scn, true);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseSeparatelyOrCombined(scn, "Combined");
+
+        fireTwoDestinyShot(scn, vsd, 2, 2);
+        assertFalse("First combined HTB firing must not resolve a hit by itself", vsd.isHit());
+
+        fireTwoDestinyShot(scn, vsd, 2, 2);
+        assertTrue("TC -1 and Defiance +2 must both apply per draw", vsd.isHit());
+        assertWeaponDestinyDrawValues(scn, 3, 3, 3, 3);
+
+        String log = gameLog(scn);
+        assertTrue(log.contains("twice: combined"));
+        assertTrue(log.contains("Targeting Computer Combined firing 1"));
+        assertTrue(log.contains("Targeting Computer Combined firing 2"));
+        assertFalse("No parentheses around the weapon name", log.contains("firing 1 ("));
+        assertFalse(log.contains("firing 2 ("));
+    }
+
+    @Test
     public void TargetingComputerFiresHeavyTurbolaserFromHomeOneCombined() {
         // Combined HTB vs Stalker: each firing is one weapon destiny (sum of two TC-modified draws).
         // dest 4,4 => (4-1)+(4-1)=6 stored, not a hit yet. Second firing 4,4 => 6. Combined 12, total -1 = 11 vs 7 hit.
@@ -517,9 +600,12 @@ public class Card_1_39_Tests {
     private void chooseSeparatelyOrCombined(VirtualTableScenario scn, String mode) {
         assertFalse("These setups attach one legal weapon; GEMP must auto-select it instead of prompting",
                 scn.LSDecisionAvailable("Choose weapon"));
-        assertTrue("Expected Separately/Combined prompt, got: "
+        assertTrue("Expected Fire a weapon twice prompt, got: "
                         + (scn.GetCurrentDecision() == null ? "null" : scn.GetCurrentDecision().getText()),
-                scn.LSDecisionAvailable("separately or combined"));
+                scn.LSDecisionAvailable("Fire a weapon twice"));
+        assertTrue(scn.LSChoiceAvailable("Separately"));
+        assertTrue(scn.LSChoiceAvailable("Combined"));
+        assertTrue(scn.LSChoiceAvailable("Don't Fire (Cancel)"));
         scn.LSChoose(mode);
     }
 
@@ -547,6 +633,42 @@ public class Card_1_39_Tests {
         var tie2 = scn.GetDSCard("tie2");
         scn.MoveCardsToLocation(system, ywing, stalker, tie, tie2);
         scn.AttachCardsTo(ywing, sw4, tc);
+    }
+
+    private void setupDefiance(VirtualTableScenario scn, boolean withTc) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var defiance = scn.GetLSCard("defiance");
+        var htb = scn.GetLSCard("htb");
+        var vsd = scn.GetDSCard("vsd");
+        scn.MoveCardsToLocation(system, defiance, vsd);
+        if (withTc) {
+            scn.AttachCardsTo(defiance, htb, scn.GetLSCard("tc"));
+        }
+        else {
+            scn.AttachCardsTo(defiance, htb);
+        }
+    }
+
+    private String gameLog(VirtualTableScenario scn) {
+        return String.join("\n", scn.gameState().getLastMessages());
+    }
+
+    private void assertWeaponDestinyDrawValues(VirtualTableScenario scn, int... expected) {
+        List<Integer> actual = new ArrayList<>();
+        for (String msg : scn.gameState().getLastMessages()) {
+            int idx = msg.indexOf(" as a ");
+            int destIdx = msg.indexOf(" for weapon destiny");
+            if (idx >= 0 && destIdx > idx) {
+                actual.add((int) Float.parseFloat(msg.substring(idx + " as a ".length(), destIdx).trim()));
+            }
+        }
+        assertTrue("Expected last weapon destiny draws " + Arrays.toString(expected) + " but saw " + actual,
+                actual.size() >= expected.length);
+        List<Integer> last = actual.subList(actual.size() - expected.length, actual.size());
+        for (int i = 0; i < expected.length; i++) {
+            assertEquals("weapon destiny draw " + (i + 1) + " of " + last, expected[i], last.get(i).intValue());
+        }
     }
 
     private void setupHomeOne(VirtualTableScenario scn) {

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
@@ -604,6 +604,32 @@ public class Card_1_39_Tests {
     }
 
     @Test
+    public void TargetingComputerAttachedDoesNotSubtractFromNormalHeavyTurbolaserFire() {
+        // Playtest: Verrack on Defiance fires HTB at Executor with Targeting Computer attached but unused.
+        // Printed 3 (HTB) and 6 (Concentrate All Fire): each +2 Defiance +2 Verrack vs capital.
+        // Correct: 7 and 10, total 17-1=16 vs armor 12.
+        // Unused TC -1 would make 6 and 9, total 14.
+        var scn = GetScenario();
+        var htb = scn.GetLSCard("htb");
+        var executor = scn.GetDSCard("executor");
+        setupDefianceVerrack(scn, true);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
+
+        assertTrue(scn.LSCardActionAvailable(htb, "Fire"));
+        scn.LSUseCardAction(htb, "Fire");
+        fireTwoDestinyShot(scn, executor, 3, 6);
+
+        assertEquals(12, scn.GetDefense(executor));
+        assertWeaponDestinyDrawValues(scn, 7, 10);
+        assertEquals("unused Targeting Computer must not subtract 1 per draw (that would total 14)",
+                16, lastTotalWeaponDestiny(scn));
+        assertTrue(executor.isHit());
+        assertFalse("Ordinary non-TC shots stay unlabeled", gameLog(scn).contains("firing 1"));
+    }
+
+    @Test
     public void DefianceDackVerrackTargetingComputerSeparatelyEachBonusesRequiredVsExecutor() {
         // TC -1 each. Printed 3 and 3: each draw 3+2+1+2-1=7, total 14-1=13 vs 12 hit.
         // Missing Dack: 11 vs 12 miss.
@@ -859,6 +885,22 @@ public class Card_1_39_Tests {
         scn.AttachCardsTo(ywing, sw4, tc);
     }
 
+
+    private void setupDefianceVerrack(VirtualTableScenario scn, boolean withTc) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var defiance = scn.GetLSCard("defiance");
+        var htb = scn.GetLSCard("htb");
+        var executor = scn.GetDSCard("executor");
+        scn.MoveCardsToLocation(system, defiance, executor);
+        scn.BoardAsPassenger(defiance, scn.GetLSCard("verrack"));
+        if (withTc) {
+            scn.AttachCardsTo(defiance, htb, scn.GetLSCard("tc"));
+        }
+        else {
+            scn.AttachCardsTo(defiance, htb);
+        }
+    }
 
     private void setupDefianceGunners(VirtualTableScenario scn, boolean withTc) {
         scn.StartGame();

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
@@ -653,6 +653,30 @@ public class Card_1_39_Tests {
     }
 
     @Test
+    public void DefianceKarieDackVerrackTargetingComputerSeparatelyDrawsAreEightNotNineVsExecutor() {
+        // Playtest: Targeting Computer fires Heavy Turbolaser Battery twice separately at Executor.
+        // Defiance +2 each (FiredBy), Karie Neth +1, Dack Ralter +1, Captain Verrack +2 vs capital = +6.
+        // Targeting Computer -1 each while using Fire a weapon twice. Printed 3 and 3 must be 8 and 8, not 9 and 9.
+        // Heavy Turbolaser Battery -1 vs capital still applies to the total: 16-1=15 vs armor 12.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var executor = scn.GetDSCard("executor");
+        setupDefianceKarieGunners(scn);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseSeparatelyOrCombined(scn, "Separately");
+        fireTwoDestinyShot(scn, executor, 3, 3);
+
+        assertWeaponDestinyDrawValues(scn, 8, 8);
+        assertEquals("Targeting Computer -1 must apply to each draw; 9+9-1 vs capital would total 17",
+                15, lastTotalWeaponDestiny(scn));
+        assertTrue(executor.isHit());
+    }
+
+    @Test
     public void TargetingComputerSeparatelyFireTwiceClearsFiringStateAfterDefianceHitsCapital() {
         // Playtest crash: Targeting Computer fires Heavy Turbolaser Battery twice separately
         // (TIE, then a capital). Defiance required response reduces the capital power by 5.
@@ -936,6 +960,22 @@ public class Card_1_39_Tests {
         }
     }
 
+    /**
+     * Defiance with Karie Neth piloting, Dack Ralter and Captain Verrack as passengers,
+     * Heavy Turbolaser Battery and Targeting Computer, facing Executor.
+     */
+    private void setupDefianceKarieGunners(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var defiance = scn.GetLSCard("defiance");
+        var htb = scn.GetLSCard("htb");
+        var executor = scn.GetDSCard("executor");
+        scn.MoveCardsToLocation(system, defiance, executor);
+        scn.BoardAsPilot(defiance, scn.GetLSCard("karie"));
+        scn.BoardAsPassenger(defiance, scn.GetLSCard("dack"), scn.GetLSCard("verrack"));
+        scn.AttachCardsTo(defiance, htb, scn.GetLSCard("tc"));
+    }
+
     private void setupDefianceGunners(VirtualTableScenario scn, boolean withTc) {
         scn.StartGame();
         var system = scn.GetLSStartingLocation();
@@ -994,9 +1034,9 @@ public class Card_1_39_Tests {
      * still set the game is canceled.
      */
     private void assertFireTwiceStateCleared(VirtualTableScenario scn) {
+        scn.game().takeSnapshot("after Targeting Computer");
         assertTrue("Targeting Computer fire-twice must clear separately-or-combined firing state",
                 scn.gameState().getSeparatelyOrCombinedFiringState() == null);
-        scn.game().takeSnapshot("after Targeting Computer");
     }
 
     /**

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
@@ -553,6 +553,8 @@ public class Card_1_39_Tests {
         assertTrue(log.contains("Targeting Computer Combined firing 2"));
         assertFalse("No parentheses around the weapon name", log.contains("firing 1 ("));
         assertFalse(log.contains("firing 2 ("));
+
+        assertFireTwiceStateCleared(scn);
     }
 
     @Test
@@ -648,6 +650,38 @@ public class Card_1_39_Tests {
         assertWeaponDestinyDrawValues(scn, 7, 7);
         assertEquals(13, lastTotalWeaponDestiny(scn));
         assertTrue("Separately HTB still needs Dack, Verrack, and Defiance each-draw bonuses", executor.isHit());
+    }
+
+    @Test
+    public void TargetingComputerSeparatelyFireTwiceClearsFiringStateAfterDefianceHitsCapital() {
+        // Playtest crash: Targeting Computer fires Heavy Turbolaser Battery twice separately
+        // (TIE, then a capital). Defiance required response reduces the capital power by 5.
+        // Weapons-segment Pass then aborted because separately-or-combined firing state was still set.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var tie = scn.GetDSCard("tie");
+        var vsd = scn.GetDSCard("vsd");
+        setupDefiance(scn, true);
+        scn.MoveCardsToLocation(scn.GetLSStartingLocation(), tie);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseSeparatelyOrCombined(scn, "Separately");
+
+        fireTwoDestinyShot(scn, tie, 7, 7);
+        assertTrue(tie.isHit());
+
+        int vsdPowerBefore = scn.GetPower(vsd);
+        fireTwoDestinyShot(scn, vsd, 7, 7);
+        assertTrue(vsd.isHit());
+        scn.PassResponses("required");
+        scn.PassResponses("power by 5");
+        scn.PassAllResponses();
+        assertEquals("Defiance required response must reduce the capital power by 5", vsdPowerBefore - 5, scn.GetPower(vsd));
+
+        assertFireTwiceStateCleared(scn);
     }
 
     @Test
@@ -954,6 +988,20 @@ public class Card_1_39_Tests {
         }
     }
 
+    /**
+     * After Targeting Computer fire-twice finishes, separately-or-combined firing state must be empty
+     * and taking a snapshot must not throw. Weapons-segment Pass snapshots the game; if that state is
+     * still set the game is canceled.
+     */
+    private void assertFireTwiceStateCleared(VirtualTableScenario scn) {
+        assertTrue("Targeting Computer fire-twice must clear separately-or-combined firing state",
+                scn.gameState().getSeparatelyOrCombinedFiringState() == null);
+        scn.game().takeSnapshot("after Targeting Computer");
+    }
+
+    /**
+     * Defiance with Heavy Turbolaser Battery (and Targeting Computer when withTc) facing a Victory-class Star Destroyer.
+     */
     private void setupDefiance(VirtualTableScenario scn, boolean withTc) {
         scn.StartGame();
         var system = scn.GetLSStartingLocation();
@@ -1055,6 +1103,9 @@ public class Card_1_39_Tests {
         scn.PassDestinyDrawResponses();
         scn.PassResponses("ABOUT_TO_BE_HIT");
         scn.PassResponses("HIT -");
+        // Defiance required: Reduce a capital starship power by 5 after it is hit.
+        scn.PassResponses("required");
+        scn.PassResponses("power by 5");
         scn.PassResponses("FIRED_WEAPON");
         passPostFiringResponses(scn);
     }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
@@ -26,6 +26,20 @@ public class Card_1_39_Tests {
                 new HashMap<>()
                 {{
                     put("tc", "1_39");
+                    put("tc2", "1_39");
+                    put("tc3", "1_39");
+                    put("tc4", "1_39");
+                    put("bwing", "7_140");
+                    put("squadron", "7_150");
+                    put("sw42", "2_081");
+                    put("sw43", "2_081");
+                    put("sw44", "2_081");
+                    put("xwlc2", "7_162");
+                    put("xwlc3", "7_162");
+                    put("xwlc4", "7_162");
+                    put("htb2", "9_89");
+                    put("htb3", "9_89");
+                    put("htb4", "9_89");
                     put("karie", "9_18");
                     put("pilot", "1_27");
                     put("red7", "7_146");
@@ -56,7 +70,7 @@ public class Card_1_39_Tests {
                     put("vsd", "2_155");
                     put("executor", "4_167");
                 }},
-                10,
+                40,
                 10,
                 StartingSetup.DefaultLSSpaceSystem,
                 StartingSetup.DefaultDSSpaceSystem,
@@ -871,6 +885,342 @@ public class Card_1_39_Tests {
         assertTrue(tie.isHit());
     }
 
+
+    @Test
+    public void TargetingComputerFourCopiesMayDeployOnBwingEvenIfOnlyOneCanBeUsed() {
+        /**
+         * Advanced Rulebook Devices: any number of Targeting Computers may deploy on a starship
+         * even if that ship cannot use all of them this turn. A starfighter may use only one device
+         * per turn. Cumulative Rule: copies of Targeting Computer do not stack +1 maneuver.
+         */
+        var scn = GetScenario();
+        var bwing = scn.GetLSCard("bwing");
+        var tc = scn.GetLSCard("tc");
+        var tc2 = scn.GetLSCard("tc2");
+        var tc3 = scn.GetLSCard("tc3");
+        var tc4 = scn.GetLSCard("tc4");
+        scn.MoveCardsToHand(tc, tc2, tc3, tc4);
+
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        scn.MoveCardsToLocation(system, bwing);
+
+        // Open format: Dark Side goes first. Skip to Light Side deploy, then move Reserve
+        // into the Force Pile so four Targeting Computers (2 Force each) can deploy.
+        scn.SkipToLSTurn(Phase.DEPLOY);
+        scn.EnsureLSForcePile(8);
+        assertTrue("Expected Light Side deploy actions, got: " + decisionDump(scn),
+                scn.AwaitingLSDeployPhaseActions());
+
+        PhysicalCardImpl[] computers = { tc, tc2, tc3, tc4 };
+        for (PhysicalCardImpl computer : computers) {
+            assertTrue("Targeting Computer must be deployable on the B-wing. " + decisionDump(scn),
+                    scn.LSGetDecision() != null && scn.LSDeployAvailable(computer));
+            scn.LSDeployCard(computer);
+            if (scn.LSGetDecision() != null && scn.LSHasCardChoiceAvailable(bwing)) {
+                scn.LSChooseCard(bwing);
+            }
+            if (scn.GetCurrentDecision() != null) {
+                scn.PassAllResponses();
+            }
+            // Deploy phase alternates players the same way weapons segment does.
+            if (scn.AwaitingDSDeployPhaseActions()) {
+                scn.DSPass();
+            }
+            assertTrue(scn.IsAttachedTo(bwing, computer));
+        }
+
+        assertEquals("Cumulative Rule: four Targeting Computers still add only +1 maneuver, not +4",
+                3, scn.GetManeuver(bwing));
+    }
+
+    @Test
+    public void TargetingComputerStarfighterMayUseOnlyOneCopyPerTurn() {
+        // B-wing Attack Fighter may fire many weapons each turn, so leftover SW-4 Ion Cannons
+        // stay fireable after one Targeting Computer. The starfighter may still use only one
+        // device per turn, so the other three Targeting Computers cannot Fire a weapon twice.
+        var scn = GetScenario();
+        var bwing = scn.GetLSCard("bwing");
+        var tc = scn.GetLSCard("tc");
+        var tc2 = scn.GetLSCard("tc2");
+        var tc3 = scn.GetLSCard("tc3");
+        var tc4 = scn.GetLSCard("tc4");
+        var sw4 = scn.GetLSCard("sw4");
+        var sw42 = scn.GetLSCard("sw42");
+        var tie = scn.GetDSCard("tie");
+        setupBwingWithFourTargetingComputers(scn);
+
+        assertEquals("Unused Targeting Computers still give +1 maneuver (continuous text is not using the device)",
+                3, scn.GetManeuver(bwing));
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(6);
+
+        assertTrue(fireTwiceAvailable(scn, tc));
+        assertTrue(fireTwiceAvailable(scn, tc2));
+        assertTrue(fireTwiceAvailable(scn, tc3));
+        assertTrue(fireTwiceAvailable(scn, tc4));
+
+        useFireAWeaponTwice(scn, tc, sw4, "Separately");
+        fireOneShot(scn, tie, 1);
+        fireOneShot(scn, tie, 1);
+        passDarkSideWeaponsIfNeeded(scn);
+
+        assertTrue("B-wing still has unused SW-4 Ion Cannons, so Light Side stays in weapons segment. "
+                        + decisionDump(scn),
+                scn.AwaitingLSWeaponsSegmentActions());
+        assertFalse("That Targeting Computer copy cannot be used again this turn. " + decisionDump(scn),
+                fireTwiceAvailable(scn, tc));
+        assertFalse("Starfighter may use only one device per turn. " + decisionDump(scn),
+                fireTwiceAvailable(scn, tc2));
+        assertFalse("Starfighter may use only one device per turn", fireTwiceAvailable(scn, tc3));
+        assertFalse("Starfighter may use only one device per turn", fireTwiceAvailable(scn, tc4));
+        assertTrue("Leftover SW-4 Ion Cannon can still Fire (device limit is not a weapon limit). "
+                        + decisionDump(scn),
+                scn.LSCardActionAvailable(sw42, "Fire"));
+        assertEquals("After using one Targeting Computer, maneuver is still +1, not +4 and not lost",
+                3, scn.GetManeuver(bwing));
+    }
+
+    @Test
+    public void TargetingComputerSquadronMayUseThreeCopiesPerTurn() {
+        // X-wing Assault Squadron is a Decipher squadron-class starship (Filters.squadron).
+        // Squadrons may use three different devices per turn. After three Targeting Computers
+        // are used, the fourth cannot Fire a weapon twice this turn.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var tc2 = scn.GetLSCard("tc2");
+        var tc3 = scn.GetLSCard("tc3");
+        var tc4 = scn.GetLSCard("tc4");
+        var xwlc = scn.GetLSCard("xwlc");
+        var xwlc2 = scn.GetLSCard("xwlc2");
+        var xwlc3 = scn.GetLSCard("xwlc3");
+        var tie = scn.GetDSCard("tie");
+        setupSquadronWithFourTargetingComputers(scn);
+
+        scn.EnsureLSForcePile(4);
+        scn.StartBattleAndSkipToWeaponsSegment();
+
+        assertTrue(fireTwiceAvailable(scn, tc));
+        assertTrue(fireTwiceAvailable(scn, tc2));
+        assertTrue(fireTwiceAvailable(scn, tc3));
+        assertTrue(fireTwiceAvailable(scn, tc4));
+
+        useFireAWeaponTwice(scn, tc, xwlc, "Separately");
+        fireOneShot(scn, tie, 1, 0);
+        fireOneShot(scn, tie, 1, 0);
+        passDarkSideWeaponsIfNeeded(scn);
+        assertTrue("Squadron may use a second Targeting Computer this turn. " + decisionDump(scn),
+                fireTwiceAvailable(scn, tc2));
+        assertFalse("The Targeting Computer copy already used cannot Fire a weapon twice again this turn",
+                fireTwiceAvailable(scn, tc));
+
+        useFireAWeaponTwice(scn, tc2, xwlc2, "Separately");
+        fireOneShot(scn, tie, 1, 0);
+        fireOneShot(scn, tie, 1, 0);
+        passDarkSideWeaponsIfNeeded(scn);
+        assertTrue("Squadron may use a third Targeting Computer this turn. " + decisionDump(scn),
+                fireTwiceAvailable(scn, tc3));
+
+        useFireAWeaponTwice(scn, tc3, xwlc3, "Separately");
+        fireOneShot(scn, tie, 1, 0);
+        fireOneShot(scn, tie, 1, 0);
+        passDarkSideWeaponsIfNeeded(scn);
+
+        if (scn.AwaitingLSWeaponsSegmentActions()) {
+            assertFalse("Squadron may use only three devices per turn. " + decisionDump(scn),
+                    fireTwiceAvailable(scn, tc4));
+        }
+        else {
+            assertTrue("Expected weapons segment after three Targeting Computer uses. " + decisionDump(scn),
+                    scn.AwaitingDSWeaponsSegmentActions());
+        }
+    }
+
+    @Test
+    public void TargetingComputerCapitalMayUseAllFourCopiesPerTurn() {
+        // Home One is a capital starship and may use any number of devices per turn.
+        // Using copy A does not prevent using copy B, C, or D this turn.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var tc2 = scn.GetLSCard("tc2");
+        var tc3 = scn.GetLSCard("tc3");
+        var tc4 = scn.GetLSCard("tc4");
+        var htb = scn.GetLSCard("htb");
+        var htb2 = scn.GetLSCard("htb2");
+        var htb3 = scn.GetLSCard("htb3");
+        var htb4 = scn.GetLSCard("htb4");
+        var stalker = scn.GetDSCard("stalker");
+        setupCapitalWithFourTargetingComputers(scn);
+
+        scn.EnsureLSForcePile(16);
+        scn.StartBattleAndSkipToWeaponsSegment();
+
+        PhysicalCardImpl[] computers = { tc, tc2, tc3, tc4 };
+        PhysicalCardImpl[] batteries = { htb, htb2, htb3, htb4 };
+        for (int i = 0; i < computers.length; i++) {
+            assertTrue("Capital may use Targeting Computer copy " + (i + 1) + " this turn. "
+                            + decisionDump(scn),
+                    fireTwiceAvailable(scn, computers[i]));
+            useFireAWeaponTwice(scn, computers[i], batteries[i], "Separately");
+            fireTwoDestinyShot(scn, stalker, 1, 1);
+            fireTwoDestinyShot(scn, stalker, 1, 1);
+            passDarkSideWeaponsIfNeeded(scn);
+            assertFalse("Used Targeting Computer copy " + (i + 1) + " cannot Fire a weapon twice again this turn. "
+                            + decisionDump(scn),
+                    fireTwiceAvailable(scn, computers[i]));
+        }
+    }
+
+    @Test
+    public void TargetingComputerEachCopyCanBeUsedOnlyOncePerTurn() {
+        // One Rule: an individual Targeting Computer copy can only be used once per turn.
+        // OncePerBattle is not enough if a second battle the same turn would re-offer it.
+        // No clean Decipher card initiates a second battle the same turn, so this checks the
+        // same-copy limit in one battle on a capital (device slots are unlimited there).
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var tc2 = scn.GetLSCard("tc2");
+        var tc3 = scn.GetLSCard("tc3");
+        var tc4 = scn.GetLSCard("tc4");
+        var htb = scn.GetLSCard("htb");
+        var stalker = scn.GetDSCard("stalker");
+        setupCapitalWithFourTargetingComputers(scn);
+
+        scn.EnsureLSForcePile(8);
+        scn.StartBattleAndSkipToWeaponsSegment();
+
+        assertTrue(fireTwiceAvailable(scn, tc));
+        useFireAWeaponTwice(scn, tc, htb, "Separately");
+        fireTwoDestinyShot(scn, stalker, 1, 1);
+        fireTwoDestinyShot(scn, stalker, 1, 1);
+        passDarkSideWeaponsIfNeeded(scn);
+
+        assertTrue("After using copy A, Light Side should still have weapons actions. " + decisionDump(scn),
+                scn.AwaitingLSWeaponsSegmentActions());
+        assertFalse("Copy A cannot Fire a weapon twice again this turn. " + decisionDump(scn),
+                fireTwiceAvailable(scn, tc));
+        assertTrue("Using copy A does not prevent using copy B this turn. " + decisionDump(scn),
+                fireTwiceAvailable(scn, tc2));
+        assertTrue("Copy C is still available this turn", fireTwiceAvailable(scn, tc3));
+        assertTrue("Copy D is still available this turn", fireTwiceAvailable(scn, tc4));
+    }
+
+
+    /**
+     * B-wing Attack Fighter with four Targeting Computers and four SW-4 Ion Cannons vs two TIEs.
+     * The B-wing may fire many weapons during battle, so leftover cannons stay fireable after
+     * one Targeting Computer is used.
+     */
+    private void setupBwingWithFourTargetingComputers(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var bwing = scn.GetLSCard("bwing");
+        var tie = scn.GetDSCard("tie");
+        var tie2 = scn.GetDSCard("tie2");
+        scn.MoveCardsToLocation(system, bwing, tie, tie2);
+        scn.AttachCardsTo(bwing,
+                scn.GetLSCard("sw4"), scn.GetLSCard("sw42"), scn.GetLSCard("sw43"), scn.GetLSCard("sw44"),
+                scn.GetLSCard("tc"), scn.GetLSCard("tc2"), scn.GetLSCard("tc3"), scn.GetLSCard("tc4"));
+    }
+
+    /**
+     * X-wing Assault Squadron with four Targeting Computers and four X-wing Laser Cannons vs two TIEs.
+     * Squadrons may use three different devices per turn.
+     */
+    private void setupSquadronWithFourTargetingComputers(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var squadron = scn.GetLSCard("squadron");
+        var tie = scn.GetDSCard("tie");
+        var tie2 = scn.GetDSCard("tie2");
+        scn.MoveCardsToLocation(system, squadron, tie, tie2);
+        scn.AttachCardsTo(squadron,
+                scn.GetLSCard("xwlc"), scn.GetLSCard("xwlc2"), scn.GetLSCard("xwlc3"), scn.GetLSCard("xwlc4"),
+                scn.GetLSCard("tc"), scn.GetLSCard("tc2"), scn.GetLSCard("tc3"), scn.GetLSCard("tc4"));
+    }
+
+    /**
+     * Home One with four Targeting Computers and four Heavy Turbolaser Batteries vs Stalker.
+     * Capitals may use any number of devices per turn. Stalker is the proven Home One target.
+     */
+    private void setupCapitalWithFourTargetingComputers(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var homeone = scn.GetLSCard("homeone");
+        var stalker = scn.GetDSCard("stalker");
+        scn.MoveCardsToLocation(system, homeone, stalker);
+        scn.AttachCardsTo(homeone,
+                scn.GetLSCard("htb"), scn.GetLSCard("htb2"), scn.GetLSCard("htb3"), scn.GetLSCard("htb4"),
+                scn.GetLSCard("tc"), scn.GetLSCard("tc2"), scn.GetLSCard("tc3"), scn.GetLSCard("tc4"));
+    }
+
+    /**
+     * Starts Fire a weapon twice on the given Targeting Computer. If several weapons can fire,
+     * choose the given weapon. Then pick Separately or Combined.
+     */
+    private void useFireAWeaponTwice(VirtualTableScenario scn, PhysicalCardImpl targetingComputer,
+                                     PhysicalCardImpl weapon, String mode) {
+        assertTrue("Fire a weapon twice must be available on that Targeting Computer. " + decisionDump(scn),
+                fireTwiceAvailable(scn, targetingComputer));
+        scn.LSUseCardAction(targetingComputer, "Fire a weapon twice");
+        if (scn.LSGetDecision() != null && scn.LSDecisionAvailable("Choose weapon")) {
+            scn.LSChooseCard(weapon);
+        }
+        assertTrue("Expected Fire a weapon twice prompt, got: " + decisionDump(scn),
+                scn.LSGetDecision() != null && scn.LSDecisionAvailable("Fire a weapon twice"));
+        assertTrue(scn.LSChoiceAvailable("Separately"));
+        assertTrue(scn.LSChoiceAvailable("Combined"));
+        assertTrue(scn.LSChoiceAvailable("Don't Fire (Cancel)"));
+        scn.LSChoose(mode);
+    }
+
+    /**
+     * Weapons segment alternates players. After Light Side uses a Targeting Computer, Dark Side
+     * is asked next even if Light Side still has weapons or devices. Pass Dark Side to get back
+     * to Light Side's remaining Targeting Computers.
+     */
+    private void passDarkSideWeaponsIfNeeded(VirtualTableScenario scn) {
+        if (scn.AwaitingDSWeaponsSegmentActions()) {
+            scn.DSPass();
+        }
+    }
+
+    /**
+     * True if Light Side currently has Fire a weapon twice on that Targeting Computer copy.
+     * False (does not throw) when Light Side has no decision.
+     */
+    private boolean fireTwiceAvailable(VirtualTableScenario scn, PhysicalCardImpl targetingComputer) {
+        return scn.LSGetDecision() != null && scn.LSCardActionAvailable(targetingComputer, "Fire a weapon twice");
+    }
+
+    /**
+     * Light Side and Dark Side current decision text plus Light Side action list, for assertion messages.
+     */
+    private String decisionDump(VirtualTableScenario scn) {
+        String ls = scn.LSGetDecision() == null ? "null" : scn.LSGetDecision().getText();
+        String ds = scn.DSGetDecision() == null ? "null" : scn.DSGetDecision().getText();
+        String actions = "n/a";
+        try {
+            if (scn.LSGetDecision() != null) {
+                actions = String.valueOf(scn.GetLSAvailableActions());
+            }
+        }
+        catch (RuntimeException ignored) {
+            actions = "(no actionText)";
+        }
+        String phase = String.valueOf(scn.gameState().getCurrentPhase());
+        String player = String.valueOf(scn.gameState().getCurrentPlayerId());
+        String soc = scn.gameState().getSeparatelyOrCombinedFiringState() == null ? "none" : "active";
+        int force = scn.GetLSForcePileCount();
+        String logTail = "";
+        java.util.List<String> msgs = scn.gameState().getLastMessages();
+        int from = Math.max(0, msgs.size() - 12);
+        logTail = String.join(" | ", msgs.subList(from, msgs.size()));
+        return "player=" + player + " phase=" + phase + " force=" + force + " soc=" + soc
+                + " LS=" + ls + " actions=" + actions + " DS=" + ds + " log=" + logTail;
+    }
+
     private void setupRed7(VirtualTableScenario scn, boolean includeKarie) {
         scn.StartGame();
         var system = scn.GetLSStartingLocation();
@@ -1117,6 +1467,9 @@ public class Card_1_39_Tests {
     private void fireOneShot(VirtualTableScenario scn, PhysicalCardImpl target, int destiny, Integer forceToUse) {
         // Combined second shots auto-target and may already be at Force/Fire responses.
         // Prepare destiny before passing those responses so the next draw is stubbed.
+        if (scn.AwaitingLSWeaponsSegmentActions() || scn.AwaitingDSWeaponsSegmentActions()) {
+            return;
+        }
         if (scn.LSGetDecision() != null && scn.LSHasCardChoiceAvailable(target)) {
             scn.LSChooseCard(target);
         }
@@ -1128,6 +1481,9 @@ public class Card_1_39_Tests {
     }
 
     private void fireTwoDestinyShot(VirtualTableScenario scn, PhysicalCardImpl target, int destiny1, int destiny2) {
+        if (scn.AwaitingLSWeaponsSegmentActions() || scn.AwaitingDSWeaponsSegmentActions()) {
+            return;
+        }
         if (scn.LSGetDecision() != null && scn.LSHasCardChoiceAvailable(target)) {
             scn.LSChooseCard(target);
         }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
@@ -37,6 +37,16 @@ public class Card_1_39_Tests {
                     put("htb", "9_89");
                     put("ept", "9_88");
                     put("defiance", "9_67");
+                    put("dack", "3_4");
+                    put("verrack", "9_7");
+                    put("cec", "7_56");
+                    put("corellia", "2_61");
+                    put("falcon", "1_143");
+                    put("gunner", "3_17");
+                    put("qlc", "1_159");
+                    put("tennumb", "9_29");
+                    put("blue5", "9_63");
+                    put("missiles", "9_87");
                 }},
                 new HashMap<>()
                 {{
@@ -44,6 +54,7 @@ public class Card_1_39_Tests {
                     put("tie", "1_304");
                     put("tie2", "1_304");
                     put("vsd", "2_155");
+                    put("executor", "4_167");
                 }},
                 10,
                 10,
@@ -567,6 +578,215 @@ public class Card_1_39_Tests {
         assertTrue(stalker.isHit());
     }
 
+
+    @Test
+    public void DefianceDackVerrackHeavyTurbolaserEachBonusesRequiredVsExecutor() {
+        // Dack passenger +1 each, Verrack aboard +2 each vs capital, Defiance +2 each, HTB -1 total vs capital.
+        // Printed 2 and 2: each draw 2+2+1+2=7, total 14-1=13 vs Executor armor 12 hit.
+        // Missing Dack: 12-1=11 vs 12 miss. Missing Verrack or Defiance is even lower.
+        var scn = GetScenario();
+        var htb = scn.GetLSCard("htb");
+        var executor = scn.GetDSCard("executor");
+        setupDefianceGunners(scn, false);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
+
+        assertTrue(scn.LSCardActionAvailable(htb, "Fire"));
+        scn.LSUseCardAction(htb, "Fire");
+        fireTwoDestinyShot(scn, executor, 2, 2);
+
+        assertEquals(12, scn.GetDefense(executor));
+        assertWeaponDestinyDrawValues(scn, 7, 7);
+        assertEquals("total must be 13 so dropping Dack's +1 each (11 vs 12) cannot pass",
+                13, lastTotalWeaponDestiny(scn));
+        assertTrue("Dack + Verrack + Defiance each-draw bonuses are all required to hit Executor", executor.isHit());
+    }
+
+    @Test
+    public void DefianceDackVerrackTargetingComputerSeparatelyEachBonusesRequiredVsExecutor() {
+        // TC -1 each. Printed 3 and 3: each draw 3+2+1+2-1=7, total 14-1=13 vs 12 hit.
+        // Missing Dack: 11 vs 12 miss.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var executor = scn.GetDSCard("executor");
+        setupDefianceGunners(scn, true);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseSeparatelyOrCombined(scn, "Separately");
+        fireTwoDestinyShot(scn, executor, 3, 3);
+
+        assertWeaponDestinyDrawValues(scn, 7, 7);
+        assertEquals(13, lastTotalWeaponDestiny(scn));
+        assertTrue("Separately HTB still needs Dack, Verrack, and Defiance each-draw bonuses", executor.isHit());
+    }
+
+    @Test
+    public void DefianceDackVerrackTargetingComputerCombinedEachBonusesRequiredVsExecutor() {
+        // Combined HTB: two draws per firing, twice, then HTB -1 once.
+        // Printed 0 x4 with TC -1: each draw 0+2+1+2-1=4, combined 16-1=15 vs 12 hit.
+        // Missing Dack: 12-1=11 vs 12 miss.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var executor = scn.GetDSCard("executor");
+        setupDefianceGunners(scn, true);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseSeparatelyOrCombined(scn, "Combined");
+        fireTwoDestinyShot(scn, executor, 0, 0);
+        assertFalse("First combined HTB firing must not resolve a hit by itself", executor.isHit());
+        fireTwoDestinyShot(scn, executor, 0, 0);
+
+        assertWeaponDestinyDrawValues(scn, 4, 4, 4, 4);
+        assertEquals("combined total 15 so missing Dack's +1 on all four draws (11 vs 12) cannot pass",
+                15, lastTotalWeaponDestiny(scn));
+        assertTrue(executor.isHit());
+    }
+
+    @Test
+    public void FalconCecKarieRogueGunnerQuadLaserEachBonusesRequiredVsVictoryClass() {
+        // CEC +2 each on Quad Laser Cannon, Karie +1 each aboard, Rogue Gunner +1 each as passenger.
+        // Vs capital: Quad Laser's +1 vs starfighter does not apply. Printed 2: 2+2+1+1=6 vs VSD 5 hit.
+        // Missing Karie or Rogue Gunner: 5 vs 5 miss. Missing CEC: 4 vs 5 miss.
+        var scn = GetScenario();
+        var qlc = scn.GetLSCard("qlc");
+        var vsd = scn.GetDSCard("vsd");
+        setupFalconCec(scn, false);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
+
+        assertTrue(scn.LSCardActionAvailable(qlc, "Fire"));
+        scn.LSUseCardAction(qlc, "Fire");
+        fireOneShot(scn, vsd, 2);
+
+        assertEquals(5, scn.GetDefense(vsd));
+        assertWeaponDestinyDrawValues(scn, 6);
+        assertEquals(6, lastTotalWeaponDestiny(scn));
+        assertTrue("CEC, Karie, and Rogue Gunner each-draw bonuses are all required to hit VSD", vsd.isHit());
+    }
+
+    @Test
+    public void FalconCecKarieRogueGunnerTargetingComputerSeparatelyEachBonusesRequiredVsVictoryClass() {
+        // TC -1 each. Printed 3: 3+2+1+1-1=6 vs VSD 5 hit. Missing a +1 character: 5 vs 5 miss.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var vsd = scn.GetDSCard("vsd");
+        setupFalconCec(scn, true);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseSeparatelyOrCombined(scn, "Separately");
+        fireOneShot(scn, vsd, 3);
+
+        assertWeaponDestinyDrawValues(scn, 6);
+        assertEquals(6, lastTotalWeaponDestiny(scn));
+        assertTrue(vsd.isHit());
+    }
+
+    @Test
+    public void FalconCecKarieRogueGunnerTargetingComputerCombinedEachBonusesRequiredVsVictoryClass() {
+        // Combined two draws, then Quad Laser total +1 vs starfighter does not apply vs capital.
+        // Printed 0 and 0 with TC -1: each 0+2+1+1-1=3, combined 6 vs 5 hit.
+        // Missing a +1 character: 2+2=4 vs 5 miss.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var vsd = scn.GetDSCard("vsd");
+        setupFalconCec(scn, true);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseSeparatelyOrCombined(scn, "Combined");
+        fireOneShot(scn, vsd, 0);
+        assertFalse("First combined Quad Laser firing must not resolve a hit by itself", vsd.isHit());
+        fireOneShot(scn, vsd, 0);
+
+        assertWeaponDestinyDrawValues(scn, 3, 3);
+        assertEquals(6, lastTotalWeaponDestiny(scn));
+        assertTrue(vsd.isHit());
+    }
+
+    @Test
+    public void TenNumbBlueSquadron5ConcussionMissilesTotalBonusRequiredVsTie() {
+        // Blue Squadron 5 +2 each draw. Ten Numb +2 total on a B-wing he pilots. Missiles +1 total vs starfighter.
+        // One draw: EACH vs TOTAL look the same. Printed 0 as 2, total 0+2+2+1=5 vs TIE 3 hit.
+        // Without Ten Numb: 3 vs 3 miss.
+        var scn = GetScenario();
+        var missiles = scn.GetLSCard("missiles");
+        var tie = scn.GetDSCard("tie");
+        setupTenNumbBlue5(scn, false);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
+
+        assertTrue(scn.LSCardActionAvailable(missiles, "Fire"));
+        scn.LSUseCardAction(missiles, "Fire");
+        fireOneShot(scn, tie, 0);
+
+        assertEquals(3, scn.GetDefense(tie));
+        assertWeaponDestinyDrawValues(scn, 2);
+        assertEquals("total 5 so Ten Numb's +2 is required (3 vs 3 miss)", 5, lastTotalWeaponDestiny(scn));
+        assertTrue(tie.isHit());
+    }
+
+    @Test
+    public void TenNumbBlueSquadron5TargetingComputerSeparatelyTotalBonusRequiredVsTie() {
+        // TC -1 each. Printed 0 as 1, then Ten Numb +2 total and missiles +1 total: 1+2+1=4 vs TIE 3 hit.
+        // Without Ten Numb: 2 vs 3 miss. One draw still cannot tell EACH from TOTAL.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var tie = scn.GetDSCard("tie");
+        setupTenNumbBlue5(scn, true);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseSeparatelyOrCombined(scn, "Separately");
+        fireOneShot(scn, tie, 0);
+
+        assertWeaponDestinyDrawValues(scn, 1);
+        assertEquals(4, lastTotalWeaponDestiny(scn));
+        assertTrue(tie.isHit());
+    }
+
+    @Test
+    public void TenNumbBlueSquadron5TargetingComputerCombinedAppliesTotalOnceNotPerDraw() {
+        // Combined is the EACH vs TOTAL distinguisher.
+        // Printed 0 and 0: each draw 0+2 Blue -1 TC = 1 (Ten Numb must NOT be on the draw).
+        // Combined 1+1=2, then Ten Numb +2 total once and missiles +1 once = 5 vs TIE 3 hit.
+        // If Ten Numb were wrongly each-draw, draws would log as 3 and 3 and the total would be 7.
+        // Without Ten Numb: 3 vs 3 miss.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var tie = scn.GetDSCard("tie");
+        setupTenNumbBlue5(scn, true);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        scn.EnsureLSForcePile(4);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseSeparatelyOrCombined(scn, "Combined");
+        fireOneShot(scn, tie, 0);
+        assertFalse("First combined Concussion Missiles firing must not resolve a hit by itself", tie.isHit());
+        fireOneShot(scn, tie, 0);
+
+        assertWeaponDestinyDrawValues(scn, 1, 1);
+        assertEquals("total 5 means Ten Numb +2 applied once; EACH would log 3+3 and total 7",
+                5, lastTotalWeaponDestiny(scn));
+        assertTrue(tie.isHit());
+    }
+
     private void setupRed7(VirtualTableScenario scn, boolean includeKarie) {
         scn.StartGame();
         var system = scn.GetLSStartingLocation();
@@ -637,6 +857,59 @@ public class Card_1_39_Tests {
         var tie2 = scn.GetDSCard("tie2");
         scn.MoveCardsToLocation(system, ywing, stalker, tie, tie2);
         scn.AttachCardsTo(ywing, sw4, tc);
+    }
+
+
+    private void setupDefianceGunners(VirtualTableScenario scn, boolean withTc) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var defiance = scn.GetLSCard("defiance");
+        var htb = scn.GetLSCard("htb");
+        var executor = scn.GetDSCard("executor");
+        scn.MoveCardsToLocation(system, defiance, executor);
+        scn.BoardAsPassenger(defiance, scn.GetLSCard("dack"), scn.GetLSCard("verrack"));
+        if (withTc) {
+            scn.AttachCardsTo(defiance, htb, scn.GetLSCard("tc"));
+        }
+        else {
+            scn.AttachCardsTo(defiance, htb);
+        }
+    }
+
+    private void setupFalconCec(VirtualTableScenario scn, boolean withTc) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var falcon = scn.GetLSCard("falcon");
+        var qlc = scn.GetLSCard("qlc");
+        var vsd = scn.GetDSCard("vsd");
+        var corellia = scn.GetLSCard("corellia");
+        scn.MoveLocationToTable(corellia);
+        scn.AttachCardsTo(corellia, scn.GetLSCard("cec"));
+        scn.MoveCardsToLocation(system, falcon, vsd);
+        scn.BoardAsPilot(falcon, scn.GetLSCard("karie"));
+        scn.BoardAsPassenger(falcon, scn.GetLSCard("gunner"));
+        if (withTc) {
+            scn.AttachCardsTo(falcon, qlc, scn.GetLSCard("tc"));
+        }
+        else {
+            scn.AttachCardsTo(falcon, qlc);
+        }
+    }
+
+    private void setupTenNumbBlue5(VirtualTableScenario scn, boolean withTc) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var blue5 = scn.GetLSCard("blue5");
+        var missiles = scn.GetLSCard("missiles");
+        var tie = scn.GetDSCard("tie");
+        scn.MoveCardsToLocation(system, blue5, tie);
+        scn.BoardAsPilot(blue5, scn.GetLSCard("tennumb"));
+        if (withTc) {
+            scn.AttachCardsTo(blue5, missiles, scn.GetLSCard("tc"));
+        }
+        else {
+            scn.AttachCardsTo(blue5, missiles);
+        }
     }
 
     private void setupDefiance(VirtualTableScenario scn, boolean withTc) {

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
@@ -1,6 +1,7 @@
 package com.gempukku.swccgo.cards.set1.light;
 
 import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.IonizationType;
 import com.gempukku.swccgo.common.Phase;
 import com.gempukku.swccgo.common.Rarity;
 import com.gempukku.swccgo.common.Side;
@@ -26,6 +27,11 @@ public class Card_1_39_Tests {
                     put("pilot", "1_27");
                     put("red7", "7_146");
                     put("xwing", "1_146");
+                    put("ywing", "1_147");
+                    put("xwlc", "7_162");
+                    put("sw4", "2_081");
+                    put("homeone", "9_74");
+                    put("htb", "9_89");
                     put("ept", "9_88");
                 }},
                 new HashMap<>()
@@ -247,6 +253,218 @@ public class Card_1_39_Tests {
         assertTrue(stalker.isHit());
     }
 
+
+    @Test
+    public void TargetingComputerFiresXwingLaserCannonTwiceSeparately() {
+        // 7_162 X-wing Laser Cannon: may use X=0..3 Force; destiny + X > DV to hit.
+        // With X=0 vs TIE maneuver 3: dest 5, TC -1 => 4 > 3 hit. Retarget second TIE.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var xwlc = scn.GetLSCard("xwlc");
+        var tie = scn.GetDSCard("tie");
+        var tie2 = scn.GetDSCard("tie2");
+        setupXwingLaser(scn);
+
+        startWeaponsSegment(scn);
+
+        assertTrue(scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseWeaponIfPrompted(scn, xwlc);
+        scn.LSChoose("Separately");
+
+        fireOneShot(scn, tie, 5, 0);
+        assertTrue(tie.isHit());
+        assertFalse(tie2.isHit());
+
+        fireOneShot(scn, tie2, 5, 0);
+        assertTrue(tie2.isHit());
+    }
+
+    @Test
+    public void TargetingComputerFiresXwingLaserCannonTwiceCombined() {
+        // Combined X=0: first dest 4 is (4-1)=3 stored, not yet a hit vs TIE 3.
+        // Second dest 4: (4-1)=3. Combined 6 vs 3 hits the single target.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var xwlc = scn.GetLSCard("xwlc");
+        var tie = scn.GetDSCard("tie");
+        setupXwingLaser(scn);
+
+        startWeaponsSegment(scn);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseWeaponIfPrompted(scn, xwlc);
+        scn.LSChoose("Combined");
+
+        fireOneShot(scn, tie, 4, 0);
+        assertFalse("First combined X-wing Laser Cannon shot must not resolve a hit by itself", tie.isHit());
+
+        fireOneShot(scn, tie, 4, 0);
+        assertTrue(tie.isHit());
+    }
+
+    @Test
+    public void TargetingComputerFiresSw4IonCannonTwiceSeparatelyAndIonizes() {
+        // 2_081 SW-4 Ion Cannon (LS ion cannon; Premiere 1_318 is DS Star Destroyer only).
+        // Cost 1 Force. Destiny > DV ionizes (armor/maneuver=0, hyperspeed=0); does not "hit".
+        // dest 5, TC -1 => 4 > TIE 3 ionize.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var sw4 = scn.GetLSCard("sw4");
+        var tie = scn.GetDSCard("tie");
+        var tie2 = scn.GetDSCard("tie2");
+        setupYwingIon(scn);
+
+        startWeaponsSegment(scn);
+
+        int forceBefore = scn.GetLSForcePileCount();
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseWeaponIfPrompted(scn, sw4);
+        scn.LSChoose("Separately");
+
+        fireOneShot(scn, tie, 5);
+        assertTrue(isIonized(tie));
+        assertFalse(tie.isHit());
+        assertFalse(isIonized(tie2));
+
+        fireOneShot(scn, tie2, 5);
+        assertTrue(isIonized(tie2));
+        assertFalse(tie2.isHit());
+        assertEquals(forceBefore - 2, scn.GetLSForcePileCount());
+    }
+
+    @Test
+    public void TargetingComputerFiresSw4IonCannonTwiceCombinedAndIonizes() {
+        // Combined: dest 4 then 4. Each firing (4-1)=3. Combined 6 > TIE 3 ionizes; not a hit.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var sw4 = scn.GetLSCard("sw4");
+        var tie = scn.GetDSCard("tie");
+        setupYwingIon(scn);
+
+        startWeaponsSegment(scn);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseWeaponIfPrompted(scn, sw4);
+        scn.LSChoose("Combined");
+
+        fireOneShot(scn, tie, 4);
+        assertFalse(isIonized(tie));
+        assertFalse(tie.isHit());
+
+        fireOneShot(scn, tie, 4);
+        assertTrue(isIonized(tie));
+        assertFalse("Ion Cannon must ionize, not hit", tie.isHit());
+    }
+
+    @Test
+    public void TargetingComputerSeparatelySkipsUnpaidSecondShotWithoutRewindingFirst() {
+        // Appendix B option A: SW-4 costs 1 Force per shot. With 1 Force remaining,
+        // shot 1 pays and ionizes; shot 2 does not initiate; TC is still used.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var sw4 = scn.GetLSCard("sw4");
+        var tie = scn.GetDSCard("tie");
+        var tie2 = scn.GetDSCard("tie2");
+        setupYwingIon(scn);
+
+        startWeaponsSegment(scn);
+        drainLSForcePileTo(scn, 1);
+        assertEquals(1, scn.GetLSForcePileCount());
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseWeaponIfPrompted(scn, sw4);
+        scn.LSChoose("Separately");
+
+        fireOneShot(scn, tie, 5);
+        assertTrue(isIonized(tie));
+        assertFalse(tie.isHit());
+        assertFalse(isIonized(tie2));
+        assertEquals(0, scn.GetLSForcePileCount());
+
+        passOptionalResponses(scn);
+        if (scn.AwaitingLSWeaponsSegmentActions()) {
+            assertFalse(scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
+        }
+        else {
+            assertTrue(scn.AwaitingDSWeaponsSegmentActions() || scn.GetCurrentDecision() != null);
+        }
+        assertFalse("Second TIE must not be ionized when shot 2 cannot pay", isIonized(tie2));
+    }
+
+    @Test
+    public void TargetingComputerCombinedAppliesCompletedFiringsWhenSecondShotCannotPay() {
+        // Appendix B option A combined: dest 5 stored as (5-1)=4, shot 2 cannot pay.
+        // Combined total of completed firings 4 > TIE 3 still ionizes. Action does not fully fail.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var sw4 = scn.GetLSCard("sw4");
+        var tie = scn.GetDSCard("tie");
+        setupYwingIon(scn);
+
+        startWeaponsSegment(scn);
+        drainLSForcePileTo(scn, 1);
+        assertEquals(1, scn.GetLSForcePileCount());
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseWeaponIfPrompted(scn, sw4);
+        scn.LSChoose("Combined");
+
+        fireOneShot(scn, tie, 5);
+        passOptionalResponses(scn);
+
+        assertTrue("Completed combined firing must still apply vs the target", isIonized(tie));
+        assertFalse(tie.isHit());
+        assertEquals(0, scn.GetLSForcePileCount());
+        if (scn.AwaitingLSWeaponsSegmentActions()) {
+            assertFalse(scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
+        }
+    }
+
+    @Test
+    public void TargetingComputerFiresHeavyTurbolaserFromHomeOneSeparately() {
+        // Capital setup (AR example 2 structure): Home One 9_74 + Heavy Turbolaser Battery 9_89.
+        // HTB uses 2 Force, draws 2 destiny, total -1 vs capital. dest 7,7: (7-1)+(7-1)=12, then -1 = 11 vs Stalker 7 hit.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var htb = scn.GetLSCard("htb");
+        var stalker = scn.GetDSCard("stalker");
+        setupHomeOne(scn);
+
+        startWeaponsSegment(scn);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseWeaponIfPrompted(scn, htb);
+        scn.LSChoose("Separately");
+
+        fireTwoDestinyShot(scn, stalker, 7, 7);
+        assertTrue(stalker.isHit());
+    }
+
+    @Test
+    public void TargetingComputerFiresHeavyTurbolaserFromHomeOneCombined() {
+        // Combined HTB vs Stalker: each firing is one weapon destiny (sum of two TC-modified draws).
+        // dest 4,4 => (4-1)+(4-1)=6 stored, not a hit yet. Second firing 4,4 => 6. Combined 12, total -1 = 11 vs 7 hit.
+        var scn = GetScenario();
+        var tc = scn.GetLSCard("tc");
+        var htb = scn.GetLSCard("htb");
+        var stalker = scn.GetDSCard("stalker");
+        setupHomeOne(scn);
+
+        startWeaponsSegment(scn);
+        ensureLSForcePile(scn, 4);
+
+        scn.LSUseCardAction(tc, "Fire a weapon twice");
+        chooseWeaponIfPrompted(scn, htb);
+        scn.LSChoose("Combined");
+
+        fireTwoDestinyShot(scn, stalker, 4, 4);
+        assertFalse("First combined HTB firing must not resolve a hit by itself", stalker.isHit());
+
+        fireTwoDestinyShot(scn, stalker, 4, 4);
+        assertTrue(stalker.isHit());
+    }
+
     private void setupRed7(VirtualTableScenario scn, boolean includeKarie) {
         scn.StartGame();
         var system = scn.GetLSStartingLocation();
@@ -294,20 +512,121 @@ public class Card_1_39_Tests {
         }
     }
 
+    private void setupXwingLaser(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var xwing = scn.GetLSCard("xwing");
+        var xwlc = scn.GetLSCard("xwlc");
+        var tc = scn.GetLSCard("tc");
+        var stalker = scn.GetDSCard("stalker");
+        var tie = scn.GetDSCard("tie");
+        var tie2 = scn.GetDSCard("tie2");
+        scn.MoveCardsToLocation(system, xwing, stalker, tie, tie2);
+        scn.AttachCardsTo(xwing, xwlc, tc);
+    }
+
+    private void setupYwingIon(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var ywing = scn.GetLSCard("ywing");
+        var sw4 = scn.GetLSCard("sw4");
+        var tc = scn.GetLSCard("tc");
+        var stalker = scn.GetDSCard("stalker");
+        var tie = scn.GetDSCard("tie");
+        var tie2 = scn.GetDSCard("tie2");
+        scn.MoveCardsToLocation(system, ywing, stalker, tie, tie2);
+        scn.AttachCardsTo(ywing, sw4, tc);
+    }
+
+    private void setupHomeOne(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var homeone = scn.GetLSCard("homeone");
+        var htb = scn.GetLSCard("htb");
+        var tc = scn.GetLSCard("tc");
+        var stalker = scn.GetDSCard("stalker");
+        var tie = scn.GetDSCard("tie");
+        scn.MoveCardsToLocation(system, homeone, stalker, tie);
+        scn.AttachCardsTo(homeone, htb, tc);
+    }
+
     private void fireOneShot(VirtualTableScenario scn, PhysicalCardImpl target, int destiny) {
+        fireOneShot(scn, target, destiny, null);
+    }
+
+    private void fireOneShot(VirtualTableScenario scn, PhysicalCardImpl target, int destiny, Integer forceToUse) {
         // Combined second shots auto-target and may already be at Force/Fire responses.
         // Prepare destiny before passing those responses so the next draw is stubbed.
         if (scn.LSGetDecision() != null && scn.LSHasCardChoiceAvailable(target)) {
             scn.LSChooseCard(target);
         }
+        chooseForceAmountIfPrompted(scn, forceToUse);
         scn.PrepareLSDestiny(destiny);
         scn.PassForceUseResponses();
         scn.PassWeaponFireWithDestinyDraw();
+        passPostFiringResponses(scn);
+    }
+
+    private void fireTwoDestinyShot(VirtualTableScenario scn, PhysicalCardImpl target, int destiny1, int destiny2) {
+        if (scn.LSGetDecision() != null && scn.LSHasCardChoiceAvailable(target)) {
+            scn.LSChooseCard(target);
+        }
+        chooseForceAmountIfPrompted(scn, null);
+        scn.PassForceUseResponses();
+        // Prepare first draw before Fire responses (combined shot 2 may already be in that window).
+        // Prepare each subsequent draw immediately before it so the same destiny value can be reused
+        // (LS destiny pack has only one card per 0-7).
+        scn.PrepareLSDestiny(destiny1);
+        scn.PassResponses("Fire ");
+        scn.PassDestinyDrawResponses();
+        scn.PrepareLSDestiny(destiny2);
+        scn.PassDestinyDrawResponses();
+        scn.PassResponses("ABOUT_TO_BE_HIT");
+        scn.PassResponses("HIT -");
+        scn.PassResponses("FIRED_WEAPON");
+        passPostFiringResponses(scn);
+    }
+
+    private void chooseForceAmountIfPrompted(VirtualTableScenario scn, Integer forceToUse) {
+        if (scn.LSGetDecision() == null || scn.LSGetDecision().getText() == null) {
+            return;
+        }
+        String text = scn.LSGetDecision().getText().toLowerCase();
+        if (!(text.contains("amount") || text.contains("how much") || text.contains("force to use") || text.contains("x ="))) {
+            return;
+        }
+        int amount = forceToUse != null ? forceToUse : scn.LSGetChoiceMin();
+        scn.LSDecided(amount);
+    }
+
+    private void ensureLSForcePile(VirtualTableScenario scn, int min) {
+        while (scn.GetLSForcePileCount() < min && scn.GetLSReserveDeckCount() > 2) {
+            scn.MoveCardsToTopOfLSForcePile(scn.GetTopOfLSReserveDeck());
+        }
+    }
+
+    private void drainLSForcePileTo(VirtualTableScenario scn, int remaining) {
+        while (scn.GetLSForcePileCount() > remaining) {
+            scn.MoveCardsToHand(scn.GetTopOfLSForcePile());
+        }
+    }
+
+    private boolean isIonized(PhysicalCardImpl card) {
+        return card.getIonization() != null
+                && (card.getIonization().contains(IonizationType.DEFENSE_IONIZED)
+                || card.getIonization().contains(IonizationType.HYPERSPEED_IONIZED));
     }
 
     private void passOptionalResponses(VirtualTableScenario scn) {
         if (scn.GetCurrentDecision() != null) {
             scn.PassAllResponses();
         }
+    }
+
+    private void passPostFiringResponses(VirtualTableScenario scn) {
+        // Ion Cannon resets attributes then ionizes; do not PassAllResponses or combined shot 2's Fire window is consumed.
+        scn.PassResponses("ATTRIBUTE_RESET_OR_MODIFIED");
+        scn.PassResponses("Ionized");
+        scn.PassResponses("FIRED_WEAPON");
     }
 }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_39_Tests.java
@@ -1,6 +1,8 @@
 package com.gempukku.swccgo.cards.set1.light;
 
 import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.ExpansionSet;
 import com.gempukku.swccgo.common.Phase;
 import com.gempukku.swccgo.common.Rarity;
 import com.gempukku.swccgo.common.Side;
@@ -104,8 +106,16 @@ public class Card_1_39_Tests {
         assertEquals("Targeting Computer", card.getTitle());
         assertEquals(Uniqueness.UNRESTRICTED, card.getUniqueness());
         assertEquals(Side.LIGHT, card.getSide());
-        assertTrue(card.isCardType(CardType.DEVICE));
+        scn.BlueprintCardTypeCheck(card, new ArrayList<>() {{
+            add(CardType.DEVICE);
+        }});
         assertEquals(3, card.getDestiny(), scn.epsilon);
+        scn.BlueprintIconCheck(card, new ArrayList<>() {{
+            add(Icon.DEVICE);
+        }});
+        scn.BlueprintKeywordCheck(card, new ArrayList<>() {{
+        }});
+        assertEquals(ExpansionSet.PREMIERE, card.getExpansionSet());
         assertEquals(Rarity.U1, card.getRarity());
     }
 
@@ -513,7 +523,7 @@ public class Card_1_39_Tests {
     }
 
     @Test
-    public void DefianceHeavyTurbolaserVsVictoryClassAddsTwoToEachDraw() {
+    public void TargetingComputerDoesNotAffectUnattachedHeavyTurbolaserVsVictoryClass() {
         // HTB draws two destinies vs VSD (capital): HTB -1 total, not -6 vs starfighter. No Targeting Computer.
         // Printed destinies 2 and 2. No bonus: 2+2-1=3 vs armor 5 miss.
         // +1 each would be (2+1)+(2+1)-1=5 vs 5 miss (equal fails).
@@ -539,7 +549,7 @@ public class Card_1_39_Tests {
     }
 
     @Test
-    public void DefianceTargetingComputerCombinedAppliesMinusOneAndPlusTwoPerDraw() {
+    public void TargetingComputerCombinedAppliesMinusOneAndPlusTwoPerDrawOnCapital() {
         // TC -1 and Defiance +2 per draw (net +1 vs printed). HTB two draws per firing.
         // Printed 2,2 then 2,2: each firing (2-1+2)*2=6. Combined 12, HTB -1 vs capital = 11 vs VSD 5 hit.
         // Without Defiance +2: (2-1)*2 per firing, combined 4, -1 = 3 vs 5 miss.
@@ -596,7 +606,7 @@ public class Card_1_39_Tests {
 
 
     @Test
-    public void DefianceDackVerrackHeavyTurbolaserEachBonusesRequiredVsExecutor() {
+    public void TargetingComputerNotRequiredForIndependentHeavyTurbolaserBonuses() {
         // Dack passenger +1 each, Verrack aboard +2 each vs capital, Defiance +2 each, HTB -1 total vs capital.
         // Printed 2 and 2: each draw 2+2+1+2=7, total 14-1=13 vs Executor armor 12 hit.
         // Missing Dack: 12-1=11 vs 12 miss. Missing Verrack or Defiance is even lower.
@@ -646,7 +656,7 @@ public class Card_1_39_Tests {
     }
 
     @Test
-    public void DefianceDackVerrackTargetingComputerSeparatelyEachBonusesRequiredVsExecutor() {
+    public void TargetingComputerSeparatelyAppliesEachBonusesRequiredVsExecutor() {
         // TC -1 each. Printed 3 and 3: each draw 3+2+1+2-1=7, total 14-1=13 vs 12 hit.
         // Missing Dack: 11 vs 12 miss.
         var scn = GetScenario();
@@ -667,7 +677,7 @@ public class Card_1_39_Tests {
     }
 
     @Test
-    public void DefianceKarieDackVerrackTargetingComputerSeparatelyDrawsAreEightNotNineVsExecutor() {
+    public void TargetingComputerSeparatelyDrawTotalsAccountForGunnerAndPilot() {
         // Playtest: Targeting Computer fires Heavy Turbolaser Battery twice separately at Executor.
         // Defiance +2 each (FiredBy), Karie Neth +1, Dack Ralter +1, Captain Verrack +2 vs capital = +6.
         // Targeting Computer -1 each while using Fire a weapon twice. Printed 3 and 3 must be 8 and 8, not 9 and 9.
@@ -723,7 +733,7 @@ public class Card_1_39_Tests {
     }
 
     @Test
-    public void DefianceDackVerrackTargetingComputerCombinedEachBonusesRequiredVsExecutor() {
+    public void TargetingComputerCombinedAppliesEachBonusesRequiredVsExecutor() {
         // Combined HTB: two draws per firing, twice, then HTB -1 once.
         // Printed 0 x4 with TC -1: each draw 0+2+1+2-1=4, combined 16-1=15 vs 12 hit.
         // Missing Dack: 12-1=11 vs 12 miss.
@@ -748,7 +758,7 @@ public class Card_1_39_Tests {
     }
 
     @Test
-    public void FalconCecKarieRogueGunnerQuadLaserEachBonusesRequiredVsVictoryClass() {
+    public void TargetingComputerNotRequiredForIndependentQuadLaserBonuses() {
         // CEC +2 each on Quad Laser Cannon, Karie +1 each aboard, Rogue Gunner +1 each as passenger.
         // Vs capital: Quad Laser's +1 vs starfighter does not apply. Printed 2: 2+2+1+1=6 vs VSD 5 hit.
         // Missing Karie or Rogue Gunner: 5 vs 5 miss. Missing CEC: 4 vs 5 miss.
@@ -771,7 +781,7 @@ public class Card_1_39_Tests {
     }
 
     @Test
-    public void FalconCecKarieRogueGunnerTargetingComputerSeparatelyEachBonusesRequiredVsVictoryClass() {
+    public void TargetingComputerSeparatelyAppliesQuadLaserBonusesVsVictoryClass() {
         // TC -1 each. Printed 3: 3+2+1+1-1=6 vs VSD 5 hit. Missing a +1 character: 5 vs 5 miss.
         var scn = GetScenario();
         var tc = scn.GetLSCard("tc");
@@ -791,7 +801,7 @@ public class Card_1_39_Tests {
     }
 
     @Test
-    public void FalconCecKarieRogueGunnerTargetingComputerCombinedEachBonusesRequiredVsVictoryClass() {
+    public void TargetingComputerCombinedAppliesQuadLaserBonusesVsVictoryClass() {
         // Combined two draws, then Quad Laser total +1 vs starfighter does not apply vs capital.
         // Printed 0 and 0 with TC -1: each 0+2+1+1-1=3, combined 6 vs 5 hit.
         // Missing a +1 character: 2+2=4 vs 5 miss.
@@ -815,7 +825,7 @@ public class Card_1_39_Tests {
     }
 
     @Test
-    public void TenNumbBlueSquadron5ConcussionMissilesTotalBonusRequiredVsTie() {
+    public void TargetingComputerNotRequiredForIndependentConcussionMissileBonus() {
         // Blue Squadron 5 +2 each draw. Ten Numb +2 total on a B-wing he pilots. Missiles +1 total vs starfighter.
         // One draw: EACH vs TOTAL look the same. Printed 0 as 2, total 0+2+2+1=5 vs TIE 3 hit.
         // Without Ten Numb: 3 vs 3 miss.
@@ -838,7 +848,7 @@ public class Card_1_39_Tests {
     }
 
     @Test
-    public void TenNumbBlueSquadron5TargetingComputerSeparatelyTotalBonusRequiredVsTie() {
+    public void TargetingComputerSeparatelyAppliesConcussionMissileTotalBonus() {
         // TC -1 each. Printed 0 as 1, then Ten Numb +2 total and missiles +1 total: 1+2+1=4 vs TIE 3 hit.
         // Without Ten Numb: 2 vs 3 miss. One draw still cannot tell EACH from TOTAL.
         var scn = GetScenario();
@@ -859,7 +869,7 @@ public class Card_1_39_Tests {
     }
 
     @Test
-    public void TenNumbBlueSquadron5TargetingComputerCombinedAppliesTotalOnceNotPerDraw() {
+    public void TargetingComputerCombinedAppliesConcussionMissileTotalOnceNotPerDraw() {
         // Combined is the EACH vs TOTAL distinguisher.
         // Printed 0 and 0: each draw 0+2 Blue -1 TC = 1 (Ten Numb must NOT be on the draw).
         // Combined 1+1=2, then Ten Numb +2 total once and missiles +1 once = 5 vs TIE 3 hit.
@@ -909,12 +919,12 @@ public class Card_1_39_Tests {
         // into the Force Pile so four Targeting Computers (2 Force each) can deploy.
         scn.SkipToLSTurn(Phase.DEPLOY);
         scn.EnsureLSForcePile(8);
-        assertTrue("Expected Light Side deploy actions, got: " + decisionDump(scn),
+        assertTrue("Expected Light Side deploy actions, got: " ,
                 scn.AwaitingLSDeployPhaseActions());
 
         PhysicalCardImpl[] computers = { tc, tc2, tc3, tc4 };
         for (PhysicalCardImpl computer : computers) {
-            assertTrue("Targeting Computer must be deployable on the B-wing. " + decisionDump(scn),
+            assertTrue("Targeting Computer must be deployable on the B-wing. " ,
                     scn.LSGetDecision() != null && scn.LSDeployAvailable(computer));
             scn.LSDeployCard(computer);
             if (scn.LSGetDecision() != null && scn.LSHasCardChoiceAvailable(bwing)) {
@@ -967,16 +977,16 @@ public class Card_1_39_Tests {
         passDarkSideWeaponsIfNeeded(scn);
 
         assertTrue("B-wing still has unused SW-4 Ion Cannons, so Light Side stays in weapons segment. "
-                        + decisionDump(scn),
+                        ,
                 scn.AwaitingLSWeaponsSegmentActions());
-        assertFalse("That Targeting Computer copy cannot be used again this turn. " + decisionDump(scn),
+        assertFalse("That Targeting Computer copy cannot be used again this turn. " ,
                 fireTwiceAvailable(scn, tc));
-        assertFalse("Starfighter may use only one device per turn. " + decisionDump(scn),
+        assertFalse("Starfighter may use only one device per turn. " ,
                 fireTwiceAvailable(scn, tc2));
         assertFalse("Starfighter may use only one device per turn", fireTwiceAvailable(scn, tc3));
         assertFalse("Starfighter may use only one device per turn", fireTwiceAvailable(scn, tc4));
         assertTrue("Leftover SW-4 Ion Cannon can still Fire (device limit is not a weapon limit). "
-                        + decisionDump(scn),
+                        ,
                 scn.LSCardActionAvailable(sw42, "Fire"));
         assertEquals("After using one Targeting Computer, maneuver is still +1, not +4 and not lost",
                 3, scn.GetManeuver(bwing));
@@ -1010,7 +1020,7 @@ public class Card_1_39_Tests {
         fireOneShot(scn, tie, 1, 0);
         fireOneShot(scn, tie, 1, 0);
         passDarkSideWeaponsIfNeeded(scn);
-        assertTrue("Squadron may use a second Targeting Computer this turn. " + decisionDump(scn),
+        assertTrue("Squadron may use a second Targeting Computer this turn. " ,
                 fireTwiceAvailable(scn, tc2));
         assertFalse("The Targeting Computer copy already used cannot Fire a weapon twice again this turn",
                 fireTwiceAvailable(scn, tc));
@@ -1019,7 +1029,7 @@ public class Card_1_39_Tests {
         fireOneShot(scn, tie, 1, 0);
         fireOneShot(scn, tie, 1, 0);
         passDarkSideWeaponsIfNeeded(scn);
-        assertTrue("Squadron may use a third Targeting Computer this turn. " + decisionDump(scn),
+        assertTrue("Squadron may use a third Targeting Computer this turn. " ,
                 fireTwiceAvailable(scn, tc3));
 
         useFireAWeaponTwice(scn, tc3, xwlc3, "Separately");
@@ -1028,11 +1038,11 @@ public class Card_1_39_Tests {
         passDarkSideWeaponsIfNeeded(scn);
 
         if (scn.AwaitingLSWeaponsSegmentActions()) {
-            assertFalse("Squadron may use only three devices per turn. " + decisionDump(scn),
+            assertFalse("Squadron may use only three devices per turn. " ,
                     fireTwiceAvailable(scn, tc4));
         }
         else {
-            assertTrue("Expected weapons segment after three Targeting Computer uses. " + decisionDump(scn),
+            assertTrue("Expected weapons segment after three Targeting Computer uses. " ,
                     scn.AwaitingDSWeaponsSegmentActions());
         }
     }
@@ -1060,14 +1070,14 @@ public class Card_1_39_Tests {
         PhysicalCardImpl[] batteries = { htb, htb2, htb3, htb4 };
         for (int i = 0; i < computers.length; i++) {
             assertTrue("Capital may use Targeting Computer copy " + (i + 1) + " this turn. "
-                            + decisionDump(scn),
+                            ,
                     fireTwiceAvailable(scn, computers[i]));
             useFireAWeaponTwice(scn, computers[i], batteries[i], "Separately");
             fireTwoDestinyShot(scn, stalker, 1, 1);
             fireTwoDestinyShot(scn, stalker, 1, 1);
             passDarkSideWeaponsIfNeeded(scn);
             assertFalse("Used Targeting Computer copy " + (i + 1) + " cannot Fire a weapon twice again this turn. "
-                            + decisionDump(scn),
+                            ,
                     fireTwiceAvailable(scn, computers[i]));
         }
     }
@@ -1096,11 +1106,11 @@ public class Card_1_39_Tests {
         fireTwoDestinyShot(scn, stalker, 1, 1);
         passDarkSideWeaponsIfNeeded(scn);
 
-        assertTrue("After using copy A, Light Side should still have weapons actions. " + decisionDump(scn),
+        assertTrue("After using copy A, Light Side should still have weapons actions. " ,
                 scn.AwaitingLSWeaponsSegmentActions());
-        assertFalse("Copy A cannot Fire a weapon twice again this turn. " + decisionDump(scn),
+        assertFalse("Copy A cannot Fire a weapon twice again this turn. " ,
                 fireTwiceAvailable(scn, tc));
-        assertTrue("Using copy A does not prevent using copy B this turn. " + decisionDump(scn),
+        assertTrue("Using copy A does not prevent using copy B this turn. " ,
                 fireTwiceAvailable(scn, tc2));
         assertTrue("Copy C is still available this turn", fireTwiceAvailable(scn, tc3));
         assertTrue("Copy D is still available this turn", fireTwiceAvailable(scn, tc4));
@@ -1161,13 +1171,13 @@ public class Card_1_39_Tests {
      */
     private void useFireAWeaponTwice(VirtualTableScenario scn, PhysicalCardImpl targetingComputer,
                                      PhysicalCardImpl weapon, String mode) {
-        assertTrue("Fire a weapon twice must be available on that Targeting Computer. " + decisionDump(scn),
+        assertTrue("Fire a weapon twice must be available on that Targeting Computer. " ,
                 fireTwiceAvailable(scn, targetingComputer));
         scn.LSUseCardAction(targetingComputer, "Fire a weapon twice");
         if (scn.LSGetDecision() != null && scn.LSDecisionAvailable("Choose weapon")) {
             scn.LSChooseCard(weapon);
         }
-        assertTrue("Expected Fire a weapon twice prompt, got: " + decisionDump(scn),
+        assertTrue("Expected Fire a weapon twice prompt, got: " ,
                 scn.LSGetDecision() != null && scn.LSDecisionAvailable("Fire a weapon twice"));
         assertTrue(scn.LSChoiceAvailable("Separately"));
         assertTrue(scn.LSChoiceAvailable("Combined"));
@@ -1192,33 +1202,6 @@ public class Card_1_39_Tests {
      */
     private boolean fireTwiceAvailable(VirtualTableScenario scn, PhysicalCardImpl targetingComputer) {
         return scn.LSGetDecision() != null && scn.LSCardActionAvailable(targetingComputer, "Fire a weapon twice");
-    }
-
-    /**
-     * Light Side and Dark Side current decision text plus Light Side action list, for assertion messages.
-     */
-    private String decisionDump(VirtualTableScenario scn) {
-        String ls = scn.LSGetDecision() == null ? "null" : scn.LSGetDecision().getText();
-        String ds = scn.DSGetDecision() == null ? "null" : scn.DSGetDecision().getText();
-        String actions = "n/a";
-        try {
-            if (scn.LSGetDecision() != null) {
-                actions = String.valueOf(scn.GetLSAvailableActions());
-            }
-        }
-        catch (RuntimeException ignored) {
-            actions = "(no actionText)";
-        }
-        String phase = String.valueOf(scn.gameState().getCurrentPhase());
-        String player = String.valueOf(scn.gameState().getCurrentPlayerId());
-        String soc = scn.gameState().getSeparatelyOrCombinedFiringState() == null ? "none" : "active";
-        int force = scn.GetLSForcePileCount();
-        String logTail = "";
-        java.util.List<String> msgs = scn.gameState().getLastMessages();
-        int from = Math.max(0, msgs.size() - 12);
-        logTail = String.join(" | ", msgs.subList(from, msgs.size()));
-        return "player=" + player + " phase=" + phase + " force=" + force + " soc=" + soc
-                + " LS=" + ls + " actions=" + actions + " DS=" + ds + " log=" + logTail;
     }
 
     private void setupRed7(VirtualTableScenario scn, boolean includeKarie) {

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_75_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_75_Tests.java
@@ -59,6 +59,12 @@ public class Card_1_75_Tests {
                     put("htb2", "9_89");
                     put("homeone", "9_74");
                     put("defiance", "9_67");
+                    put("falcon", "1_143");
+                    put("corvette", "1_140");
+                    put("qlc", "1_159");
+                    put("bomber3", "9_66");
+                    put("ept2", "9_88");
+                    put("ept3", "9_88");
                 }},
                 new HashMap<>()
                 {{
@@ -787,6 +793,119 @@ public class Card_1_75_Tests {
     }
 
     @Test
+    public void CombinedAttackConcussionMissilesAndQuadLaserCannonPlusOnesStack() {
+        // Falcon (1_143) with Concussion Missiles (9_87) and Corellian Corvette (1_140)
+        // with Quad Laser Cannon (1_159) Combined Attack a TIE (starfighter, maneuver 3).
+        // Different titles: Concussion Missiles +1 and Quad Laser Cannon +1 both apply (+2).
+        // Draws 1 and 1. Draw sum 2. Total 4 > 3 hit.
+        // Collapsing different titles to one +1 is 3, not > 3, miss.
+        var scn = GetScenario();
+        var ca = scn.GetLSCard("ca");
+        var missiles = scn.GetLSCard("missiles");
+        var qlc = scn.GetLSCard("qlc");
+        var tie = scn.GetDSCard("tie");
+        setupFalconConcussionMissilesAndCorvetteQuadLaser(scn);
+        scn.MoveCardsToHand(ca);
+        scn.EnsureLSForcePile(6);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        playCombinedAttack(scn, tie, missiles, qlc);
+
+        fireOneShot(scn, tie, 1);
+        assertFalse("First Combined Attack destiny must not resolve a hit by itself", tie.isHit());
+        fireOneShot(scn, tie, 1, 1);
+        finishCombinedAttack(scn);
+
+        assertEquals(3, scn.GetDefense(tie));
+        assertTrue("Concussion Missiles +1 and Quad Laser Cannon +1 stack to +2: 2+2=4 > TIE maneuver 3", tie.isHit());
+        String log = gameLog(scn);
+        assertTrue("Combined Attack destinies 1 + 1 = 2. LOG:\n" + log, log.contains("1 + 1 = 2"));
+        assertTrue("Total modifiers +2 from different titles. LOG:\n" + log, log.contains("Total modifiers +2"));
+        assertTrue("Grand total 4 after stacked +2. LOG:\n" + log, log.contains("Total weapon destiny 4"));
+        assertFalse("Do not collapse different titles to one +1 (that would be 3)", log.contains("Total weapon destiny 3"));
+    }
+
+    @Test
+    public void CombinedAttackEptAndIntruderMissileStackAfterIonCannonTargetsCapital() {
+        // First fire SW-4 Ion Cannon (2_081) on a B-wing at Stalker (ordinary, not Combined Attack).
+        // Destiny 1 does not beat armor 7, so Stalker is not ionized, but it was targeted this turn.
+        // Then Combined Attack Enhanced Proton Torpedoes (9_88) + Intruder Missile (7_159)
+        // at the same Stalker. Different titles: Enhanced Proton Torpedoes +1 vs capital and
+        // Intruder Missile +3 stack = +4. Draws 1 and 3. Draw sum 4. Total 8 > 7 hit.
+        // Enhanced Proton Torpedoes only +1 is 5 miss; Intruder Missile only +3 is 7 miss.
+        var scn = GetScenario();
+        var ca = scn.GetLSCard("ca");
+        var sw4 = scn.GetLSCard("sw4");
+        var ept = scn.GetLSCard("ept");
+        var im = scn.GetLSCard("im");
+        var stalker = scn.GetDSCard("stalker");
+        setupIonCannonThenEptAndIntruderMissileVsStalker(scn);
+        scn.MoveCardsToHand(ca);
+        scn.EnsureLSForcePile(8);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        assertTrue(scn.LSCardActionAvailable(sw4, "Fire"));
+        scn.LSUseCardAction(sw4, "Fire");
+        fireOneShot(scn, stalker, 1);
+        scn.PassAllResponses();
+        passDarkSideWeaponsIfNeeded(scn);
+        assertFalse("SW-4 Ion Cannon destiny 1 must not ionize Stalker armor 7", stalker.isHit());
+        assertEquals(7, scn.GetDefense(stalker));
+
+        playCombinedAttack(scn, stalker, ept, im);
+        fireOneShot(scn, stalker, 1);
+        assertFalse("First Combined Attack destiny must not resolve a hit by itself", stalker.isHit());
+        fireOneShot(scn, stalker, 3);
+        finishCombinedAttack(scn);
+
+        assertEquals(7, scn.GetDefense(stalker));
+        assertTrue("Enhanced Proton Torpedoes +1 and Intruder Missile +3 stack to +4: 4+4=8 > Stalker armor 7", stalker.isHit());
+        String log = gameLog(scn);
+        assertTrue("Combined Attack destinies 1 + 3 = 4. LOG:\n" + log, log.contains("1 + 3 = 4"));
+        assertTrue("Total modifiers +4 from different titles. LOG:\n" + log, log.contains("Total modifiers +4"));
+        assertTrue("Grand total 8 after stacked +4. LOG:\n" + log, log.contains("Total weapon destiny 8"));
+        assertFalse("Do not keep only Enhanced Proton Torpedoes +1 (that would be 5)", log.contains("Total weapon destiny 5"));
+        assertFalse("Do not keep only Intruder Missile +3 (that would be 7)", log.contains("Total weapon destiny 7"));
+    }
+
+    @Test
+    public void CombinedAttackThreeEnhancedProtonTorpedoesAppliesMinusOneOnceVsStarfighter() {
+        // Three B-wing Bombers (9_66) each with Enhanced Proton Torpedoes (9_88)
+        // Combined Attack a TIE (not capital). Enhanced Proton Torpedoes -1 vs non-capital
+        // applies once (same title), not -3. B-wing Bomber ion-cannon-draw +3 does not apply
+        // (they are firing Enhanced Proton Torpedoes, not ion cannons).
+        // Draws 2, 2, 1. Draw sum 5. Total 4 > 3 hit. Wrong -1 per copy (-3) is 2 miss.
+        var scn = GetScenario();
+        var ca = scn.GetLSCard("ca");
+        var ept = scn.GetLSCard("ept");
+        var ept2 = scn.GetLSCard("ept2");
+        var ept3 = scn.GetLSCard("ept3");
+        var tie = scn.GetDSCard("tie");
+        setupThreeBwingBombersWithEnhancedProtonTorpedoes(scn);
+        scn.MoveCardsToHand(ca);
+        scn.EnsureLSForcePile(8);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        playCombinedAttack(scn, tie, ept, ept2, ept3);
+
+        fireOneShot(scn, tie, 2);
+        assertFalse("First Combined Attack destiny must not resolve a hit by itself", tie.isHit());
+        fireOneShot(scn, tie, 2);
+        fireOneShot(scn, tie, 1);
+        finishCombinedAttack(scn);
+
+        assertWeaponDestinyDrawValues(scn, 2, 2, 1);
+        assertEquals(3, scn.GetDefense(tie));
+        assertTrue("Enhanced Proton Torpedoes -1 once on 5 is 4 > TIE maneuver 3", tie.isHit());
+        String log = gameLog(scn);
+        assertTrue("Combined Attack destinies 2 + 2 + 1 = 5. LOG:\n" + log, log.contains("2 + 2 + 1 = 5"));
+        assertTrue("Total modifiers -1 once. LOG:\n" + log, log.contains("Total modifiers -1"));
+        assertTrue("Grand total 4 after Enhanced Proton Torpedoes -1 once. LOG:\n" + log, log.contains("Total weapon destiny 4"));
+        assertFalse("Do not subtract Enhanced Proton Torpedoes -1 per copy (that would be -3)", log.contains("Total modifiers -3"));
+        assertFalse("B-wing Bomber ion-cannon-draw +3 must not apply to Enhanced Proton Torpedoes", log.contains("5 + 5 + 4"));
+    }
+
+    @Test
     public void BoringConversationAnywayCancelsCombinedAttackBeforeWeaponsFire() {
         // Sense (1_267) / Boring Conversation Anyway (1_235) cancel Combined Attack (1_75)
         // before any weapon fires. Weapons may still fire normally afterward.
@@ -1035,6 +1154,65 @@ public class Card_1_75_Tests {
         scn.MoveCardsToLocation(system, bomber, bwing2, tie);
         scn.AttachCardsTo(bomber, missiles);
         scn.AttachCardsTo(bwing2, missiles2);
+    }
+
+    /**
+     * Falcon with Concussion Missiles and Corellian Corvette with Quad Laser Cannon vs a TIE.
+     * Rebel Pilot (1_27) aboard Falcon so it can fire.
+     */
+    private void setupFalconConcussionMissilesAndCorvetteQuadLaser(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var falcon = scn.GetLSCard("falcon");
+        var corvette = scn.GetLSCard("corvette");
+        var missiles = scn.GetLSCard("missiles");
+        var qlc = scn.GetLSCard("qlc");
+        var tie = scn.GetDSCard("tie");
+        var pilot = scn.GetLSCard("pilot");
+        scn.MoveCardsToLocation(system, falcon, corvette, tie);
+        scn.BoardAsPilot(falcon, pilot);
+        scn.AttachCardsTo(falcon, missiles);
+        scn.AttachCardsTo(corvette, qlc);
+    }
+
+    /**
+     * B-wing SW-4 Ion Cannon, Y-wing Enhanced Proton Torpedoes, and B-wing Bomber
+     * Intruder Missile vs Stalker. Fire the ion cannon first (not Combined Attack), then
+     * Combined Attack the other two weapons at the same capital.
+     */
+    private void setupIonCannonThenEptAndIntruderMissileVsStalker(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var bwing = scn.GetLSCard("bwing");
+        var ywing = scn.GetLSCard("ywing");
+        var bomber = scn.GetLSCard("bomber");
+        var sw4 = scn.GetLSCard("sw4");
+        var ept = scn.GetLSCard("ept");
+        var im = scn.GetLSCard("im");
+        var stalker = scn.GetDSCard("stalker");
+        scn.MoveCardsToLocation(system, bwing, ywing, bomber, stalker);
+        scn.AttachCardsTo(bwing, sw4);
+        scn.AttachCardsTo(ywing, ept);
+        scn.AttachCardsTo(bomber, im);
+    }
+
+    /**
+     * Three B-wing Bombers each with Enhanced Proton Torpedoes vs a TIE.
+     */
+    private void setupThreeBwingBombersWithEnhancedProtonTorpedoes(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var bomber = scn.GetLSCard("bomber");
+        var bwing2 = scn.GetLSCard("bwing2");
+        var bomber3 = scn.GetLSCard("bomber3");
+        var ept = scn.GetLSCard("ept");
+        var ept2 = scn.GetLSCard("ept2");
+        var ept3 = scn.GetLSCard("ept3");
+        var tie = scn.GetDSCard("tie");
+        scn.MoveCardsToLocation(system, bomber, bwing2, bomber3, tie);
+        scn.AttachCardsTo(bomber, ept);
+        scn.AttachCardsTo(bwing2, ept2);
+        scn.AttachCardsTo(bomber3, ept3);
     }
 
     /**

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_75_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_75_Tests.java
@@ -210,7 +210,6 @@ public class Card_1_75_Tests {
 
         scn.StartBattleAndSkipToWeaponsSegment();
         playCombinedAttack(scn, tie, xwlc, xwlc2);
-        chooseUseTargetingComputer(scn, true);
         chooseSeparatelyOrCombined(scn, "Combined");
 
         // TC -1 on each draw from the TC starship: dest 4,4 then 1 from the other weapon => (4-1)+(4-1)+1 = 7 > 3.
@@ -244,7 +243,6 @@ public class Card_1_75_Tests {
 
         scn.StartBattleAndSkipToWeaponsSegment();
         playCombinedAttack(scn, tie, xwlc, xwlc2);
-        chooseUseTargetingComputer(scn, true);
         chooseSeparatelyOrCombined(scn, "Combined");
 
         fireOneShot(scn, tie, 4, 0);
@@ -265,8 +263,7 @@ public class Card_1_75_Tests {
 
     @Test
     public void TargetingComputerInsideCombinedAttackPresentsSeparatelyOrCombinedChoice() {
-        // Bill: Combined Attack + Targeting Computer must ask fire-twice, then Separately vs Combined.
-        // Both shots still go into the Combined Attack destiny pool either way. Pick Combined.
+        // Same three-way as standalone Targeting Computer. Both shots still go into the CA pool.
         var scn = GetScenario();
         var ca = scn.GetLSCard("ca");
         var xwlc = scn.GetLSCard("xwlc");
@@ -277,17 +274,37 @@ public class Card_1_75_Tests {
 
         scn.StartBattleAndSkipToWeaponsSegment();
         playCombinedAttack(scn, tie, xwlc, xwlc2);
-        chooseUseTargetingComputer(scn, true);
-        assertTrue("Expected Separately/Combined prompt inside Combined Attack, got: "
-                        + (scn.LSGetDecision() == null ? "null" : scn.LSGetDecision().getText()),
-                scn.LSDecisionAvailable("separately or combined"));
-        scn.LSChoose("Combined");
+        chooseSeparatelyOrCombined(scn, "Combined");
 
         fireOneShot(scn, tie, 4, 0);
         fireOneShot(scn, tie, 4, 0);
         fireOneShot(scn, tie, 1, 0);
         finishCombinedAttack(scn);
         assertTrue(tie.isHit());
+    }
+
+    @Test
+    public void TargetingComputerDontFireInsideCombinedAttackLeavesDeviceUnused() {
+        // Don't Fire fires the Combined Attack weapon once and does not consume Targeting Computer.
+        var scn = GetScenario();
+        var ca = scn.GetLSCard("ca");
+        var xwlc = scn.GetLSCard("xwlc");
+        var xwlc2 = scn.GetLSCard("xwlc2");
+        var tie = scn.GetDSCard("tie");
+        setupTwoXwingLasersWithTcOnFirst(scn);
+        scn.MoveCardsToHand(ca);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        playCombinedAttack(scn, tie, xwlc, xwlc2);
+        chooseSeparatelyOrCombined(scn, "Don't Fire (Cancel)");
+
+        // One shot from the TC ship (no second TC firing) plus the other weapon.
+        fireOneShot(scn, tie, 4, 0);
+        fireOneShot(scn, tie, 1, 0);
+        finishCombinedAttack(scn);
+        assertTrue("4 + 1 without TC -1 still hits TIE 3", tie.isHit());
+        // Weapon already fired in Combined Attack, so TC has nothing left to fire;
+        // unused is proven by only two destinies (no extra TC shot) succeeding as 4+1.
     }
 
     @Test
@@ -411,18 +428,13 @@ public class Card_1_75_Tests {
         scn.PassAllResponses();
     }
 
-    private void chooseUseTargetingComputer(VirtualTableScenario scn, boolean use) {
-        String text = scn.LSGetDecision() == null ? "null" : scn.LSGetDecision().getText();
-        assertTrue("Expected Targeting Computer fire-twice prompt, got: " + text,
-                text != null && (text.contains("Targeting Computer")
-                        || (text.toLowerCase().contains("fire") && text.toLowerCase().contains("twice"))));
-        scn.LSChoose(use ? "Yes" : "No");
-    }
-
     private void chooseSeparatelyOrCombined(VirtualTableScenario scn, String mode) {
-        assertTrue("Expected Separately/Combined prompt, got: "
+        assertTrue("Expected Fire a weapon twice prompt, got: "
                         + (scn.LSGetDecision() == null ? "null" : scn.LSGetDecision().getText()),
-                scn.LSDecisionAvailable("separately or combined"));
+                scn.LSDecisionAvailable("Fire a weapon twice"));
+        assertTrue(scn.LSChoiceAvailable("Separately"));
+        assertTrue(scn.LSChoiceAvailable("Combined"));
+        assertTrue(scn.LSChoiceAvailable("Don't Fire (Cancel)"));
         scn.LSChoose(mode);
     }
 

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_75_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_75_Tests.java
@@ -1,0 +1,411 @@
+package com.gempukku.swccgo.cards.set1.light;
+
+import com.gempukku.swccgo.common.CardSubtype;
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.game.PhysicalCardImpl;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Card_1_75_Tests {
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>()
+                {{
+                    put("ca", "1_75");
+                    put("tc", "1_39");
+                    put("pilot", "1_27");
+                    put("pilot2", "1_27");
+                    put("xwing", "1_146");
+                    put("xwing2", "1_146");
+                    put("ywing", "1_147");
+                    put("xwlc", "7_162");
+                    put("xwlc2", "7_162");
+                    put("ept", "9_88");
+                    put("bwing", "7_140");
+                    put("bwing2", "9_66");
+                    put("im", "7_159");
+                    put("im2", "7_159");
+                }},
+                new HashMap<>()
+                {{
+                    put("stalker", "3_152");
+                    put("executor", "4_167");
+                    put("tie", "1_304");
+                    put("tie2", "1_304");
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSSpaceSystem,
+                StartingSetup.DefaultDSSpaceSystem,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void CombinedAttackStatsAndKeywordsAreCorrect() {
+        /**
+         * Title: Combined Attack
+         * Uniqueness: Unrestricted
+         * Side: Light
+         * Type: Interrupt
+         * Subtype: Lost
+         * Destiny: 4
+         * Game Text: During a battle, target opponent's starship present with two (or more) of your starship weapons.
+         *      Add all weapon destiny draws together. Apply that total separately for each weapon in an order of your choosing.
+         * Lore: Efficient cooperation allowed the Rebels to coordinate the attack of their small starfighters effectively
+         *      at the Battle of Yavin.
+         * Set: Premiere
+         * Rarity: C2
+         */
+        var scn = GetScenario();
+        var card = scn.GetLSCard("ca").getBlueprint();
+
+        assertEquals("Combined Attack", card.getTitle());
+        assertEquals(Uniqueness.UNRESTRICTED, card.getUniqueness());
+        assertEquals(Side.LIGHT, card.getSide());
+        assertTrue(card.isCardType(CardType.INTERRUPT));
+        assertEquals(CardSubtype.LOST, card.getCardSubtype());
+        assertEquals(4, card.getDestiny(), scn.epsilon);
+        assertEquals(Rarity.C2, card.getRarity());
+    }
+
+    @Test
+    public void CombinedAttackCannotBePlayedOutsideBattle() {
+        var scn = GetScenario();
+        var ca = scn.GetLSCard("ca");
+        setupTwoXwingLasers(scn);
+        scn.MoveCardsToHand(ca);
+
+        scn.SkipToLSTurn(Phase.CONTROL);
+        assertFalse(scn.LSCardPlayAvailable(ca));
+
+        scn.SkipToPhase(Phase.DEPLOY);
+        assertFalse(scn.LSCardPlayAvailable(ca));
+    }
+
+    @Test
+    public void CombinedAttackCannotBePlayedWithFewerThanTwoLegalStarshipWeapons() {
+        var scn = GetScenario();
+        var ca = scn.GetLSCard("ca");
+        setupOneXwingLaser(scn);
+        scn.MoveCardsToHand(ca);
+
+        startWeaponsSegment(scn);
+        assertFalse("Combined Attack requires two or more legal starship weapons", scn.LSCardPlayAvailable(ca));
+    }
+
+    @Test
+    public void CombinedAttackAddsDestinyDrawsAndAppliesTotalToEachWeapon() {
+        // Two X-wing Laser Cannons (X=0) vs TIE maneuver 3.
+        // Destinies 2 then 3: separately 2 miss and 3 miss; Combined Attack draw-sum 5 > 3 hits.
+        var scn = GetScenario();
+        var ca = scn.GetLSCard("ca");
+        var xwlc = scn.GetLSCard("xwlc");
+        var xwlc2 = scn.GetLSCard("xwlc2");
+        var tie = scn.GetDSCard("tie");
+        setupTwoXwingLasers(scn);
+        scn.MoveCardsToHand(ca);
+
+        startWeaponsSegment(scn);
+        assertTrue(scn.LSCardPlayAvailable(ca));
+        playCombinedAttack(scn, tie, xwlc, xwlc2);
+
+        fireOneShot(scn, tie, 2, 0);
+        assertFalse("First Combined Attack destiny must not resolve a hit by itself", tie.isHit());
+
+        fireOneShot(scn, tie, 3, 0);
+        finishCombinedAttack(scn);
+        assertTrue(tie.isHit());
+    }
+
+    @Test
+    public void CombinedAttackExample2EptAndTwoIntruderMissilesHitsStalkerNotExecutor() {
+        /**
+         * Google Doc / Rulebook Example 2 (fleshed out):
+         * LS Combined Attack combining Enhanced Proton Torpedoes + 2 Intruder Missiles.
+         * Draws 1, 2, 3. Draw-sum 6.
+         * Total modifiers: +1 from Torpedoes (vs capital) and +3 from ONE Intruder Missile
+         * (not +6 from two; cumulative / per-weapon).
+         * Per-weapon AR: EPT 6+1=7 vs Stalker armor 7 miss; IM 6+3=9 vs 7 hit.
+         * Executor armor 12: 7 and 9 both miss.
+         * Grand-total teaching number 1+2+3+1+3=10 also hits Stalker and misses Executor.
+         */
+        var scn = GetScenario();
+        var ca = scn.GetLSCard("ca");
+        var ept = scn.GetLSCard("ept");
+        var im = scn.GetLSCard("im");
+        var im2 = scn.GetLSCard("im2");
+        var stalker = scn.GetDSCard("stalker");
+        setupEptAndTwoIntruderMissiles(scn, false);
+        scn.MoveCardsToHand(ca);
+
+        startWeaponsSegment(scn);
+        playCombinedAttack(scn, stalker, ept, im, im2);
+        stackCombinedAttackDestinies(scn, 1, 2, 3);
+
+        fireOneShot(scn, stalker, 1);
+        assertFalse(stalker.isHit());
+        fireOneShot(scn, stalker, 2);
+        assertFalse(stalker.isHit());
+        fireOneShot(scn, stalker, 3);
+        finishCombinedAttack(scn);
+        assertTrue("Stalker armor 7 must be hit by Combined Attack example 2", stalker.isHit());
+        assertEquals(7, scn.GetDefense(stalker));
+    }
+
+    @Test
+    public void CombinedAttackExample2DoesNotHitExecutorArmor12() {
+        var scn = GetScenario();
+        var ca = scn.GetLSCard("ca");
+        var ept = scn.GetLSCard("ept");
+        var im = scn.GetLSCard("im");
+        var im2 = scn.GetLSCard("im2");
+        var executor = scn.GetDSCard("executor");
+        setupEptAndTwoIntruderMissiles(scn, true);
+        scn.MoveCardsToHand(ca);
+
+        startWeaponsSegment(scn);
+        playCombinedAttack(scn, executor, ept, im, im2);
+        stackCombinedAttackDestinies(scn, 1, 2, 3);
+
+        fireOneShot(scn, executor, 1);
+        fireOneShot(scn, executor, 2);
+        fireOneShot(scn, executor, 3);
+        finishCombinedAttack(scn);
+
+        assertFalse("Executor armor 12 must not be hit by destinies 1+2+3 plus EPT/IM totals", executor.isHit());
+    }
+
+    @Test
+    public void TargetingComputerBothShotsGoIntoCombinedAttackPool() {
+        // Two XWLCs, one ship has Targeting Computer. Use TC inside CA.
+        // Destinies 4 and 4 (TC weapon, two draws, each -1) plus 1 (second weapon) = 7 vs TIE 3.
+        // TC weapon is still one weapon when applying the shared total.
+        var scn = GetScenario();
+        var ca = scn.GetLSCard("ca");
+        var tc = scn.GetLSCard("tc");
+        var xwlc = scn.GetLSCard("xwlc");
+        var xwlc2 = scn.GetLSCard("xwlc2");
+        var tie = scn.GetDSCard("tie");
+        setupTwoXwingLasersWithTcOnFirst(scn);
+        scn.MoveCardsToHand(ca);
+
+        startWeaponsSegment(scn);
+        playCombinedAttack(scn, tie, xwlc, xwlc2);
+        chooseUseTargetingComputer(scn, true);
+
+        // TC -1 on each draw from the TC starship: dest 4,4 then 1 from the other weapon => (4-1)+(4-1)+1 = 7 > 3.
+        fireOneShot(scn, tie, 4, 0);
+        assertFalse(tie.isHit());
+        fireOneShot(scn, tie, 4, 0);
+        assertFalse("TC second draw is still in the Combined Attack pool, not a standalone TC resolve", tie.isHit());
+        fireOneShot(scn, tie, 1, 0);
+        finishCombinedAttack(scn);
+        assertTrue(tie.isHit());
+
+        passOptionalResponses(scn);
+        if (scn.AwaitingLSWeaponsSegmentActions()) {
+            assertFalse("Both TC shots were inside Combined Attack; TC cannot be used again this battle",
+                    scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
+        }
+    }
+
+    @Test
+    public void TargetingComputerCannotSplitOneShotInsideCombinedAttackAndOneOutside() {
+        // Forum p=1111897: both TC shots consecutive and both inside Combined Attack.
+        var scn = GetScenario();
+        var ca = scn.GetLSCard("ca");
+        var tc = scn.GetLSCard("tc");
+        var xwlc = scn.GetLSCard("xwlc");
+        var xwlc2 = scn.GetLSCard("xwlc2");
+        var tie = scn.GetDSCard("tie");
+        var tie2 = scn.GetDSCard("tie2");
+        setupTwoXwingLasersWithTcOnFirst(scn);
+        scn.MoveCardsToHand(ca);
+
+        startWeaponsSegment(scn);
+        playCombinedAttack(scn, tie, xwlc, xwlc2);
+        chooseUseTargetingComputer(scn, true);
+
+        fireOneShot(scn, tie, 4, 0);
+        fireOneShot(scn, tie, 4, 0);
+        fireOneShot(scn, tie, 4, 0);
+        finishCombinedAttack(scn);
+        assertTrue(tie.isHit());
+
+        passOptionalResponses(scn);
+        if (scn.AwaitingLSWeaponsSegmentActions()) {
+            assertFalse("Cannot fire the leftover TC shot outside Combined Attack",
+                    scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
+            assertFalse("XWLC already used its Combined Attack / once-per-battle firing",
+                    scn.LSCardActionAvailable(xwlc));
+        }
+        assertFalse("Second TIE must not be hit by a split leftover TC shot", tie2.isHit());
+    }
+
+
+
+    private void setupTwoXwingLasers(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var xwing = scn.GetLSCard("xwing");
+        var xwing2 = scn.GetLSCard("xwing2");
+        var xwlc = scn.GetLSCard("xwlc");
+        var xwlc2 = scn.GetLSCard("xwlc2");
+        var tie = scn.GetDSCard("tie");
+        var tie2 = scn.GetDSCard("tie2");
+        scn.MoveCardsToLocation(system, xwing, xwing2, tie, tie2);
+        scn.AttachCardsTo(xwing, xwlc);
+        scn.AttachCardsTo(xwing2, xwlc2);
+    }
+
+    private void setupOneXwingLaser(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var xwing = scn.GetLSCard("xwing");
+        var xwlc = scn.GetLSCard("xwlc");
+        var tie = scn.GetDSCard("tie");
+        scn.MoveCardsToLocation(system, xwing, tie);
+        scn.AttachCardsTo(xwing, xwlc);
+    }
+
+    private void setupTwoXwingLasersWithTcOnFirst(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var xwing = scn.GetLSCard("xwing");
+        var xwing2 = scn.GetLSCard("xwing2");
+        var xwlc = scn.GetLSCard("xwlc");
+        var xwlc2 = scn.GetLSCard("xwlc2");
+        var tc = scn.GetLSCard("tc");
+        var tie = scn.GetDSCard("tie");
+        var tie2 = scn.GetDSCard("tie2");
+        scn.MoveCardsToLocation(system, xwing, xwing2, tie, tie2);
+        scn.AttachCardsTo(xwing, xwlc, tc);
+        scn.AttachCardsTo(xwing2, xwlc2);
+    }
+
+    private void setupEptAndTwoIntruderMissiles(VirtualTableScenario scn, boolean vsExecutor) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var ywing = scn.GetLSCard("ywing");
+        var bwing = scn.GetLSCard("bwing");
+        var bwing2 = scn.GetLSCard("bwing2");
+        var ept = scn.GetLSCard("ept");
+        var im = scn.GetLSCard("im");
+        var im2 = scn.GetLSCard("im2");
+        var target = vsExecutor ? scn.GetDSCard("executor") : scn.GetDSCard("stalker");
+        scn.MoveCardsToLocation(system, ywing, bwing, bwing2, target);
+        scn.BoardAsPilot(bwing, scn.GetLSCard("pilot"));
+        scn.BoardAsPilot(bwing2, scn.GetLSCard("pilot2"));
+        scn.AttachCardsTo(ywing, ept);
+        scn.AttachCardsTo(bwing, im);
+        scn.AttachCardsTo(bwing2, im2);
+    }
+
+    private void startWeaponsSegment(VirtualTableScenario scn) {
+        scn.SkipToLSTurn(Phase.BATTLE);
+        scn.LSInitiateBattle(scn.GetLSStartingLocation());
+        passOptionalResponses(scn);
+        assertTrue(scn.AwaitingLSWeaponsSegmentActions());
+    }
+
+    private void playCombinedAttack(VirtualTableScenario scn, PhysicalCardImpl target, PhysicalCardImpl... weapons) {
+        var ca = scn.GetLSCard("ca");
+        if (scn.LSCardPlayAvailable(ca)) {
+            scn.LSPlayCard(ca);
+        }
+        else {
+            scn.LSUseCardAction(ca);
+        }
+        if (scn.LSHasCardChoiceAvailable(target)) {
+            scn.LSChooseCard(target);
+        }
+        if (weapons.length > 0 && scn.LSGetDecision() != null) {
+            scn.LSChooseCards(weapons);
+        }
+        passOptionalResponses(scn);
+    }
+
+    private void chooseUseTargetingComputer(VirtualTableScenario scn, boolean use) {
+        if (scn.LSGetDecision() == null || scn.LSGetDecision().getText() == null) {
+            return;
+        }
+        String text = scn.LSGetDecision().getText();
+        if (text.contains("Targeting Computer") || text.contains("fire") && text.contains("twice")) {
+            scn.LSChoose(use ? "Yes" : "No");
+        }
+    }
+
+    private void fireOneShot(VirtualTableScenario scn, PhysicalCardImpl target, int destiny) {
+        fireOneShot(scn, target, destiny, null);
+    }
+
+    private void fireOneShot(VirtualTableScenario scn, PhysicalCardImpl target, int destiny, Integer forceToUse) {
+        scn.PrepareLSDestiny(destiny);
+        if (scn.LSGetDecision() != null && scn.LSHasCardChoiceAvailable(target)) {
+            scn.LSChooseCard(target);
+        }
+        chooseForceAmountIfPrompted(scn, forceToUse);
+        scn.PassForceUseResponses();
+        scn.PassWeaponFireWithDestinyDraw();
+        passPostFiringResponses(scn);
+    }
+
+    private void stackCombinedAttackDestinies(VirtualTableScenario scn, int... destinies) {
+        // Last prepared card sits on top, so stack in reverse.
+        for (int i = destinies.length - 1; i >= 0; i--) {
+            scn.PrepareLSDestiny(destinies[i]);
+        }
+    }
+
+    private void chooseForceAmountIfPrompted(VirtualTableScenario scn, Integer forceToUse) {
+        if (scn.LSGetDecision() == null || scn.LSGetDecision().getText() == null) {
+            return;
+        }
+        String text = scn.LSGetDecision().getText().toLowerCase();
+        if (!(text.contains("amount") || text.contains("how much") || text.contains("force to use") || text.contains("x ="))) {
+            return;
+        }
+        int amount = forceToUse != null ? forceToUse : scn.LSGetChoiceMin();
+        scn.LSDecided(amount);
+    }
+
+    private void passOptionalResponses(VirtualTableScenario scn) {
+        if (scn.GetCurrentDecision() != null) {
+            scn.PassAllResponses();
+        }
+    }
+
+    private void passPostFiringResponses(VirtualTableScenario scn) {
+        scn.PassResponses("ATTRIBUTE_RESET_OR_MODIFIED");
+        scn.PassResponses("Ionized");
+        scn.PassResponses("ABOUT_TO_BE_HIT");
+        scn.PassResponses("HIT -");
+        scn.PassResponses("FIRED_WEAPON");
+        scn.PassResponses("PLACE_IN_CARD_PILE");
+    }
+
+    private void finishCombinedAttack(VirtualTableScenario scn) {
+        scn.PassResponses("PLACE_IN_CARD_PILE");
+        scn.PassAllResponses();
+        scn.PassResponses("ABOUT_TO_BE_HIT");
+        scn.PassResponses("HIT -");
+        scn.PassResponses("FIRED_WEAPON");
+        scn.PassAllResponses();
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_75_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_75_Tests.java
@@ -211,7 +211,7 @@ public class Card_1_75_Tests {
 
         scn.StartBattleAndSkipToWeaponsSegment();
         playCombinedAttack(scn, tie, xwlc, xwlc2);
-        chooseWhetherToUseTargetingComputer(scn, true);
+        chooseWhetherToUseTargetingComputer(scn, xwlc, true);
 
         // TC -1 on each draw from the TC starship: dest 4,4 then 1 from the other weapon => (4-1)+(4-1)+1 = 7 > 3.
         fireOneShot(scn, tie, 4, 0);
@@ -244,7 +244,7 @@ public class Card_1_75_Tests {
 
         scn.StartBattleAndSkipToWeaponsSegment();
         playCombinedAttack(scn, tie, xwlc, xwlc2);
-        chooseWhetherToUseTargetingComputer(scn, true);
+        chooseWhetherToUseTargetingComputer(scn, xwlc, true);
 
         fireOneShot(scn, tie, 4, 0);
         fireOneShot(scn, tie, 4, 0);
@@ -278,7 +278,7 @@ public class Card_1_75_Tests {
 
         scn.StartBattleAndSkipToWeaponsSegment();
         playCombinedAttack(scn, tie, xwlc, xwlc2);
-        chooseWhetherToUseTargetingComputer(scn, true);
+        chooseWhetherToUseTargetingComputer(scn, xwlc, true);
         if (scn.LSGetDecision() != null) {
             assertFalse("Using Targeting Computer inside Combined Attack must not then ask Separately vs Combined",
                     scn.LSChoiceAvailable("Separately"));
@@ -315,7 +315,7 @@ public class Card_1_75_Tests {
 
         scn.StartBattleAndSkipToWeaponsSegment();
         playCombinedAttack(scn, tie, xwlc, xwlc2);
-        chooseWhetherToUseTargetingComputer(scn, false);
+        chooseWhetherToUseTargetingComputer(scn, xwlc, false);
 
         // One shot from the Targeting Computer ship (no second Targeting Computer firing) plus the other weapon.
         fireOneShot(scn, tie, 4, 0);
@@ -342,7 +342,7 @@ public class Card_1_75_Tests {
 
         scn.StartBattleAndSkipToWeaponsSegment();
         playCombinedAttack(scn, tie, xwlc, xwlc2);
-        assertTargetingComputerTableChooser(scn);
+        assertTargetingComputerTableChooser(scn, xwlc);
         assertTrue(scn.LSHasCardChoiceAvailable(tc));
         assertTrue(scn.LSHasCardChoiceAvailable(tc2));
         assertEquals("Only unused Targeting Computers on the firing starship", 2, scn.LSGetCardChoiceCount());
@@ -502,11 +502,13 @@ public class Card_1_75_Tests {
 
     /**
      * Combined Attack optional Targeting Computer table chooser: click a Targeting Computer
-     * card to fire that Combined Attack weapon twice into the pool, or Done to skip.
-     * Not the standalone Fire a weapon twice three-way, and not MultipleChoice buttons.
+     * card to fire the named Combined Attack weapon twice into the pool, or Done to skip.
+     * The prompt names that firing weapon (for example X-wing Laser Cannon) so the player
+     * knows which Combined Attack weapon is about to fire. Not the standalone Fire a weapon
+     * twice three-way, and not MultipleChoice buttons.
      */
-    private void chooseWhetherToUseTargetingComputer(VirtualTableScenario scn, boolean useTargetingComputer) {
-        assertTargetingComputerTableChooser(scn);
+    private void chooseWhetherToUseTargetingComputer(VirtualTableScenario scn, PhysicalCardImpl weapon, boolean useTargetingComputer) {
+        assertTargetingComputerTableChooser(scn, weapon);
         if (useTargetingComputer) {
             scn.LSChooseCard(scn.GetLSCard("tc"));
         }
@@ -518,12 +520,13 @@ public class Card_1_75_Tests {
 
     /**
      * Combined Attack Targeting Computer prompt is a table-card chooser, not buttons.
+     * The decision text must name Targeting Computer, the firing weapon's title, and Done.
      */
-    private void assertTargetingComputerTableChooser(VirtualTableScenario scn) {
-        assertTrue("Expected optional Targeting Computer prompt for Combined Attack, got: "
-                        + (scn.LSGetDecision() == null ? "null" : scn.LSGetDecision().getText()),
+    private void assertTargetingComputerTableChooser(VirtualTableScenario scn, PhysicalCardImpl weapon) {
+        String decisionText = scn.LSGetDecision() == null ? "null" : scn.LSGetDecision().getText();
+        assertTrue("Expected optional Targeting Computer prompt naming " + weapon.getTitle() + ", got: " + decisionText,
                 scn.LSDecisionAvailable("Targeting Computer")
-                        && scn.LSDecisionAvailable("Combined Attack")
+                        && scn.LSDecisionAvailable(weapon.getTitle())
                         && scn.LSDecisionAvailable("Done"));
         assertFalse("Combined Attack must not ask Separately vs Combined", scn.LSChoiceAvailable("Separately"));
         assertFalse("Combined Attack must not offer Don't Fire (Cancel)", scn.LSChoiceAvailable("Don't Fire"));

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_75_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_75_Tests.java
@@ -105,7 +105,7 @@ public class Card_1_75_Tests {
         setupOneXwingLaser(scn);
         scn.MoveCardsToHand(ca);
 
-        startWeaponsSegment(scn);
+        scn.StartBattleAndSkipToWeaponsSegment();
         assertFalse("Combined Attack requires two or more legal starship weapons", scn.LSCardPlayAvailable(ca));
     }
 
@@ -121,7 +121,7 @@ public class Card_1_75_Tests {
         setupTwoXwingLasers(scn);
         scn.MoveCardsToHand(ca);
 
-        startWeaponsSegment(scn);
+        scn.StartBattleAndSkipToWeaponsSegment();
         assertTrue(scn.LSCardPlayAvailable(ca));
         playCombinedAttack(scn, tie, xwlc, xwlc2);
 
@@ -154,7 +154,7 @@ public class Card_1_75_Tests {
         setupEptAndTwoIntruderMissiles(scn, false);
         scn.MoveCardsToHand(ca);
 
-        startWeaponsSegment(scn);
+        scn.StartBattleAndSkipToWeaponsSegment();
         playCombinedAttack(scn, stalker, ept, im, im2);
         stackCombinedAttackDestinies(scn, 1, 2, 3);
 
@@ -179,7 +179,7 @@ public class Card_1_75_Tests {
         setupEptAndTwoIntruderMissiles(scn, true);
         scn.MoveCardsToHand(ca);
 
-        startWeaponsSegment(scn);
+        scn.StartBattleAndSkipToWeaponsSegment();
         playCombinedAttack(scn, executor, ept, im, im2);
         stackCombinedAttackDestinies(scn, 1, 2, 3);
 
@@ -205,7 +205,7 @@ public class Card_1_75_Tests {
         setupTwoXwingLasersWithTcOnFirst(scn);
         scn.MoveCardsToHand(ca);
 
-        startWeaponsSegment(scn);
+        scn.StartBattleAndSkipToWeaponsSegment();
         playCombinedAttack(scn, tie, xwlc, xwlc2);
         chooseUseTargetingComputer(scn, true);
 
@@ -218,7 +218,7 @@ public class Card_1_75_Tests {
         finishCombinedAttack(scn);
         assertTrue(tie.isHit());
 
-        passOptionalResponses(scn);
+        scn.PassAllResponses();
         if (scn.AwaitingLSWeaponsSegmentActions()) {
             assertFalse("Both TC shots were inside Combined Attack; TC cannot be used again this battle",
                     scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
@@ -238,7 +238,7 @@ public class Card_1_75_Tests {
         setupTwoXwingLasersWithTcOnFirst(scn);
         scn.MoveCardsToHand(ca);
 
-        startWeaponsSegment(scn);
+        scn.StartBattleAndSkipToWeaponsSegment();
         playCombinedAttack(scn, tie, xwlc, xwlc2);
         chooseUseTargetingComputer(scn, true);
 
@@ -248,7 +248,7 @@ public class Card_1_75_Tests {
         finishCombinedAttack(scn);
         assertTrue(tie.isHit());
 
-        passOptionalResponses(scn);
+        scn.PassAllResponses();
         if (scn.AwaitingLSWeaponsSegmentActions()) {
             assertFalse("Cannot fire the leftover TC shot outside Combined Attack",
                     scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
@@ -317,13 +317,6 @@ public class Card_1_75_Tests {
         scn.AttachCardsTo(bwing2, im2);
     }
 
-    private void startWeaponsSegment(VirtualTableScenario scn) {
-        scn.SkipToLSTurn(Phase.BATTLE);
-        scn.LSInitiateBattle(scn.GetLSStartingLocation());
-        passOptionalResponses(scn);
-        assertTrue(scn.AwaitingLSWeaponsSegmentActions());
-    }
-
     private void playCombinedAttack(VirtualTableScenario scn, PhysicalCardImpl target, PhysicalCardImpl... weapons) {
         var ca = scn.GetLSCard("ca");
         if (scn.LSCardPlayAvailable(ca)) {
@@ -338,17 +331,15 @@ public class Card_1_75_Tests {
         if (weapons.length > 0 && scn.LSGetDecision() != null) {
             scn.LSChooseCards(weapons);
         }
-        passOptionalResponses(scn);
+        scn.PassAllResponses();
     }
 
     private void chooseUseTargetingComputer(VirtualTableScenario scn, boolean use) {
-        if (scn.LSGetDecision() == null || scn.LSGetDecision().getText() == null) {
-            return;
-        }
-        String text = scn.LSGetDecision().getText();
-        if (text.contains("Targeting Computer") || text.contains("fire") && text.contains("twice")) {
-            scn.LSChoose(use ? "Yes" : "No");
-        }
+        String text = scn.LSGetDecision() == null ? "null" : scn.LSGetDecision().getText();
+        assertTrue("Expected Targeting Computer fire-twice prompt, got: " + text,
+                text != null && (text.contains("Targeting Computer")
+                        || (text.toLowerCase().contains("fire") && text.toLowerCase().contains("twice"))));
+        scn.LSChoose(use ? "Yes" : "No");
     }
 
     private void fireOneShot(VirtualTableScenario scn, PhysicalCardImpl target, int destiny) {
@@ -383,12 +374,6 @@ public class Card_1_75_Tests {
         }
         int amount = forceToUse != null ? forceToUse : scn.LSGetChoiceMin();
         scn.LSDecided(amount);
-    }
-
-    private void passOptionalResponses(VirtualTableScenario scn) {
-        if (scn.GetCurrentDecision() != null) {
-            scn.PassAllResponses();
-        }
     }
 
     private void passPostFiringResponses(VirtualTableScenario scn) {

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_75_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_75_Tests.java
@@ -26,6 +26,7 @@ public class Card_1_75_Tests {
                 {{
                     put("ca", "1_75");
                     put("tc", "1_39");
+                    put("tc2", "1_39");
                     put("pilot", "1_27");
                     put("pilot2", "1_27");
                     put("xwing", "1_146");
@@ -210,7 +211,7 @@ public class Card_1_75_Tests {
 
         scn.StartBattleAndSkipToWeaponsSegment();
         playCombinedAttack(scn, tie, xwlc, xwlc2);
-        chooseSeparatelyOrCombined(scn, "Combined");
+        chooseWhetherToUseTargetingComputer(scn, true);
 
         // TC -1 on each draw from the TC starship: dest 4,4 then 1 from the other weapon => (4-1)+(4-1)+1 = 7 > 3.
         fireOneShot(scn, tie, 4, 0);
@@ -243,7 +244,7 @@ public class Card_1_75_Tests {
 
         scn.StartBattleAndSkipToWeaponsSegment();
         playCombinedAttack(scn, tie, xwlc, xwlc2);
-        chooseSeparatelyOrCombined(scn, "Combined");
+        chooseWhetherToUseTargetingComputer(scn, true);
 
         fireOneShot(scn, tie, 4, 0);
         fireOneShot(scn, tie, 4, 0);
@@ -262,10 +263,14 @@ public class Card_1_75_Tests {
     }
 
     @Test
-    public void TargetingComputerInsideCombinedAttackPresentsSeparatelyOrCombinedChoice() {
-        // Same three-way as standalone Targeting Computer. Both shots still go into the CA pool.
+    public void TargetingComputerInsideCombinedAttackOffersOptionalUseWithoutSeparatelyCombinedCancel() {
+        // Combined Attack already chose the target. Optional Targeting Computer prompt:
+        // use a Targeting Computer (always combined into the Combined Attack pool) or use none.
+        // No Separately / Combined / Don't Fire. Choosing use consumes Targeting Computer
+        // and both destinies join the Combined Attack pool.
         var scn = GetScenario();
         var ca = scn.GetLSCard("ca");
+        var tc = scn.GetLSCard("tc");
         var xwlc = scn.GetLSCard("xwlc");
         var xwlc2 = scn.GetLSCard("xwlc2");
         var tie = scn.GetDSCard("tie");
@@ -274,18 +279,33 @@ public class Card_1_75_Tests {
 
         scn.StartBattleAndSkipToWeaponsSegment();
         playCombinedAttack(scn, tie, xwlc, xwlc2);
-        chooseSeparatelyOrCombined(scn, "Combined");
+        chooseWhetherToUseTargetingComputer(scn, true);
+        if (scn.LSGetDecision() != null) {
+            assertFalse("Using Targeting Computer inside Combined Attack must not then ask Separately vs Combined",
+                    scn.LSChoiceAvailable("Separately"));
+            assertFalse("Using Targeting Computer inside Combined Attack must not offer Don't Fire (Cancel)",
+                    scn.LSChoiceAvailable("Don't Fire"));
+            assertFalse("Must not present the standalone Fire a weapon twice three-way after opting in",
+                    scn.LSDecisionAvailable("Fire a weapon twice"));
+        }
 
         fireOneShot(scn, tie, 4, 0);
         fireOneShot(scn, tie, 4, 0);
         fireOneShot(scn, tie, 1, 0);
         finishCombinedAttack(scn);
         assertTrue(tie.isHit());
+
+        scn.PassAllResponses();
+        if (scn.AwaitingLSWeaponsSegmentActions()) {
+            assertFalse("Choosing Targeting Computer inside Combined Attack consumes it",
+                    scn.LSCardActionAvailable(tc, "Fire a weapon twice"));
+        }
     }
 
     @Test
-    public void TargetingComputerDontFireInsideCombinedAttackLeavesDeviceUnused() {
-        // Don't Fire fires the Combined Attack weapon once and does not consume Targeting Computer.
+    public void TargetingComputerInsideCombinedAttackCanBeSkippedAndRemainsUnused() {
+        // Choosing Do not use Targeting Computer fires the Combined Attack weapon once
+        // and does not consume Targeting Computer.
         var scn = GetScenario();
         var ca = scn.GetLSCard("ca");
         var xwlc = scn.GetLSCard("xwlc");
@@ -296,15 +316,45 @@ public class Card_1_75_Tests {
 
         scn.StartBattleAndSkipToWeaponsSegment();
         playCombinedAttack(scn, tie, xwlc, xwlc2);
-        chooseSeparatelyOrCombined(scn, "Don't Fire (Cancel)");
+        chooseWhetherToUseTargetingComputer(scn, false);
 
-        // One shot from the TC ship (no second TC firing) plus the other weapon.
+        // One shot from the Targeting Computer ship (no second Targeting Computer firing) plus the other weapon.
         fireOneShot(scn, tie, 4, 0);
         fireOneShot(scn, tie, 1, 0);
         finishCombinedAttack(scn);
-        assertTrue("4 + 1 without TC -1 still hits TIE 3", tie.isHit());
-        // Weapon already fired in Combined Attack, so TC has nothing left to fire;
-        // unused is proven by only two destinies (no extra TC shot) succeeding as 4+1.
+        assertTrue("4 + 1 without Targeting Computer -1 still hits TIE 3", tie.isHit());
+        // Unused is proven by only two destinies (no extra Targeting Computer shot) succeeding as 4+1.
+    }
+
+    @Test
+    public void TargetingComputerInsideCombinedAttackCanChooseAmongMultipleComputersOrNone() {
+        // Two unused Targeting Computers on the same starship: pick one specific computer, or none.
+        var scn = GetScenario();
+        var ca = scn.GetLSCard("ca");
+        var xwlc = scn.GetLSCard("xwlc");
+        var xwlc2 = scn.GetLSCard("xwlc2");
+        var tie = scn.GetDSCard("tie");
+        setupTwoXwingLasersWithTwoTargetingComputersOnFirst(scn);
+        scn.MoveCardsToHand(ca);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        playCombinedAttack(scn, tie, xwlc, xwlc2);
+        assertTrue("Expected optional Targeting Computer prompt, got: "
+                        + (scn.LSGetDecision() == null ? "null" : scn.LSGetDecision().getText()),
+                scn.LSDecisionAvailable("Targeting Computer")
+                        && scn.LSDecisionAvailable("Combined Attack"));
+        assertTrue(scn.LSChoiceAvailable("Do not use Targeting Computer"));
+        assertFalse("Combined Attack must not ask Separately vs Combined", scn.LSChoiceAvailable("Separately"));
+        assertFalse("Combined Attack must not offer Don't Fire (Cancel)", scn.LSChoiceAvailable("Don't Fire"));
+        assertEquals("Two Targeting Computers plus Do not use Targeting Computer", 3, scn.LSGetChoiceCount());
+        // Pick the second Targeting Computer specifically (not auto-first).
+        scn.LSDecided(1);
+
+        fireOneShot(scn, tie, 4, 0);
+        fireOneShot(scn, tie, 4, 0);
+        fireOneShot(scn, tie, 1, 0);
+        finishCombinedAttack(scn);
+        assertTrue(tie.isHit());
     }
 
     @Test
@@ -393,6 +443,25 @@ public class Card_1_75_Tests {
         scn.AttachCardsTo(xwing2, xwlc2);
     }
 
+    /**
+     * Two X-wing Laser Cannons vs two TIEs, with two unused Targeting Computers on the first X-wing.
+     */
+    private void setupTwoXwingLasersWithTwoTargetingComputersOnFirst(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var xwing = scn.GetLSCard("xwing");
+        var xwing2 = scn.GetLSCard("xwing2");
+        var xwlc = scn.GetLSCard("xwlc");
+        var xwlc2 = scn.GetLSCard("xwlc2");
+        var tc = scn.GetLSCard("tc");
+        var tc2 = scn.GetLSCard("tc2");
+        var tie = scn.GetDSCard("tie");
+        var tie2 = scn.GetDSCard("tie2");
+        scn.MoveCardsToLocation(system, xwing, xwing2, tie, tie2);
+        scn.AttachCardsTo(xwing, xwlc, tc, tc2);
+        scn.AttachCardsTo(xwing2, xwlc2);
+    }
+
     private void setupEptAndTwoIntruderMissiles(VirtualTableScenario scn, boolean vsExecutor) {
         scn.StartGame();
         var system = scn.GetLSStartingLocation();
@@ -428,14 +497,24 @@ public class Card_1_75_Tests {
         scn.PassAllResponses();
     }
 
-    private void chooseSeparatelyOrCombined(VirtualTableScenario scn, String mode) {
-        assertTrue("Expected Fire a weapon twice prompt, got: "
+    /**
+     * Combined Attack optional Targeting Computer prompt: use one (always combined into
+     * the Combined Attack pool) or use none. Not the standalone Fire a weapon twice three-way.
+     */
+    private void chooseWhetherToUseTargetingComputer(VirtualTableScenario scn, boolean useTargetingComputer) {
+        assertTrue("Expected optional Targeting Computer prompt for Combined Attack, got: "
                         + (scn.LSGetDecision() == null ? "null" : scn.LSGetDecision().getText()),
-                scn.LSDecisionAvailable("Fire a weapon twice"));
-        assertTrue(scn.LSChoiceAvailable("Separately"));
-        assertTrue(scn.LSChoiceAvailable("Combined"));
-        assertTrue(scn.LSChoiceAvailable("Don't Fire (Cancel)"));
-        scn.LSChoose(mode);
+                scn.LSDecisionAvailable("Targeting Computer")
+                        && scn.LSDecisionAvailable("Combined Attack"));
+        assertFalse("Combined Attack must not ask Separately vs Combined", scn.LSChoiceAvailable("Separately"));
+        assertFalse("Combined Attack must not offer Don't Fire (Cancel)", scn.LSChoiceAvailable("Don't Fire"));
+        assertTrue(scn.LSChoiceAvailable("Do not use Targeting Computer"));
+        if (useTargetingComputer) {
+            scn.LSDecided(0);
+        }
+        else {
+            scn.LSChoose("Do not use Targeting Computer");
+        }
     }
 
     private void fireOneShot(VirtualTableScenario scn, PhysicalCardImpl target, int destiny) {

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_75_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_75_Tests.java
@@ -6,12 +6,14 @@ import com.gempukku.swccgo.common.Phase;
 import com.gempukku.swccgo.common.Rarity;
 import com.gempukku.swccgo.common.Side;
 import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.common.Zone;
 import com.gempukku.swccgo.framework.StartingSetup;
 import com.gempukku.swccgo.framework.VirtualTableScenario;
 import com.gempukku.swccgo.game.PhysicalCardImpl;
 import org.junit.Test;
 
 import java.util.HashMap;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -258,6 +260,34 @@ public class Card_1_75_Tests {
         assertFalse("Second TIE must not be hit by a split leftover TC shot", tie2.isHit());
     }
 
+    @Test
+    public void CombinedAttackXwingLaserCannonX3LosesTieNotMerelyHit() {
+        // Playtest: Combined Attack, pay 3 Force to fire X-wing Laser Cannon. Combined destinies
+        // succeed vs TIE DV 3, but XWLC game text is "lost if destiny + X > DV" when X=3.
+        // Must use the weapon's own result path, not HitCardEffect for every non-ion weapon.
+        var scn = GetScenario();
+        var ca = scn.GetLSCard("ca");
+        var xwlc = scn.GetLSCard("xwlc");
+        var xwlc2 = scn.GetLSCard("xwlc2");
+        var tie = scn.GetDSCard("tie");
+        setupTwoXwingLasers(scn);
+        scn.MoveCardsToHand(ca);
+        scn.EnsureLSForcePile(6);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        playCombinedAttack(scn, tie, xwlc, xwlc2);
+
+        fireOneShot(scn, tie, 4, 3);
+        assertFalse("First Combined Attack destiny must not resolve a hit or loss by itself", tie.isHit());
+        assertEquals(Zone.AT_LOCATION, tie.getZone());
+
+        fireOneShot(scn, tie, 4, 0);
+        finishCombinedAttack(scn);
+
+        assertTrue("X-wing Laser Cannon at X=3 must lose the TIE, not merely hit",
+                tie.getZone() == Zone.LOST_PILE || tie.getZone() == Zone.TOP_OF_LOST_PILE);
+        assertFalse("TIE must not remain at the location as merely hit", tie.getZone() == Zone.AT_LOCATION);
+    }
 
 
     private void setupTwoXwingLasers(VirtualTableScenario scn) {
@@ -379,18 +409,42 @@ public class Card_1_75_Tests {
     private void passPostFiringResponses(VirtualTableScenario scn) {
         scn.PassResponses("ATTRIBUTE_RESET_OR_MODIFIED");
         scn.PassResponses("Ionized");
+        scn.PassResponses("ABOUT_TO_BE_LOST");
         scn.PassResponses("ABOUT_TO_BE_HIT");
         scn.PassResponses("HIT -");
         scn.PassResponses("FIRED_WEAPON");
         scn.PassResponses("PLACE_IN_CARD_PILE");
     }
 
+    private void chooseResultApplyOrderIfPrompted(VirtualTableScenario scn) {
+        int safety = 0;
+        while (safety++ < 8 && scn.LSGetDecision() != null && scn.LSGetDecision().getText() != null) {
+            String text = scn.LSGetDecision().getText().toLowerCase();
+            if (!(text.contains("applies first") || text.contains("weapon result"))) {
+                break;
+            }
+            // ChooseArbitraryCardsEffect uses temp0/temp1 indexes, not in-play card IDs.
+            List<String> ids = scn.LSGetCardChoices();
+            if (ids == null || ids.isEmpty()) {
+                break;
+            }
+            scn.PlayerDecided("Light Side Player", ids.get(0));
+        }
+    }
+
     private void finishCombinedAttack(VirtualTableScenario scn) {
+        chooseResultApplyOrderIfPrompted(scn);
         scn.PassResponses("PLACE_IN_CARD_PILE");
         scn.PassAllResponses();
+        scn.PassResponses("ABOUT_TO_BE_LOST");
         scn.PassResponses("ABOUT_TO_BE_HIT");
         scn.PassResponses("HIT -");
         scn.PassResponses("FIRED_WEAPON");
+        chooseResultApplyOrderIfPrompted(scn);
+        scn.PassResponses("ABOUT_TO_BE_LOST");
+        scn.PassAllResponses();
+        chooseResultApplyOrderIfPrompted(scn);
+        scn.PassResponses("ABOUT_TO_BE_LOST");
         scn.PassAllResponses();
     }
 }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_75_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_75_Tests.java
@@ -29,6 +29,16 @@ public class Card_1_75_Tests {
                     put("ca", "1_75");
                     put("tc", "1_39");
                     put("tc2", "1_39");
+                    put("tc3", "1_39");
+                    put("tc4", "1_39");
+                    put("squadron", "7_150");
+                    put("sw42", "2_081");
+                    put("sw43", "2_081");
+                    put("sw44", "2_081");
+                    put("xwlc3", "7_162");
+                    put("xwlc4", "7_162");
+                    put("htb3", "9_89");
+                    put("htb4", "9_89");
                     put("pilot", "1_27");
                     put("pilot2", "1_27");
                     put("xwing", "1_146");
@@ -54,7 +64,7 @@ public class Card_1_75_Tests {
                     put("tie", "1_304");
                     put("tie2", "1_304");
                 }},
-                10,
+                40,
                 10,
                 StartingSetup.DefaultLSSpaceSystem,
                 StartingSetup.DefaultDSSpaceSystem,
@@ -514,6 +524,231 @@ public class Card_1_75_Tests {
         assertCombinedAttackStateCleared(scn);
     }
 
+
+    @Test
+    public void CombinedAttackStarfighterMayUseOnlyOneTargetingComputerCopy() {
+        // B-wing Attack Fighter may fire many weapons, but a starfighter may use only one
+        // device per turn. Combined Attack clicking one Targeting Computer consumes that
+        // starfighter device slot; later Combined Attack weapons must not offer another copy.
+        var scn = GetScenario();
+        var ca = scn.GetLSCard("ca");
+        var tc = scn.GetLSCard("tc");
+        var tc2 = scn.GetLSCard("tc2");
+        var tc3 = scn.GetLSCard("tc3");
+        var tc4 = scn.GetLSCard("tc4");
+        var sw4 = scn.GetLSCard("sw4");
+        var sw42 = scn.GetLSCard("sw42");
+        var tie = scn.GetDSCard("tie");
+        setupBwingWithFourTargetingComputers(scn);
+        scn.MoveCardsToHand(ca);
+        scn.EnsureLSForcePile(8);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        playCombinedAttack(scn, tie, sw4, sw42);
+        assertTargetingComputerTableChooser(scn, sw4);
+        assertTrue(scn.LSHasCardChoiceAvailable(tc));
+        assertTrue(scn.LSHasCardChoiceAvailable(tc2));
+        assertTrue(scn.LSHasCardChoiceAvailable(tc3));
+        assertTrue(scn.LSHasCardChoiceAvailable(tc4));
+        scn.LSChooseCard(tc);
+
+        fireOneShot(scn, tie, 1);
+        fireOneShot(scn, tie, 1);
+
+        assertFalse("Starfighter already used its one device; later Combined Attack weapons must not offer another Targeting Computer. "
+                        + decisionDump(scn),
+                targetingComputerChooserAvailable(scn, sw42));
+        fireOneShot(scn, tie, 1);
+        finishCombinedAttack(scn);
+    }
+
+    @Test
+    public void CombinedAttackSquadronMayUseThreeTargetingComputerCopies() {
+        // X-wing Assault Squadron may use three different devices per turn. Combined Attack
+        // can click three Targeting Computers; the fourth weapon must not offer the leftover copy.
+        var scn = GetScenario();
+        var ca = scn.GetLSCard("ca");
+        var tc = scn.GetLSCard("tc");
+        var tc2 = scn.GetLSCard("tc2");
+        var tc3 = scn.GetLSCard("tc3");
+        var tc4 = scn.GetLSCard("tc4");
+        var xwlc = scn.GetLSCard("xwlc");
+        var xwlc2 = scn.GetLSCard("xwlc2");
+        var xwlc3 = scn.GetLSCard("xwlc3");
+        var xwlc4 = scn.GetLSCard("xwlc4");
+        var tie = scn.GetDSCard("tie");
+        setupSquadronWithFourTargetingComputers(scn);
+        scn.MoveCardsToHand(ca);
+        scn.EnsureLSForcePile(8);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        playCombinedAttack(scn, tie, xwlc, xwlc2, xwlc3, xwlc4);
+
+        assertTargetingComputerTableChooser(scn, xwlc);
+        assertEquals("All four unused Targeting Computers are offered on the first Combined Attack weapon",
+                4, scn.LSGetCardChoiceCount());
+        scn.LSChooseCard(tc);
+        fireOneShot(scn, tie, 1, 0);
+        fireOneShot(scn, tie, 1, 0);
+
+        assertTargetingComputerTableChooser(scn, xwlc2);
+        assertFalse("Copy A already used this turn cannot be chosen again", scn.LSHasCardChoiceAvailable(tc));
+        assertTrue("Squadron may still use a second Targeting Computer this turn. " + decisionDump(scn),
+                scn.LSHasCardChoiceAvailable(tc2));
+        scn.LSChooseCard(tc2);
+        fireOneShot(scn, tie, 1, 0);
+        fireOneShot(scn, tie, 1, 0);
+
+        assertTargetingComputerTableChooser(scn, xwlc3);
+        assertTrue("Squadron may still use a third Targeting Computer this turn", scn.LSHasCardChoiceAvailable(tc3));
+        scn.LSChooseCard(tc3);
+        fireOneShot(scn, tie, 1, 0);
+        fireOneShot(scn, tie, 1, 0);
+
+        assertFalse("Squadron may use only three devices per turn; the fourth Combined Attack weapon must not offer Targeting Computer. "
+                        + decisionDump(scn),
+                targetingComputerChooserAvailable(scn, xwlc4));
+        fireOneShot(scn, tie, 1, 0);
+        finishCombinedAttack(scn);
+    }
+
+    @Test
+    public void CombinedAttackCapitalMayUseAllFourTargetingComputerCopies() {
+        // Home One may use any number of devices per turn. Combined Attack can click all four
+        // Targeting Computers, one per weapon. Each used copy cannot be chosen again.
+        var scn = GetScenario();
+        var ca = scn.GetLSCard("ca");
+        var tc = scn.GetLSCard("tc");
+        var tc2 = scn.GetLSCard("tc2");
+        var tc3 = scn.GetLSCard("tc3");
+        var tc4 = scn.GetLSCard("tc4");
+        var htb = scn.GetLSCard("htb");
+        var htb2 = scn.GetLSCard("htb2");
+        var htb3 = scn.GetLSCard("htb3");
+        var htb4 = scn.GetLSCard("htb4");
+        var stalker = scn.GetDSCard("stalker");
+        setupCapitalWithFourTargetingComputers(scn);
+        scn.MoveCardsToHand(ca);
+        scn.EnsureLSForcePile(20);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        playCombinedAttack(scn, stalker, htb, htb2, htb3, htb4);
+
+        PhysicalCardImpl[] computers = { tc, tc2, tc3, tc4 };
+        PhysicalCardImpl[] batteries = { htb, htb2, htb3, htb4 };
+        for (int i = 0; i < computers.length; i++) {
+            assertTargetingComputerTableChooser(scn, batteries[i]);
+            for (int j = 0; j < computers.length; j++) {
+                if (j < i) {
+                    assertFalse("Used Targeting Computer copy " + (j + 1) + " cannot be chosen again this turn. "
+                                    + decisionDump(scn),
+                            scn.LSHasCardChoiceAvailable(computers[j]));
+                }
+                else {
+                    assertTrue("Unused Targeting Computer copy " + (j + 1) + " must still be offered. "
+                                    + decisionDump(scn),
+                            scn.LSHasCardChoiceAvailable(computers[j]));
+                }
+            }
+            scn.LSChooseCard(computers[i]);
+            fireTwoDestinyShot(scn, stalker, 1, 1);
+            fireTwoDestinyShot(scn, stalker, 1, 1);
+        }
+        finishCombinedAttack(scn);
+    }
+
+    @Test
+    public void CombinedAttackClickedTargetingComputerCopyCannotBeChosenAgainThisTurn() {
+        // One Rule: clicking a specific Targeting Computer in Combined Attack consumes that
+        // copy for the turn. On a capital (unlimited device slots) Combined Attack must not
+        // list that same copy for a later weapon, while unused copies remain choosable.
+        var scn = GetScenario();
+        var ca = scn.GetLSCard("ca");
+        var tc = scn.GetLSCard("tc");
+        var tc2 = scn.GetLSCard("tc2");
+        var tc3 = scn.GetLSCard("tc3");
+        var tc4 = scn.GetLSCard("tc4");
+        var htb = scn.GetLSCard("htb");
+        var htb2 = scn.GetLSCard("htb2");
+        var stalker = scn.GetDSCard("stalker");
+        setupCapitalWithFourTargetingComputers(scn);
+        scn.MoveCardsToHand(ca);
+        scn.EnsureLSForcePile(12);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        playCombinedAttack(scn, stalker, htb, htb2);
+        assertTargetingComputerTableChooser(scn, htb);
+        assertTrue(scn.LSHasCardChoiceAvailable(tc));
+        scn.LSChooseCard(tc);
+        fireTwoDestinyShot(scn, stalker, 1, 1);
+        fireTwoDestinyShot(scn, stalker, 1, 1);
+
+        assertTargetingComputerTableChooser(scn, htb2);
+        assertFalse("Combined Attack must not offer the same Targeting Computer copy again this turn. "
+                        + decisionDump(scn),
+                scn.LSHasCardChoiceAvailable(tc));
+        assertTrue("Using copy A does not prevent choosing copy B this turn", scn.LSHasCardChoiceAvailable(tc2));
+        assertTrue("Copy C is still available this turn", scn.LSHasCardChoiceAvailable(tc3));
+        assertTrue("Copy D is still available this turn", scn.LSHasCardChoiceAvailable(tc4));
+        scn.LSChooseCard(tc2);
+        fireTwoDestinyShot(scn, stalker, 1, 1);
+        fireTwoDestinyShot(scn, stalker, 1, 1);
+        finishCombinedAttack(scn);
+        scn.PassAllResponses();
+        passDarkSideWeaponsIfNeeded(scn);
+
+        if (scn.AwaitingLSWeaponsSegmentActions()) {
+            assertFalse("Copy A cannot Fire a weapon twice after Combined Attack used it this turn. "
+                            + decisionDump(scn),
+                    fireTwiceAvailable(scn, tc));
+            assertFalse("Copy B cannot Fire a weapon twice after Combined Attack used it this turn",
+                    fireTwiceAvailable(scn, tc2));
+            assertTrue("Copy C was not used in Combined Attack and remains available on leftover Heavy Turbolaser Batteries. "
+                            + decisionDump(scn),
+                    fireTwiceAvailable(scn, tc3));
+            assertTrue("Copy D remains available this turn", fireTwiceAvailable(scn, tc4));
+        }
+    }
+
+    @Test
+    public void CombinedAttackDoneDoesNotConsumeStarfighterDeviceUse() {
+        // Done on the Combined Attack Targeting Computer chooser fires that weapon once and
+        // does not use the device. The starfighter's one device use remains, so leftover
+        // weapons can still Fire a weapon twice after Combined Attack.
+        var scn = GetScenario();
+        var ca = scn.GetLSCard("ca");
+        var tc = scn.GetLSCard("tc");
+        var sw4 = scn.GetLSCard("sw4");
+        var sw42 = scn.GetLSCard("sw42");
+        var tie = scn.GetDSCard("tie");
+        setupBwingWithFourTargetingComputers(scn);
+        scn.MoveCardsToHand(ca);
+        scn.EnsureLSForcePile(8);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        playCombinedAttack(scn, tie, sw4, sw42);
+        assertTargetingComputerTableChooser(scn, sw4);
+        scn.LSDecided("");
+        fireOneShot(scn, tie, 1);
+
+        assertTrue("Done must not consume the starfighter device; the next Combined Attack weapon still offers Targeting Computer. "
+                        + decisionDump(scn),
+                targetingComputerChooserAvailable(scn, sw42));
+        assertTrue(scn.LSHasCardChoiceAvailable(tc));
+        scn.LSDecided("");
+        fireOneShot(scn, tie, 1);
+        finishCombinedAttack(scn);
+        scn.PassAllResponses();
+        passDarkSideWeaponsIfNeeded(scn);
+
+        assertTrue("After Combined Attack Done, Light Side should still have leftover SW-4 Ion Cannons. "
+                        + decisionDump(scn),
+                scn.AwaitingLSWeaponsSegmentActions());
+        assertTrue("Done did not consume Targeting Computer; Fire a weapon twice remains available. "
+                        + decisionDump(scn),
+                fireTwiceAvailable(scn, tc));
+    }
+
     private void setupXwingLaserAndBwingIon(VirtualTableScenario scn) {
         scn.StartGame();
         var system = scn.GetLSStartingLocation();
@@ -841,6 +1076,74 @@ public class Card_1_75_Tests {
         for (int i = 0; i < expected.length; i++) {
             assertEquals("weapon destiny draw " + (i + 1) + " of " + last, expected[i], last.get(i).intValue());
         }
+    }
+
+
+    /**
+     * B-wing Attack Fighter with four Targeting Computers and four SW-4 Ion Cannons vs two TIEs.
+     */
+    private void setupBwingWithFourTargetingComputers(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var bwing = scn.GetLSCard("bwing");
+        var tie = scn.GetDSCard("tie");
+        var tie2 = scn.GetDSCard("tie2");
+        scn.MoveCardsToLocation(system, bwing, tie, tie2);
+        scn.AttachCardsTo(bwing,
+                scn.GetLSCard("sw4"), scn.GetLSCard("sw42"), scn.GetLSCard("sw43"), scn.GetLSCard("sw44"),
+                scn.GetLSCard("tc"), scn.GetLSCard("tc2"), scn.GetLSCard("tc3"), scn.GetLSCard("tc4"));
+    }
+
+    /**
+     * X-wing Assault Squadron with four Targeting Computers and four X-wing Laser Cannons vs two TIEs.
+     */
+    private void setupSquadronWithFourTargetingComputers(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var squadron = scn.GetLSCard("squadron");
+        var tie = scn.GetDSCard("tie");
+        var tie2 = scn.GetDSCard("tie2");
+        scn.MoveCardsToLocation(system, squadron, tie, tie2);
+        scn.AttachCardsTo(squadron,
+                scn.GetLSCard("xwlc"), scn.GetLSCard("xwlc2"), scn.GetLSCard("xwlc3"), scn.GetLSCard("xwlc4"),
+                scn.GetLSCard("tc"), scn.GetLSCard("tc2"), scn.GetLSCard("tc3"), scn.GetLSCard("tc4"));
+    }
+
+    /**
+     * Home One with four Targeting Computers and four Heavy Turbolaser Batteries vs Stalker.
+     */
+    private void setupCapitalWithFourTargetingComputers(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var homeone = scn.GetLSCard("homeone");
+        var stalker = scn.GetDSCard("stalker");
+        scn.MoveCardsToLocation(system, homeone, stalker);
+        scn.AttachCardsTo(homeone,
+                scn.GetLSCard("htb"), scn.GetLSCard("htb2"), scn.GetLSCard("htb3"), scn.GetLSCard("htb4"),
+                scn.GetLSCard("tc"), scn.GetLSCard("tc2"), scn.GetLSCard("tc3"), scn.GetLSCard("tc4"));
+    }
+
+    private boolean targetingComputerChooserAvailable(VirtualTableScenario scn, PhysicalCardImpl weapon) {
+        return scn.LSGetDecision() != null
+                && scn.LSDecisionAvailable("Targeting Computer")
+                && scn.LSDecisionAvailable(weapon.getTitle())
+                && scn.LSDecisionAvailable("Done");
+    }
+
+    private boolean fireTwiceAvailable(VirtualTableScenario scn, PhysicalCardImpl targetingComputer) {
+        return scn.LSGetDecision() != null && scn.LSCardActionAvailable(targetingComputer, "Fire a weapon twice");
+    }
+
+    private void passDarkSideWeaponsIfNeeded(VirtualTableScenario scn) {
+        if (scn.AwaitingDSWeaponsSegmentActions()) {
+            scn.DSPass();
+        }
+    }
+
+    private String decisionDump(VirtualTableScenario scn) {
+        String ls = scn.LSGetDecision() == null ? "null" : scn.LSGetDecision().getText();
+        String ds = scn.DSGetDecision() == null ? "null" : scn.DSGetDecision().getText();
+        return "LS=" + ls + " DS=" + ds;
     }
 
 }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_75_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_75_Tests.java
@@ -38,6 +38,7 @@ public class Card_1_75_Tests {
                     put("bwing2", "9_66");
                     put("im", "7_159");
                     put("im2", "7_159");
+                    put("sw4", "2_081");
                 }},
                 new HashMap<>()
                 {{
@@ -210,6 +211,7 @@ public class Card_1_75_Tests {
         scn.StartBattleAndSkipToWeaponsSegment();
         playCombinedAttack(scn, tie, xwlc, xwlc2);
         chooseUseTargetingComputer(scn, true);
+        chooseSeparatelyOrCombined(scn, "Combined");
 
         // TC -1 on each draw from the TC starship: dest 4,4 then 1 from the other weapon => (4-1)+(4-1)+1 = 7 > 3.
         fireOneShot(scn, tie, 4, 0);
@@ -243,6 +245,7 @@ public class Card_1_75_Tests {
         scn.StartBattleAndSkipToWeaponsSegment();
         playCombinedAttack(scn, tie, xwlc, xwlc2);
         chooseUseTargetingComputer(scn, true);
+        chooseSeparatelyOrCombined(scn, "Combined");
 
         fireOneShot(scn, tie, 4, 0);
         fireOneShot(scn, tie, 4, 0);
@@ -261,34 +264,78 @@ public class Card_1_75_Tests {
     }
 
     @Test
-    public void CombinedAttackXwingLaserCannonX3LosesTieNotMerelyHit() {
-        // Playtest: Combined Attack, pay 3 Force to fire X-wing Laser Cannon. Combined destinies
-        // succeed vs TIE DV 3, but XWLC game text is "lost if destiny + X > DV" when X=3.
-        // Must use the weapon's own result path, not HitCardEffect for every non-ion weapon.
+    public void TargetingComputerInsideCombinedAttackPresentsSeparatelyOrCombinedChoice() {
+        // Bill: Combined Attack + Targeting Computer must ask fire-twice, then Separately vs Combined.
+        // Both shots still go into the Combined Attack destiny pool either way. Pick Combined.
         var scn = GetScenario();
         var ca = scn.GetLSCard("ca");
         var xwlc = scn.GetLSCard("xwlc");
         var xwlc2 = scn.GetLSCard("xwlc2");
         var tie = scn.GetDSCard("tie");
-        setupTwoXwingLasers(scn);
+        setupTwoXwingLasersWithTcOnFirst(scn);
+        scn.MoveCardsToHand(ca);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        playCombinedAttack(scn, tie, xwlc, xwlc2);
+        chooseUseTargetingComputer(scn, true);
+        assertTrue("Expected Separately/Combined prompt inside Combined Attack, got: "
+                        + (scn.LSGetDecision() == null ? "null" : scn.LSGetDecision().getText()),
+                scn.LSDecisionAvailable("separately or combined"));
+        scn.LSChoose("Combined");
+
+        fireOneShot(scn, tie, 4, 0);
+        fireOneShot(scn, tie, 4, 0);
+        fireOneShot(scn, tie, 1, 0);
+        finishCombinedAttack(scn);
+        assertTrue(tie.isHit());
+    }
+
+    @Test
+    public void CombinedAttackXwingLaserCannonX3LosesTieNotMerelyHit() {
+        // Playtest: X-wing XWLC (X=3) + B-wing SW-4 Ion Cannon vs TIE.
+        // Combined destinies are high enough to succeed even without X, so a mere hit is the
+        // wrong result. XWLC at X=3 must LOSE the TIE (destiny + X > DV). Apply Ion Cannon
+        // first so a leftover WeaponFiringState cannot skip restoring X.
+        var scn = GetScenario();
+        var ca = scn.GetLSCard("ca");
+        var xwlc = scn.GetLSCard("xwlc");
+        var sw4 = scn.GetLSCard("sw4");
+        var tie = scn.GetDSCard("tie");
+        setupXwingLaserAndBwingIon(scn);
         scn.MoveCardsToHand(ca);
         scn.EnsureLSForcePile(6);
 
         scn.StartBattleAndSkipToWeaponsSegment();
-        playCombinedAttack(scn, tie, xwlc, xwlc2);
+        playCombinedAttack(scn, tie, xwlc, sw4);
 
+        int forceBeforeShots = scn.GetLSForcePileCount();
         fireOneShot(scn, tie, 4, 3);
+        assertEquals("XWLC Combined Attack shot must use 3 Force (X=3)",
+                forceBeforeShots - 3, scn.GetLSForcePileCount());
         assertFalse("First Combined Attack destiny must not resolve a hit or loss by itself", tie.isHit());
         assertEquals(Zone.AT_LOCATION, tie.getZone());
 
-        fireOneShot(scn, tie, 4, 0);
-        finishCombinedAttack(scn);
+        fireOneShot(scn, tie, 4);
+        finishCombinedAttack(scn, 1);
 
         assertTrue("X-wing Laser Cannon at X=3 must lose the TIE, not merely hit",
                 tie.getZone() == Zone.LOST_PILE || tie.getZone() == Zone.TOP_OF_LOST_PILE);
         assertFalse("TIE must not remain at the location as merely hit", tie.getZone() == Zone.AT_LOCATION);
     }
 
+
+    private void setupXwingLaserAndBwingIon(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var xwing = scn.GetLSCard("xwing");
+        var bwing = scn.GetLSCard("bwing");
+        var xwlc = scn.GetLSCard("xwlc");
+        var sw4 = scn.GetLSCard("sw4");
+        var tie = scn.GetDSCard("tie");
+        scn.MoveCardsToLocation(system, xwing, bwing, tie);
+        scn.AttachCardsTo(xwing, xwlc);
+        scn.AttachCardsTo(bwing, sw4);
+    }
 
     private void setupTwoXwingLasers(VirtualTableScenario scn) {
         scn.StartGame();
@@ -372,6 +419,13 @@ public class Card_1_75_Tests {
         scn.LSChoose(use ? "Yes" : "No");
     }
 
+    private void chooseSeparatelyOrCombined(VirtualTableScenario scn, String mode) {
+        assertTrue("Expected Separately/Combined prompt, got: "
+                        + (scn.LSGetDecision() == null ? "null" : scn.LSGetDecision().getText()),
+                scn.LSDecisionAvailable("separately or combined"));
+        scn.LSChoose(mode);
+    }
+
     private void fireOneShot(VirtualTableScenario scn, PhysicalCardImpl target, int destiny) {
         fireOneShot(scn, target, destiny, null);
     }
@@ -417,6 +471,10 @@ public class Card_1_75_Tests {
     }
 
     private void chooseResultApplyOrderIfPrompted(VirtualTableScenario scn) {
+        chooseResultApplyOrderIfPrompted(scn, 0);
+    }
+
+    private void chooseResultApplyOrderIfPrompted(VirtualTableScenario scn, int applyFirstChoiceIndex) {
         int safety = 0;
         while (safety++ < 8 && scn.LSGetDecision() != null && scn.LSGetDecision().getText() != null) {
             String text = scn.LSGetDecision().getText().toLowerCase();
@@ -428,12 +486,20 @@ public class Card_1_75_Tests {
             if (ids == null || ids.isEmpty()) {
                 break;
             }
-            scn.PlayerDecided("Light Side Player", ids.get(0));
+            int pick = applyFirstChoiceIndex;
+            if (pick < 0 || pick >= ids.size()) {
+                pick = ids.size() - 1;
+            }
+            scn.PlayerDecided("Light Side Player", ids.get(pick));
         }
     }
 
     private void finishCombinedAttack(VirtualTableScenario scn) {
-        chooseResultApplyOrderIfPrompted(scn);
+        finishCombinedAttack(scn, 0);
+    }
+
+    private void finishCombinedAttack(VirtualTableScenario scn, int applyFirstChoiceIndex) {
+        chooseResultApplyOrderIfPrompted(scn, applyFirstChoiceIndex);
         scn.PassResponses("PLACE_IN_CARD_PILE");
         scn.PassAllResponses();
         scn.PassResponses("ABOUT_TO_BE_LOST");

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_75_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_75_Tests.java
@@ -141,6 +141,7 @@ public class Card_1_75_Tests {
         fireOneShot(scn, tie, 3, 0);
         finishCombinedAttack(scn);
         assertTrue(tie.isHit());
+        assertCombinedAttackStateCleared(scn);
     }
 
     @Test
@@ -510,6 +511,7 @@ public class Card_1_75_Tests {
         String log = gameLog(scn);
         assertTrue("Combined Attack adds firing subtotals 3 + 3 + 5 = 11. LOG:\n" + log, log.contains("3 + 3 + 5 = 11"));
         assertFalse("Do not subtract Heavy Turbolaser Battery -1 again at Combined Attack resolve", log.contains("11-1="));
+        assertCombinedAttackStateCleared(scn);
     }
 
     private void setupXwingLaserAndBwingIon(VirtualTableScenario scn) {
@@ -718,6 +720,19 @@ public class Card_1_75_Tests {
             }
             scn.PlayerDecided("Light Side Player", ids.get(pick));
         }
+    }
+
+    /**
+     * After Combined Attack finishes, Combined Attack and Targeting Computer firing states must be empty
+     * and taking a snapshot must not throw. Weapons-segment Pass snapshots the game; if those states are
+     * still set the game is canceled.
+     */
+    private void assertCombinedAttackStateCleared(VirtualTableScenario scn) {
+        assertTrue("Combined Attack must clear Combined Attack firing state",
+                scn.gameState().getCombinedAttackFiringState() == null);
+        assertTrue("Combined Attack must clear Targeting Computer separately-or-combined firing state",
+                scn.gameState().getSeparatelyOrCombinedFiringState() == null);
+        scn.game().takeSnapshot("after Combined Attack");
     }
 
     private void finishCombinedAttack(VirtualTableScenario scn) {

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_75_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_75_Tests.java
@@ -49,8 +49,11 @@ public class Card_1_75_Tests {
                     put("ept", "9_88");
                     put("bwing", "7_140");
                     put("bwing2", "9_66");
+                    put("bomber", "9_66");
                     put("im", "7_159");
                     put("im2", "7_159");
+                    put("missiles", "9_87");
+                    put("missiles2", "9_87");
                     put("sw4", "2_081");
                     put("htb", "9_89");
                     put("htb2", "9_89");
@@ -63,6 +66,7 @@ public class Card_1_75_Tests {
                     put("executor", "4_167");
                     put("tie", "1_304");
                     put("tie2", "1_304");
+                    put("bca", "1_235");
                 }},
                 40,
                 10,
@@ -157,12 +161,11 @@ public class Card_1_75_Tests {
     @Test
     public void CombinedAttackExample2EptAndTwoIntruderMissilesHitsStalkerNotExecutor() {
         /**
-         * Google Doc / Rulebook Example 2 under the subtotal-add model:
-         * LS Combined Attack combining Enhanced Proton Torpedoes + 2 Intruder Missiles.
-         * Draws prepared as 1, 1, 1. Each firing is a complete total: Enhanced Proton
-         * Torpedoes 1+1=2; each Intruder Missile +3. One B-wing pilot adds +1 to a draw,
-         * so the addends are 2 + 5 + 4 = 11. That shared 11 is applied for each weapon
-         * (do not add +1 or +3 again). Stalker armor 7: hit. Executor armor 12: miss.
+         * Gergall 2015 Example 2 / option A: Combined Attack (1_75) combining
+         * Enhanced Proton Torpedoes (9_88) + 2 Intruder Missiles (7_159).
+         * Draws 1, 2, 3. Draw mods stay per draw. TOTAL mods apply once to the grand total:
+         * Enhanced Proton Torpedoes +1 vs capital once, Intruder Missile +3 once (same title,
+         * not +6). Total 1+2+3+1+3=10. Stalker armor 7: hit. Do not add +1 or +3 again at resolve.
          */
         var scn = GetScenario();
         var ca = scn.GetLSCard("ca");
@@ -180,16 +183,18 @@ public class Card_1_75_Tests {
 
         fireOneShot(scn, stalker, 1);
         assertFalse(stalker.isHit());
-        fireOneShot(scn, stalker, 1);
+        fireOneShot(scn, stalker, 2);
         assertFalse(stalker.isHit());
-        fireOneShot(scn, stalker, 1);
+        fireOneShot(scn, stalker, 3);
         finishCombinedAttack(scn);
-        assertTrue("Stalker armor 7 must be hit by Combined Attack example 2 subtotals 2+5+4=11", stalker.isHit());
+        assertTrue("Stalker armor 7 must be hit by Combined Attack Gergall Example 2 total 10", stalker.isHit());
         assertEquals(7, scn.GetDefense(stalker));
         String log = gameLog(scn);
-        assertTrue("Combined Attack adds firing subtotals 2 + 5 + 4 = 11. LOG:\n" + log, log.contains("2 + 5 + 4 = 11"));
-        assertFalse("Do not apply Enhanced Proton Torpedoes +1 again at Combined Attack resolve", log.contains("11+1="));
-        assertFalse("Do not apply Intruder Missile +3 again at Combined Attack resolve", log.contains("11+3="));
+        assertTrue("Combined Attack destinies 1 + 2 + 3 = 6. LOG:\n" + log, log.contains("1 + 2 + 3 = 6"));
+        assertTrue("Grand total is 10 after Enhanced Proton Torpedoes +1 and Intruder Missile +3 once. LOG:\n" + log,
+                log.contains("Total weapon destiny 10"));
+        assertFalse("Do not apply Enhanced Proton Torpedoes +1 again at Combined Attack resolve", log.contains("10+1="));
+        assertFalse("Do not apply Intruder Missile +3 twice (same title once, not +6)", log.contains("2 + 5 + 4 = 11"));
     }
 
     @Test
@@ -209,15 +214,16 @@ public class Card_1_75_Tests {
         // Destinies prepared immediately before each draw in fireOneShot.
 
         fireOneShot(scn, executor, 1);
-        fireOneShot(scn, executor, 1);
-        fireOneShot(scn, executor, 1);
+        fireOneShot(scn, executor, 2);
+        fireOneShot(scn, executor, 3);
         finishCombinedAttack(scn);
 
-        assertFalse("Executor armor 12 must not be hit by Combined Attack subtotals 2+5+4=11", executor.isHit());
+        assertFalse("Executor armor 12 must not be hit by Combined Attack Gergall Example 2 total 10", executor.isHit());
         String log = gameLog(scn);
-        assertTrue("Combined Attack adds firing subtotals 2 + 5 + 4 = 11 vs Executor. LOG:\n" + log, log.contains("2 + 5 + 4 = 11"));
-        assertFalse("Do not apply Enhanced Proton Torpedoes +1 again at Combined Attack resolve vs Executor", log.contains("11+1="));
-        assertFalse("Do not apply Intruder Missile +3 again at Combined Attack resolve vs Executor", log.contains("11+3="));
+        assertTrue("Combined Attack destinies 1 + 2 + 3 = 6 vs Executor. LOG:\n" + log, log.contains("1 + 2 + 3 = 6"));
+        assertTrue("Grand total is 10 vs Executor. LOG:\n" + log, log.contains("Total weapon destiny 10"));
+        assertFalse("Do not apply Enhanced Proton Torpedoes +1 again at Combined Attack resolve vs Executor", log.contains("10+1="));
+        assertFalse("Do not apply Intruder Missile +3 twice vs Executor", log.contains("2 + 5 + 4 = 11"));
     }
 
     @Test
@@ -420,11 +426,11 @@ public class Card_1_75_Tests {
 
 
     @Test
-    public void CombinedAttackTwoHeavyTurbolaserBatteriesVsExecutorAppliesMinusOnePerWeapon() {
-        // Two Heavy Turbolaser Batteries vs Executor (capital, armor 12).
-        // Each firing: draw two destinies, then Heavy Turbolaser Battery -1 vs capital.
-        // Draws 4,3 then 4,3. Subtotals 7-1=6 and 7-1=6. Combined Attack adds 6 + 6 = 12.
-        // 12 is not > armor 12, miss. Skipping either firing's -1 is 13 > 12 and would hit.
+    public void CombinedAttackTwoHeavyTurbolaserBatteriesVsExecutorAppliesMinusOneOnce() {
+        // Two Heavy Turbolaser Batteries (9_89) vs Executor (capital, armor 12).
+        // Draws 4,3 then 4,3. Draw sum 7+7=14. Heavy Turbolaser Battery -1 vs capital applies
+        // ONCE to the grand total (same title), total 13 > 12 hit.
+        // Wrong subtotal-per-firing model is 6+6=12 miss.
         var scn = GetScenario();
         var ca = scn.GetLSCard("ca");
         var htb = scn.GetLSCard("htb");
@@ -439,23 +445,24 @@ public class Card_1_75_Tests {
 
         fireTwoDestinyShot(scn, executor, 4, 3);
         assertFalse("First Combined Attack Heavy Turbolaser Battery firing must not resolve a hit by itself", executor.isHit());
-        assertEquals("First firing displayed total includes Heavy Turbolaser Battery -1 (7-1=6)", 6, lastTotalWeaponDestiny(scn));
+        assertEquals("First firing displayed total is draws only (4+3=7), not Heavy Turbolaser Battery -1 yet", 7, lastTotalWeaponDestiny(scn));
         fireTwoDestinyShot(scn, executor, 4, 3);
-        assertEquals("Second firing displayed total includes Heavy Turbolaser Battery -1 (7-1=6)", 6, lastTotalWeaponDestiny(scn));
+        assertEquals("Second firing displayed total is draws only (4+3=7)", 7, lastTotalWeaponDestiny(scn));
         finishCombinedAttack(scn);
 
         assertEquals(12, scn.GetDefense(executor));
-        assertFalse("Heavy Turbolaser Battery -1 in each subtotal must make 6+6=12 miss Executor armor 12", executor.isHit());
+        assertTrue("Heavy Turbolaser Battery -1 once on 14 is 13 > Executor armor 12", executor.isHit());
         String log = gameLog(scn);
-        assertTrue("Combined Attack adds firing subtotals 6 + 6 = 12. LOG:\n" + log, log.contains("6 + 6 = 12"));
-        assertFalse("Do not subtract Heavy Turbolaser Battery -1 again at Combined Attack resolve", log.contains("12-1="));
+        assertTrue("Combined Attack destinies 7 + 7 = 14. LOG:\n" + log, log.contains("7 + 7 = 14"));
+        assertTrue("Grand total 13 after Heavy Turbolaser Battery -1 once. LOG:\n" + log, log.contains("Total weapon destiny 13"));
+        assertFalse("Do not subtract Heavy Turbolaser Battery -1 per firing (6 + 6 = 12)", log.contains("6 + 6 = 12"));
     }
 
     @Test
-    public void CombinedAttackTwoHeavyTurbolaserBatteriesVsTieAppliesMinusSix() {
-        // Same two Heavy Turbolaser Batteries vs a TIE (not capital). Heavy Turbolaser Battery -6 per firing.
-        // Draws 2,2 then 2,2. Subtotals max(0, 4-6)=0 and 0. Combined Attack adds 0 + 0 = 0, miss vs maneuver 3.
-        // Skipping -6 on either firing is 4 > 3 and would hit.
+    public void CombinedAttackTwoHeavyTurbolaserBatteriesVsTieAppliesMinusSixOnce() {
+        // Same two Heavy Turbolaser Batteries (9_89) vs a TIE (not capital). Heavy Turbolaser Battery -6
+        // once on the grand total. Draws 4,3 then 4,3: 7+7=14, minus 6 once = 8 > maneuver 3 hit.
+        // Wrong subtotal-per-firing model is (7-6)+(7-6)=2 miss.
         var scn = GetScenario();
         var ca = scn.GetLSCard("ca");
         var htb = scn.GetLSCard("htb");
@@ -468,30 +475,29 @@ public class Card_1_75_Tests {
         scn.StartBattleAndSkipToWeaponsSegment();
         playCombinedAttack(scn, tie, htb, htb2);
 
-        fireTwoDestinyShot(scn, tie, 2, 2);
+        fireTwoDestinyShot(scn, tie, 4, 3);
         assertFalse("First Combined Attack Heavy Turbolaser Battery firing must not resolve a hit by itself", tie.isHit());
-        assertEquals("First firing displayed total includes Heavy Turbolaser Battery -6 (4-6 clamped to 0)", 0, lastTotalWeaponDestiny(scn));
-        fireTwoDestinyShot(scn, tie, 2, 2);
-        assertEquals("Second firing displayed total includes Heavy Turbolaser Battery -6 (clamped to 0)", 0, lastTotalWeaponDestiny(scn));
+        assertEquals("First firing displayed total is draws only (4+3=7), not Heavy Turbolaser Battery -6 yet", 7, lastTotalWeaponDestiny(scn));
+        fireTwoDestinyShot(scn, tie, 4, 3);
+        assertEquals("Second firing displayed total is draws only (4+3=7)", 7, lastTotalWeaponDestiny(scn));
         finishCombinedAttack(scn);
 
         assertEquals(3, scn.GetDefense(tie));
-        assertFalse("Heavy Turbolaser Battery -6 in each subtotal must make 0+0=0 miss TIE maneuver 3", tie.isHit());
+        assertTrue("Heavy Turbolaser Battery -6 once on 14 is 8 > TIE maneuver 3", tie.isHit());
         String log = gameLog(scn);
-        assertTrue("Combined Attack adds firing subtotals 0 + 0 = 0. LOG:\n" + log, log.contains("0 + 0 = 0"));
-        assertFalse("Do not subtract Heavy Turbolaser Battery -6 again at Combined Attack resolve", log.contains("0-6="));
+        assertTrue("Combined Attack destinies 7 + 7 = 14. LOG:\n" + log, log.contains("7 + 7 = 14"));
+        assertTrue("Grand total 8 after Heavy Turbolaser Battery -6 once. LOG:\n" + log, log.contains("Total weapon destiny 8"));
+        assertFalse("Do not subtract Heavy Turbolaser Battery -6 per firing", log.contains("0 + 0 = 0"));
     }
 
     @Test
     public void CombinedAttackDefianceTargetingComputerHeavyTurbolaserEachDrawAndTotalOnce() {
-        // Defiance +2 each draw, Targeting Computer -1 each draw while fire-twice,
-        // Heavy Turbolaser Battery -1 per firing vs Executor (Targeting Computer twice subtracts twice).
+        // Defiance (9_67) +2 each draw, Targeting Computer (1_39) -1 each draw while fire-twice,
+        // Heavy Turbolaser Battery (9_89) -1 once on the Combined Attack grand total vs Executor.
         // Printed 1,1 then 1,1 (Targeting Computer) then 1,1 (second battery).
-        // Targeting Computer firing 1: (1+2-1)+(1+2-1)=4, then -1 = 3.
-        // Targeting Computer firing 2: same subtotal 3 (must subtract again).
-        // Second Heavy Turbolaser Battery: (1+2)+(1+2)=6, then -1 = 5.
-        // Combined Attack adds 3 + 3 + 5 = 11, miss vs armor 12.
-        // Skipping both Targeting Computer firing subtracts is 4+4+5=13 and would hit.
+        // Draws: (1+2-1)+(1+2-1)=4 and 4, then (1+2)+(1+2)=6. Draw sum 4+4+6=14.
+        // Heavy Turbolaser Battery -1 once (same title, including Targeting Computer twice on one copy): 13 > 12 hit.
+        // Wrong subtotal-per-firing model is 3+3+5=11 miss.
         var scn = GetScenario();
         var ca = scn.GetLSCard("ca");
         var htb = scn.GetLSCard("htb");
@@ -507,20 +513,21 @@ public class Card_1_75_Tests {
 
         fireTwoDestinyShot(scn, executor, 1, 1);
         assertFalse("First Targeting Computer Combined Attack firing must not resolve a hit by itself", executor.isHit());
-        assertEquals("First Targeting Computer firing subtotal includes Heavy Turbolaser Battery -1 (4-1=3)", 3, lastTotalWeaponDestiny(scn));
+        assertEquals("First Targeting Computer firing is draws only (4), not Heavy Turbolaser Battery -1 yet", 4, lastTotalWeaponDestiny(scn));
         fireTwoDestinyShot(scn, executor, 1, 1);
         assertFalse("Second Targeting Computer Combined Attack firing must not resolve a hit by itself", executor.isHit());
-        assertEquals("Second Targeting Computer firing must subtract Heavy Turbolaser Battery -1 again (4-1=3)", 3, lastTotalWeaponDestiny(scn));
+        assertEquals("Second Targeting Computer firing is draws only (4); total -1 is not per firing", 4, lastTotalWeaponDestiny(scn));
         fireTwoDestinyShot(scn, executor, 1, 1);
-        assertEquals("Second Heavy Turbolaser Battery firing includes -1 (6-1=5). LOG:\n" + gameLog(scn), 5, lastTotalWeaponDestiny(scn));
+        assertEquals("Second Heavy Turbolaser Battery firing is draws only (6). LOG:\n" + gameLog(scn), 6, lastTotalWeaponDestiny(scn));
         finishCombinedAttack(scn);
 
         assertWeaponDestinyDrawValues(scn, 2, 2, 2, 2, 3, 3);
         assertEquals(12, scn.GetDefense(executor));
-        assertFalse("Targeting Computer twice must subtract Heavy Turbolaser Battery -1 twice so 3+3+5=11 misses Executor", executor.isHit());
+        assertTrue("Targeting Computer twice still applies Heavy Turbolaser Battery -1 once: 14-1=13 hits Executor", executor.isHit());
         String log = gameLog(scn);
-        assertTrue("Combined Attack adds firing subtotals 3 + 3 + 5 = 11. LOG:\n" + log, log.contains("3 + 3 + 5 = 11"));
-        assertFalse("Do not subtract Heavy Turbolaser Battery -1 again at Combined Attack resolve", log.contains("11-1="));
+        assertTrue("Combined Attack destinies 4 + 4 + 6 = 14. LOG:\n" + log, log.contains("4 + 4 + 6 = 14"));
+        assertTrue("Grand total 13 after Heavy Turbolaser Battery -1 once. LOG:\n" + log, log.contains("Total weapon destiny 13"));
+        assertFalse("Do not subtract Heavy Turbolaser Battery -1 per Targeting Computer firing (3 + 3 + 5 = 11)", log.contains("3 + 3 + 5 = 11"));
         assertCombinedAttackStateCleared(scn);
     }
 
@@ -749,6 +756,165 @@ public class Card_1_75_Tests {
                 fireTwiceAvailable(scn, tc));
     }
 
+    @Test
+    public void CombinedAttackTwoConcussionMissilesAddsPlusOneOnceVsStarfighter() {
+        // Two Concussion Missiles (9_87) vs a TIE (starfighter, maneuver 3).
+        // Draws 1 and 1. Draw sum 2. Concussion Missiles +1 if targeting a starfighter
+        // applies ONCE to the grand total (same title): 3 is not > 3, miss.
+        // Wrong subtotal-per-firing model is (1+1)+(1+1)=4 > 3 hit.
+        var scn = GetScenario();
+        var ca = scn.GetLSCard("ca");
+        var missiles = scn.GetLSCard("missiles");
+        var missiles2 = scn.GetLSCard("missiles2");
+        var tie = scn.GetDSCard("tie");
+        setupTwoConcussionMissiles(scn);
+        scn.MoveCardsToHand(ca);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        playCombinedAttack(scn, tie, missiles, missiles2);
+
+        fireOneShot(scn, tie, 1);
+        assertFalse("First Combined Attack Concussion Missiles firing must not resolve a hit by itself", tie.isHit());
+        fireOneShot(scn, tie, 1);
+        finishCombinedAttack(scn);
+
+        assertEquals(3, scn.GetDefense(tie));
+        assertFalse("Concussion Missiles +1 once on 2 is 3, not > TIE maneuver 3", tie.isHit());
+        String log = gameLog(scn);
+        assertTrue("Combined Attack destinies 1 + 1 = 2. LOG:\n" + log, log.contains("1 + 1 = 2"));
+        assertTrue("Grand total 3 after Concussion Missiles +1 once. LOG:\n" + log, log.contains("Total weapon destiny 3"));
+        assertFalse("Do not add Concussion Missiles +1 per copy (that would be 4)", log.contains("1 + 1 = 2") && log.contains("Total weapon destiny 4"));
+    }
+
+    @Test
+    public void BoringConversationAnywayCancelsCombinedAttackBeforeWeaponsFire() {
+        // Sense (1_267) / Boring Conversation Anyway (1_235) cancel Combined Attack (1_75)
+        // before any weapon fires. Weapons may still fire normally afterward.
+        // This test uses Boring Conversation Anyway because it names Combined Attack and
+        // does not need a Sense destiny draw against a highest-ability character.
+        var scn = GetScenario();
+        var ca = scn.GetLSCard("ca");
+        var bca = scn.GetDSCard("bca");
+        var xwlc = scn.GetLSCard("xwlc");
+        var xwlc2 = scn.GetLSCard("xwlc2");
+        var tie = scn.GetDSCard("tie");
+        setupTwoXwingLasers(scn);
+        scn.MoveCardsToHand(ca);
+        scn.MoveCardsToHand(bca);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        if (scn.LSCardPlayAvailable(ca)) {
+            scn.LSPlayCard(ca);
+        }
+        else {
+            scn.LSUseCardAction(ca);
+        }
+        if (scn.LSHasCardChoiceAvailable(tie)) {
+            scn.LSChooseCard(tie);
+        }
+        if (scn.LSGetDecision() != null) {
+            scn.LSChooseCards(xwlc, xwlc2);
+        }
+
+        // Light Side must pass Combined Attack optional responses so Dark Side can cancel.
+        // Do not use PassResponses here: that helper passes the last actor, and after Dark Side
+        // plays Boring Conversation Anyway it will not pass Light Side's leftover Combined Attack window.
+        int lsPass = 0;
+        while (lsPass++ < 8 && scn.LSDecisionAvailable("Combined Attack") && scn.LSDecisionAvailable("Optional")) {
+            scn.LSPass();
+        }
+        assertTrue("Boring Conversation Anyway must be able to cancel Combined Attack before weapons fire. "
+                        + decisionDump(scn),
+                scn.DSCardActionAvailable(bca) || scn.DSPlayUsedInterruptAvailable(bca)
+                        || scn.DSActionAvailable("Combined Attack")
+                        || scn.DSActionAvailable("Boring Conversation Anyway"));
+        if (scn.DSPlayUsedInterruptAvailable(bca)) {
+            scn.DSPlayCard(bca);
+        }
+        else if (scn.DSCardActionAvailable(bca)) {
+            scn.DSUseCardAction(bca);
+        }
+        else if (scn.DSActionAvailable("Combined Attack")) {
+            scn.DSChooseAction("Combined Attack");
+        }
+        else {
+            scn.DSChooseAction("Boring Conversation Anyway");
+        }
+        int afterCancel = 0;
+        while (afterCancel++ < 12) {
+            if (scn.AwaitingLSWeaponsSegmentActions()) {
+                break;
+            }
+            if (scn.AwaitingDSWeaponsSegmentActions()) {
+                scn.DSPass();
+                continue;
+            }
+            if (scn.DSDecisionAvailable("Playing") || scn.DSDecisionAvailable("Optional")
+                    || scn.DSDecisionAvailable("PUT_IN_CARD_PILE") || scn.DSDecisionAvailable("PLACE_IN_CARD_PILE")) {
+                scn.DSPass();
+                continue;
+            }
+            if (scn.LSDecisionAvailable("Playing") || scn.LSDecisionAvailable("Optional")
+                    || scn.LSDecisionAvailable("PUT_IN_CARD_PILE") || scn.LSDecisionAvailable("PLACE_IN_CARD_PILE")) {
+                scn.LSPass();
+                continue;
+            }
+            break;
+        }
+
+        assertFalse("Canceled Combined Attack must not hit the TIE", tie.isHit());
+        assertTrue("After Boring Conversation Anyway cancels Combined Attack, Light Side should still be in weapons segment. "
+                        + decisionDump(scn),
+                scn.AwaitingLSWeaponsSegmentActions());
+        assertTrue("X-wing Laser Cannon must still be fireable after Combined Attack is canceled. " + decisionDump(scn),
+                scn.LSCardActionAvailable(xwlc));
+        assertCombinedAttackStateCleared(scn);
+    }
+
+    @Test
+    public void CombinedAttackCannotChooseAlreadyFiredWeapon() {
+        // Already-fired weapons cannot be chosen for Combined Attack (1_75).
+        // Fire one X-wing Laser Cannon (7_162) first; Combined Attack still needs two remaining
+        // legal starship weapons and must not list the already-fired cannon.
+        var scn = GetScenario();
+        var ca = scn.GetLSCard("ca");
+        var xwlc = scn.GetLSCard("xwlc");
+        var xwlc2 = scn.GetLSCard("xwlc2");
+        var sw4 = scn.GetLSCard("sw4");
+        var tie = scn.GetDSCard("tie");
+        setupTwoXwingLasersAndBwingIon(scn);
+        scn.MoveCardsToHand(ca);
+        scn.EnsureLSForcePile(8);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        assertTrue(scn.LSCardActionAvailable(xwlc, "Fire"));
+        scn.LSUseCardAction(xwlc, "Fire");
+        fireOneShot(scn, tie, 1, 0);
+        scn.PassAllResponses();
+        passDarkSideWeaponsIfNeeded(scn);
+
+        assertTrue("Combined Attack remains playable with two leftover weapons. " + decisionDump(scn),
+                scn.LSCardPlayAvailable(ca) || scn.LSCardActionAvailable(ca));
+        if (scn.LSCardPlayAvailable(ca)) {
+            scn.LSPlayCard(ca);
+        }
+        else {
+            scn.LSUseCardAction(ca);
+        }
+        if (scn.LSHasCardChoiceAvailable(tie)) {
+            scn.LSChooseCard(tie);
+        }
+        assertFalse("Already-fired X-wing Laser Cannon cannot be chosen for Combined Attack. " + decisionDump(scn),
+                scn.LSHasCardChoiceAvailable(xwlc));
+        assertTrue("Unused X-wing Laser Cannon remains choosable", scn.LSHasCardChoiceAvailable(xwlc2));
+        assertTrue("Unused SW-4 Ion Cannon remains choosable", scn.LSHasCardChoiceAvailable(sw4));
+        scn.LSChooseCards(xwlc2, sw4);
+        scn.PassCardPlayResponses();
+        fireOneShot(scn, tie, 4, 0);
+        fireOneShot(scn, tie, 4);
+        finishCombinedAttack(scn, 1);
+    }
+
     private void setupXwingLaserAndBwingIon(VirtualTableScenario scn) {
         scn.StartGame();
         var system = scn.GetLSStartingLocation();
@@ -759,6 +925,25 @@ public class Card_1_75_Tests {
         var tie = scn.GetDSCard("tie");
         scn.MoveCardsToLocation(system, xwing, bwing, tie);
         scn.AttachCardsTo(xwing, xwlc);
+        scn.AttachCardsTo(bwing, sw4);
+    }
+
+    /**
+     * Two X-wing Laser Cannons and a B-wing SW-4 Ion Cannon vs a TIE, for the already-fired Combined Attack test.
+     */
+    private void setupTwoXwingLasersAndBwingIon(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var xwing = scn.GetLSCard("xwing");
+        var xwing2 = scn.GetLSCard("xwing2");
+        var bwing = scn.GetLSCard("bwing");
+        var xwlc = scn.GetLSCard("xwlc");
+        var xwlc2 = scn.GetLSCard("xwlc2");
+        var sw4 = scn.GetLSCard("sw4");
+        var tie = scn.GetDSCard("tie");
+        scn.MoveCardsToLocation(system, xwing, xwing2, bwing, tie);
+        scn.AttachCardsTo(xwing, xwlc);
+        scn.AttachCardsTo(xwing2, xwlc2);
         scn.AttachCardsTo(bwing, sw4);
     }
 
@@ -824,21 +1009,53 @@ public class Card_1_75_Tests {
         scn.StartGame();
         var system = scn.GetLSStartingLocation();
         var ywing = scn.GetLSCard("ywing");
-        var bwing = scn.GetLSCard("bwing");
+        var bomber = scn.GetLSCard("bomber");
         var bwing2 = scn.GetLSCard("bwing2");
         var ept = scn.GetLSCard("ept");
         var im = scn.GetLSCard("im");
         var im2 = scn.GetLSCard("im2");
         var target = vsExecutor ? scn.GetDSCard("executor") : scn.GetDSCard("stalker");
-        scn.MoveCardsToLocation(system, ywing, bwing, bwing2, target);
-        scn.BoardAsPilot(bwing, scn.GetLSCard("pilot"));
-        scn.BoardAsPilot(bwing2, scn.GetLSCard("pilot2"));
+        scn.MoveCardsToLocation(system, ywing, bomber, bwing2, target);
         scn.AttachCardsTo(ywing, ept);
-        scn.AttachCardsTo(bwing, im);
+        scn.AttachCardsTo(bomber, im);
         scn.AttachCardsTo(bwing2, im2);
     }
 
+    /**
+     * Two B-wing Bombers with Concussion Missiles vs a TIE.
+     */
+    private void setupTwoConcussionMissiles(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var bomber = scn.GetLSCard("bomber");
+        var bwing2 = scn.GetLSCard("bwing2");
+        var missiles = scn.GetLSCard("missiles");
+        var missiles2 = scn.GetLSCard("missiles2");
+        var tie = scn.GetDSCard("tie");
+        scn.MoveCardsToLocation(system, bomber, bwing2, tie);
+        scn.AttachCardsTo(bomber, missiles);
+        scn.AttachCardsTo(bwing2, missiles2);
+    }
+
+    /**
+     * Pass Light Side optional responses so Dark Side can cancel Combined Attack.
+     */
+    private void passLightSideOptionalResponses(VirtualTableScenario scn) {
+        int safety = 0;
+        while (safety++ < 6 && scn.LSGetDecision() != null && scn.LSGetDecision().getText() != null) {
+            String text = scn.LSGetDecision().getText().toLowerCase();
+            if (!(text.contains("optional") || text.contains("playing"))) {
+                break;
+            }
+            if (scn.DSGetDecision() != null && scn.DSCardActionAvailable(scn.GetDSCard("bca"))) {
+                break;
+            }
+            scn.LSPass();
+        }
+    }
+
     private void playCombinedAttack(VirtualTableScenario scn, PhysicalCardImpl target, PhysicalCardImpl... weapons) {
+
         var ca = scn.GetLSCard("ca");
         if (scn.LSCardPlayAvailable(ca)) {
             scn.LSPlayCard(ca);

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_75_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_75_Tests.java
@@ -13,6 +13,8 @@ import com.gempukku.swccgo.game.PhysicalCardImpl;
 import org.junit.Test;
 
 import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -40,6 +42,10 @@ public class Card_1_75_Tests {
                     put("im", "7_159");
                     put("im2", "7_159");
                     put("sw4", "2_081");
+                    put("htb", "9_89");
+                    put("htb2", "9_89");
+                    put("homeone", "9_74");
+                    put("defiance", "9_67");
                 }},
                 new HashMap<>()
                 {{
@@ -140,14 +146,12 @@ public class Card_1_75_Tests {
     @Test
     public void CombinedAttackExample2EptAndTwoIntruderMissilesHitsStalkerNotExecutor() {
         /**
-         * Google Doc / Rulebook Example 2 (fleshed out):
+         * Google Doc / Rulebook Example 2 under the subtotal-add model:
          * LS Combined Attack combining Enhanced Proton Torpedoes + 2 Intruder Missiles.
-         * Draws 1, 2, 3. Draw-sum 6.
-         * Total modifiers: +1 from Torpedoes (vs capital) and +3 from ONE Intruder Missile
-         * (not +6 from two; cumulative / per-weapon).
-         * Per-weapon AR: EPT 6+1=7 vs Stalker armor 7 miss; IM 6+3=9 vs 7 hit.
-         * Executor armor 12: 7 and 9 both miss.
-         * Grand-total teaching number 1+2+3+1+3=10 also hits Stalker and misses Executor.
+         * Draws prepared as 1, 1, 1. Each firing is a complete total: Enhanced Proton
+         * Torpedoes 1+1=2; each Intruder Missile +3. One B-wing pilot adds +1 to a draw,
+         * so the addends are 2 + 5 + 4 = 11. That shared 11 is applied for each weapon
+         * (do not add +1 or +3 again). Stalker armor 7: hit. Executor armor 12: miss.
          */
         var scn = GetScenario();
         var ca = scn.GetLSCard("ca");
@@ -157,19 +161,24 @@ public class Card_1_75_Tests {
         var stalker = scn.GetDSCard("stalker");
         setupEptAndTwoIntruderMissiles(scn, false);
         scn.MoveCardsToHand(ca);
+        scn.EnsureLSForcePile(8);
 
         scn.StartBattleAndSkipToWeaponsSegment();
         playCombinedAttack(scn, stalker, ept, im, im2);
-        stackCombinedAttackDestinies(scn, 1, 2, 3);
+        // Destinies prepared immediately before each draw in fireOneShot.
 
         fireOneShot(scn, stalker, 1);
         assertFalse(stalker.isHit());
-        fireOneShot(scn, stalker, 2);
+        fireOneShot(scn, stalker, 1);
         assertFalse(stalker.isHit());
-        fireOneShot(scn, stalker, 3);
+        fireOneShot(scn, stalker, 1);
         finishCombinedAttack(scn);
-        assertTrue("Stalker armor 7 must be hit by Combined Attack example 2", stalker.isHit());
+        assertTrue("Stalker armor 7 must be hit by Combined Attack example 2 subtotals 2+5+4=11", stalker.isHit());
         assertEquals(7, scn.GetDefense(stalker));
+        String log = gameLog(scn);
+        assertTrue("Combined Attack adds firing subtotals 2 + 5 + 4 = 11. LOG:\n" + log, log.contains("2 + 5 + 4 = 11"));
+        assertFalse("Do not apply Enhanced Proton Torpedoes +1 again at Combined Attack resolve", log.contains("11+1="));
+        assertFalse("Do not apply Intruder Missile +3 again at Combined Attack resolve", log.contains("11+3="));
     }
 
     @Test
@@ -182,17 +191,22 @@ public class Card_1_75_Tests {
         var executor = scn.GetDSCard("executor");
         setupEptAndTwoIntruderMissiles(scn, true);
         scn.MoveCardsToHand(ca);
+        scn.EnsureLSForcePile(8);
 
         scn.StartBattleAndSkipToWeaponsSegment();
         playCombinedAttack(scn, executor, ept, im, im2);
-        stackCombinedAttackDestinies(scn, 1, 2, 3);
+        // Destinies prepared immediately before each draw in fireOneShot.
 
         fireOneShot(scn, executor, 1);
-        fireOneShot(scn, executor, 2);
-        fireOneShot(scn, executor, 3);
+        fireOneShot(scn, executor, 1);
+        fireOneShot(scn, executor, 1);
         finishCombinedAttack(scn);
 
-        assertFalse("Executor armor 12 must not be hit by destinies 1+2+3 plus EPT/IM totals", executor.isHit());
+        assertFalse("Executor armor 12 must not be hit by Combined Attack subtotals 2+5+4=11", executor.isHit());
+        String log = gameLog(scn);
+        assertTrue("Combined Attack adds firing subtotals 2 + 5 + 4 = 11 vs Executor. LOG:\n" + log, log.contains("2 + 5 + 4 = 11"));
+        assertFalse("Do not apply Enhanced Proton Torpedoes +1 again at Combined Attack resolve vs Executor", log.contains("11+1="));
+        assertFalse("Do not apply Intruder Missile +3 again at Combined Attack resolve vs Executor", log.contains("11+3="));
     }
 
     @Test
@@ -394,6 +408,110 @@ public class Card_1_75_Tests {
     }
 
 
+    @Test
+    public void CombinedAttackTwoHeavyTurbolaserBatteriesVsExecutorAppliesMinusOnePerWeapon() {
+        // Two Heavy Turbolaser Batteries vs Executor (capital, armor 12).
+        // Each firing: draw two destinies, then Heavy Turbolaser Battery -1 vs capital.
+        // Draws 4,3 then 4,3. Subtotals 7-1=6 and 7-1=6. Combined Attack adds 6 + 6 = 12.
+        // 12 is not > armor 12, miss. Skipping either firing's -1 is 13 > 12 and would hit.
+        var scn = GetScenario();
+        var ca = scn.GetLSCard("ca");
+        var htb = scn.GetLSCard("htb");
+        var htb2 = scn.GetLSCard("htb2");
+        var executor = scn.GetDSCard("executor");
+        setupTwoHeavyTurbolaserBatteriesOnHomeOne(scn, true);
+        scn.MoveCardsToHand(ca);
+        scn.EnsureLSForcePile(6);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        playCombinedAttack(scn, executor, htb, htb2);
+
+        fireTwoDestinyShot(scn, executor, 4, 3);
+        assertFalse("First Combined Attack Heavy Turbolaser Battery firing must not resolve a hit by itself", executor.isHit());
+        assertEquals("First firing displayed total includes Heavy Turbolaser Battery -1 (7-1=6)", 6, lastTotalWeaponDestiny(scn));
+        fireTwoDestinyShot(scn, executor, 4, 3);
+        assertEquals("Second firing displayed total includes Heavy Turbolaser Battery -1 (7-1=6)", 6, lastTotalWeaponDestiny(scn));
+        finishCombinedAttack(scn);
+
+        assertEquals(12, scn.GetDefense(executor));
+        assertFalse("Heavy Turbolaser Battery -1 in each subtotal must make 6+6=12 miss Executor armor 12", executor.isHit());
+        String log = gameLog(scn);
+        assertTrue("Combined Attack adds firing subtotals 6 + 6 = 12. LOG:\n" + log, log.contains("6 + 6 = 12"));
+        assertFalse("Do not subtract Heavy Turbolaser Battery -1 again at Combined Attack resolve", log.contains("12-1="));
+    }
+
+    @Test
+    public void CombinedAttackTwoHeavyTurbolaserBatteriesVsTieAppliesMinusSix() {
+        // Same two Heavy Turbolaser Batteries vs a TIE (not capital). Heavy Turbolaser Battery -6 per firing.
+        // Draws 2,2 then 2,2. Subtotals max(0, 4-6)=0 and 0. Combined Attack adds 0 + 0 = 0, miss vs maneuver 3.
+        // Skipping -6 on either firing is 4 > 3 and would hit.
+        var scn = GetScenario();
+        var ca = scn.GetLSCard("ca");
+        var htb = scn.GetLSCard("htb");
+        var htb2 = scn.GetLSCard("htb2");
+        var tie = scn.GetDSCard("tie");
+        setupTwoHeavyTurbolaserBatteriesOnHomeOne(scn, false);
+        scn.MoveCardsToHand(ca);
+        scn.EnsureLSForcePile(6);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        playCombinedAttack(scn, tie, htb, htb2);
+
+        fireTwoDestinyShot(scn, tie, 2, 2);
+        assertFalse("First Combined Attack Heavy Turbolaser Battery firing must not resolve a hit by itself", tie.isHit());
+        assertEquals("First firing displayed total includes Heavy Turbolaser Battery -6 (4-6 clamped to 0)", 0, lastTotalWeaponDestiny(scn));
+        fireTwoDestinyShot(scn, tie, 2, 2);
+        assertEquals("Second firing displayed total includes Heavy Turbolaser Battery -6 (clamped to 0)", 0, lastTotalWeaponDestiny(scn));
+        finishCombinedAttack(scn);
+
+        assertEquals(3, scn.GetDefense(tie));
+        assertFalse("Heavy Turbolaser Battery -6 in each subtotal must make 0+0=0 miss TIE maneuver 3", tie.isHit());
+        String log = gameLog(scn);
+        assertTrue("Combined Attack adds firing subtotals 0 + 0 = 0. LOG:\n" + log, log.contains("0 + 0 = 0"));
+        assertFalse("Do not subtract Heavy Turbolaser Battery -6 again at Combined Attack resolve", log.contains("0-6="));
+    }
+
+    @Test
+    public void CombinedAttackDefianceTargetingComputerHeavyTurbolaserEachDrawAndTotalOnce() {
+        // Defiance +2 each draw, Targeting Computer -1 each draw while fire-twice,
+        // Heavy Turbolaser Battery -1 per firing vs Executor (Targeting Computer twice subtracts twice).
+        // Printed 1,1 then 1,1 (Targeting Computer) then 1,1 (second battery).
+        // Targeting Computer firing 1: (1+2-1)+(1+2-1)=4, then -1 = 3.
+        // Targeting Computer firing 2: same subtotal 3 (must subtract again).
+        // Second Heavy Turbolaser Battery: (1+2)+(1+2)=6, then -1 = 5.
+        // Combined Attack adds 3 + 3 + 5 = 11, miss vs armor 12.
+        // Skipping both Targeting Computer firing subtracts is 4+4+5=13 and would hit.
+        var scn = GetScenario();
+        var ca = scn.GetLSCard("ca");
+        var htb = scn.GetLSCard("htb");
+        var htb2 = scn.GetLSCard("htb2");
+        var executor = scn.GetDSCard("executor");
+        setupTwoHeavyTurbolaserBatteriesOnDefianceWithTargetingComputer(scn);
+        scn.MoveCardsToHand(ca);
+        scn.EnsureLSForcePile(8);
+
+        scn.StartBattleAndSkipToWeaponsSegment();
+        playCombinedAttack(scn, executor, htb, htb2);
+        chooseWhetherToUseTargetingComputer(scn, htb, true);
+
+        fireTwoDestinyShot(scn, executor, 1, 1);
+        assertFalse("First Targeting Computer Combined Attack firing must not resolve a hit by itself", executor.isHit());
+        assertEquals("First Targeting Computer firing subtotal includes Heavy Turbolaser Battery -1 (4-1=3)", 3, lastTotalWeaponDestiny(scn));
+        fireTwoDestinyShot(scn, executor, 1, 1);
+        assertFalse("Second Targeting Computer Combined Attack firing must not resolve a hit by itself", executor.isHit());
+        assertEquals("Second Targeting Computer firing must subtract Heavy Turbolaser Battery -1 again (4-1=3)", 3, lastTotalWeaponDestiny(scn));
+        fireTwoDestinyShot(scn, executor, 1, 1);
+        assertEquals("Second Heavy Turbolaser Battery firing includes -1 (6-1=5). LOG:\n" + gameLog(scn), 5, lastTotalWeaponDestiny(scn));
+        finishCombinedAttack(scn);
+
+        assertWeaponDestinyDrawValues(scn, 2, 2, 2, 2, 3, 3);
+        assertEquals(12, scn.GetDefense(executor));
+        assertFalse("Targeting Computer twice must subtract Heavy Turbolaser Battery -1 twice so 3+3+5=11 misses Executor", executor.isHit());
+        String log = gameLog(scn);
+        assertTrue("Combined Attack adds firing subtotals 3 + 3 + 5 = 11. LOG:\n" + log, log.contains("3 + 3 + 5 = 11"));
+        assertFalse("Do not subtract Heavy Turbolaser Battery -1 again at Combined Attack resolve", log.contains("11-1="));
+    }
+
     private void setupXwingLaserAndBwingIon(VirtualTableScenario scn) {
         scn.StartGame();
         var system = scn.GetLSStartingLocation();
@@ -497,7 +615,7 @@ public class Card_1_75_Tests {
         if (weapons.length > 0 && scn.LSGetDecision() != null) {
             scn.LSChooseCards(weapons);
         }
-        scn.PassAllResponses();
+        scn.PassCardPlayResponses();
     }
 
     /**
@@ -621,4 +739,93 @@ public class Card_1_75_Tests {
         scn.PassResponses("ABOUT_TO_BE_LOST");
         scn.PassAllResponses();
     }
+    /**
+     * Two Heavy Turbolaser Batteries on Home One vs Executor (capital) or a TIE (not capital).
+     */
+    private void setupTwoHeavyTurbolaserBatteriesOnHomeOne(VirtualTableScenario scn, boolean vsExecutor) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var homeone = scn.GetLSCard("homeone");
+        var htb = scn.GetLSCard("htb");
+        var htb2 = scn.GetLSCard("htb2");
+        var target = vsExecutor ? scn.GetDSCard("executor") : scn.GetDSCard("tie");
+        scn.MoveCardsToLocation(system, homeone, target);
+        scn.AttachCardsTo(homeone, htb, htb2);
+    }
+
+    /**
+     * Two Heavy Turbolaser Batteries and a Targeting Computer on Defiance vs Executor.
+     */
+    private void setupTwoHeavyTurbolaserBatteriesOnDefianceWithTargetingComputer(VirtualTableScenario scn) {
+        scn.StartGame();
+        var system = scn.GetLSStartingLocation();
+        var defiance = scn.GetLSCard("defiance");
+        var htb = scn.GetLSCard("htb");
+        var htb2 = scn.GetLSCard("htb2");
+        var tc = scn.GetLSCard("tc");
+        var executor = scn.GetDSCard("executor");
+        scn.MoveCardsToLocation(system, defiance, executor);
+        scn.AttachCardsTo(defiance, htb, htb2, tc);
+    }
+
+    /**
+     * Fire a Combined Attack weapon that draws two destinies (Heavy Turbolaser Battery).
+     * Prepare each draw immediately before it so the same destiny value can be reused.
+     */
+    private void fireTwoDestinyShot(VirtualTableScenario scn, PhysicalCardImpl target, int destiny1, int destiny2) {
+        if (scn.LSGetDecision() != null && scn.LSDecisionAvailable("Targeting Computer") && scn.LSDecisionAvailable("Done")) {
+            // Second Combined Attack weapon on the same starship: skip leftover Targeting Computer.
+            scn.LSDecided("");
+        }
+        if (scn.LSGetDecision() != null && scn.LSHasCardChoiceAvailable(target)) {
+            scn.LSChooseCard(target);
+        }
+        chooseForceAmountIfPrompted(scn, null);
+        scn.PrepareLSDestiny(destiny1);
+        scn.PassForceUseResponses();
+        scn.PassResponses("Fire ");
+        scn.PassDestinyDrawResponses();
+        scn.PrepareLSDestiny(destiny2);
+        scn.PassDestinyDrawResponses();
+        passPostFiringResponses(scn);
+    }
+
+    private String gameLog(VirtualTableScenario scn) {
+        return String.join("\n", scn.gameState().getLastMessages());
+    }
+
+    private int lastTotalWeaponDestiny(VirtualTableScenario scn) {
+        Integer last = null;
+        for (String msg : scn.gameState().getLastMessages()) {
+            String lower = msg.toLowerCase();
+            int idx = lower.lastIndexOf("total weapon destiny is ");
+            if (idx >= 0) {
+                String rest = msg.substring(idx + "total weapon destiny is ".length()).trim();
+                last = (int) Float.parseFloat(rest.split("[^0-9.]")[0]);
+            }
+        }
+        assertTrue("Expected a total weapon destiny log, got: " + gameLog(scn), last != null);
+        return last;
+    }
+
+    /**
+     * Last weapon destiny draw values in order, after each-draw modifiers (Defiance +2, Targeting Computer -1).
+     */
+    private void assertWeaponDestinyDrawValues(VirtualTableScenario scn, int... expected) {
+        List<Integer> actual = new ArrayList<>();
+        for (String msg : scn.gameState().getLastMessages()) {
+            int idx = msg.indexOf(" as a ");
+            int destIdx = msg.indexOf(" for weapon destiny");
+            if (idx >= 0 && destIdx > idx) {
+                actual.add((int) Float.parseFloat(msg.substring(idx + " as a ".length(), destIdx).trim()));
+            }
+        }
+        assertTrue("Expected last weapon destiny draws " + Arrays.toString(expected) + " but saw " + actual,
+                actual.size() >= expected.length);
+        List<Integer> last = actual.subList(actual.size() - expected.length, actual.size());
+        for (int i = 0; i < expected.length; i++) {
+            assertEquals("weapon destiny draw " + (i + 1) + " of " + last, expected[i], last.get(i).intValue());
+        }
+    }
+
 }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_75_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_75_Tests.java
@@ -264,10 +264,9 @@ public class Card_1_75_Tests {
 
     @Test
     public void TargetingComputerInsideCombinedAttackOffersOptionalUseWithoutSeparatelyCombinedCancel() {
-        // Combined Attack already chose the target. Optional Targeting Computer prompt:
-        // use a Targeting Computer (always combined into the Combined Attack pool) or use none.
-        // No Separately / Combined / Don't Fire. Choosing use consumes Targeting Computer
-        // and both destinies join the Combined Attack pool.
+        // Combined Attack already chose the target. Click a Targeting Computer card to fire
+        // that Combined Attack weapon twice into the pool. No Separately / Combined / Don't Fire.
+        // Choosing the card consumes Targeting Computer and both destinies join the pool.
         var scn = GetScenario();
         var ca = scn.GetLSCard("ca");
         var tc = scn.GetLSCard("tc");
@@ -304,8 +303,8 @@ public class Card_1_75_Tests {
 
     @Test
     public void TargetingComputerInsideCombinedAttackCanBeSkippedAndRemainsUnused() {
-        // Choosing Do not use Targeting Computer fires the Combined Attack weapon once
-        // and does not consume Targeting Computer.
+        // Done on the Targeting Computer table chooser fires the Combined Attack weapon once
+        // and does not consume Targeting Computer. Done must not cancel Combined Attack.
         var scn = GetScenario();
         var ca = scn.GetLSCard("ca");
         var xwlc = scn.GetLSCard("xwlc");
@@ -328,27 +327,31 @@ public class Card_1_75_Tests {
 
     @Test
     public void TargetingComputerInsideCombinedAttackCanChooseAmongMultipleComputersOrNone() {
-        // Two unused Targeting Computers on the same starship: pick one specific computer, or none.
+        // Two unused Targeting Computers on the firing starship: click one specific card, or Done for none.
         var scn = GetScenario();
         var ca = scn.GetLSCard("ca");
+        var tc = scn.GetLSCard("tc");
+        var tc2 = scn.GetLSCard("tc2");
         var xwlc = scn.GetLSCard("xwlc");
         var xwlc2 = scn.GetLSCard("xwlc2");
+        var xwing = scn.GetLSCard("xwing");
+        var xwing2 = scn.GetLSCard("xwing2");
         var tie = scn.GetDSCard("tie");
         setupTwoXwingLasersWithTwoTargetingComputersOnFirst(scn);
         scn.MoveCardsToHand(ca);
 
         scn.StartBattleAndSkipToWeaponsSegment();
         playCombinedAttack(scn, tie, xwlc, xwlc2);
-        assertTrue("Expected optional Targeting Computer prompt, got: "
-                        + (scn.LSGetDecision() == null ? "null" : scn.LSGetDecision().getText()),
-                scn.LSDecisionAvailable("Targeting Computer")
-                        && scn.LSDecisionAvailable("Combined Attack"));
-        assertTrue(scn.LSChoiceAvailable("Do not use Targeting Computer"));
-        assertFalse("Combined Attack must not ask Separately vs Combined", scn.LSChoiceAvailable("Separately"));
-        assertFalse("Combined Attack must not offer Don't Fire (Cancel)", scn.LSChoiceAvailable("Don't Fire"));
-        assertEquals("Two Targeting Computers plus Do not use Targeting Computer", 3, scn.LSGetChoiceCount());
+        assertTargetingComputerTableChooser(scn);
+        assertTrue(scn.LSHasCardChoiceAvailable(tc));
+        assertTrue(scn.LSHasCardChoiceAvailable(tc2));
+        assertEquals("Only unused Targeting Computers on the firing starship", 2, scn.LSGetCardChoiceCount());
+        assertFalse("Weapons are not Targeting Computer choices", scn.LSHasCardChoiceAvailable(xwlc));
+        assertFalse("Weapons are not Targeting Computer choices", scn.LSHasCardChoiceAvailable(xwlc2));
+        assertFalse("Starships are not Targeting Computer choices", scn.LSHasCardChoiceAvailable(xwing));
+        assertFalse("The other starship is not a Targeting Computer choice", scn.LSHasCardChoiceAvailable(xwing2));
         // Pick the second Targeting Computer specifically (not auto-first).
-        scn.LSDecided(1);
+        scn.LSChooseCard(tc2);
 
         fireOneShot(scn, tie, 4, 0);
         fireOneShot(scn, tie, 4, 0);
@@ -498,23 +501,34 @@ public class Card_1_75_Tests {
     }
 
     /**
-     * Combined Attack optional Targeting Computer prompt: use one (always combined into
-     * the Combined Attack pool) or use none. Not the standalone Fire a weapon twice three-way.
+     * Combined Attack optional Targeting Computer table chooser: click a Targeting Computer
+     * card to fire that Combined Attack weapon twice into the pool, or Done to skip.
+     * Not the standalone Fire a weapon twice three-way, and not MultipleChoice buttons.
      */
     private void chooseWhetherToUseTargetingComputer(VirtualTableScenario scn, boolean useTargetingComputer) {
+        assertTargetingComputerTableChooser(scn);
+        if (useTargetingComputer) {
+            scn.LSChooseCard(scn.GetLSCard("tc"));
+        }
+        else {
+            // Done skips this Targeting Computer choice only (does not cancel Combined Attack).
+            scn.LSDecided("");
+        }
+    }
+
+    /**
+     * Combined Attack Targeting Computer prompt is a table-card chooser, not buttons.
+     */
+    private void assertTargetingComputerTableChooser(VirtualTableScenario scn) {
         assertTrue("Expected optional Targeting Computer prompt for Combined Attack, got: "
                         + (scn.LSGetDecision() == null ? "null" : scn.LSGetDecision().getText()),
                 scn.LSDecisionAvailable("Targeting Computer")
-                        && scn.LSDecisionAvailable("Combined Attack"));
+                        && scn.LSDecisionAvailable("Combined Attack")
+                        && scn.LSDecisionAvailable("Done"));
         assertFalse("Combined Attack must not ask Separately vs Combined", scn.LSChoiceAvailable("Separately"));
         assertFalse("Combined Attack must not offer Don't Fire (Cancel)", scn.LSChoiceAvailable("Don't Fire"));
-        assertTrue(scn.LSChoiceAvailable("Do not use Targeting Computer"));
-        if (useTargetingComputer) {
-            scn.LSDecided(0);
-        }
-        else {
-            scn.LSChoose("Do not use Targeting Computer");
-        }
+        assertFalse("Must not use MultipleChoice Targeting Computer buttons",
+                scn.LSChoiceAvailable("Do not use Targeting Computer"));
     }
 
     private void fireOneShot(VirtualTableScenario scn, PhysicalCardImpl target, int destiny) {

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_75_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_75_Tests.java
@@ -1,5 +1,8 @@
 package com.gempukku.swccgo.cards.set1.light;
 
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+
 import com.gempukku.swccgo.common.CardSubtype;
 import com.gempukku.swccgo.common.CardType;
 import com.gempukku.swccgo.common.Phase;
@@ -108,9 +111,17 @@ public class Card_1_75_Tests {
         assertEquals("Combined Attack", card.getTitle());
         assertEquals(Uniqueness.UNRESTRICTED, card.getUniqueness());
         assertEquals(Side.LIGHT, card.getSide());
-        assertTrue(card.isCardType(CardType.INTERRUPT));
-        assertEquals(CardSubtype.LOST, card.getCardSubtype());
+        scn.BlueprintCardTypeCheck(card, new ArrayList<>() {{
+            add(CardType.INTERRUPT);
+        }});
         assertEquals(4, card.getDestiny(), scn.epsilon);
+        assertEquals(CardSubtype.LOST, card.getCardSubtype());
+        scn.BlueprintIconCheck(card, new ArrayList<>() {{
+            add(Icon.INTERRUPT);
+        }});
+        scn.BlueprintKeywordCheck(card, new ArrayList<>() {{
+        }});
+        assertEquals(ExpansionSet.PREMIERE, card.getExpansionSet());
         assertEquals(Rarity.C2, card.getRarity());
     }
 
@@ -233,7 +244,7 @@ public class Card_1_75_Tests {
     }
 
     @Test
-    public void TargetingComputerBothShotsGoIntoCombinedAttackPool() {
+    public void CombinedAttackIncludesBothTargetingComputerShotsInPool() {
         // Two XWLCs, one ship has Targeting Computer. Use TC inside CA.
         // Destinies 4 and 4 (TC weapon, two draws, each -1) plus 1 (second weapon) = 7 vs TIE 3.
         // TC weapon is still one weapon when applying the shared total.
@@ -267,7 +278,7 @@ public class Card_1_75_Tests {
     }
 
     @Test
-    public void TargetingComputerCannotSplitOneShotInsideCombinedAttackAndOneOutside() {
+    public void CombinedAttackCannotSplitTargetingComputerShotsInsideAndOutside() {
         // Forum p=1111897: both TC shots consecutive and both inside Combined Attack.
         var scn = GetScenario();
         var ca = scn.GetLSCard("ca");
@@ -300,7 +311,7 @@ public class Card_1_75_Tests {
     }
 
     @Test
-    public void TargetingComputerInsideCombinedAttackOffersOptionalUseWithoutSeparatelyCombinedCancel() {
+    public void CombinedAttackOffersOptionalTargetingComputerUse() {
         // Combined Attack already chose the target. Click a Targeting Computer card to fire
         // that Combined Attack weapon twice into the pool. No Separately / Combined / Don't Fire.
         // Choosing the card consumes Targeting Computer and both destinies join the pool.
@@ -339,7 +350,7 @@ public class Card_1_75_Tests {
     }
 
     @Test
-    public void TargetingComputerInsideCombinedAttackCanBeSkippedAndRemainsUnused() {
+    public void CombinedAttackCanSkipTargetingComputerLeavingItUnused() {
         // Done on the Targeting Computer table chooser fires the Combined Attack weapon once
         // and does not consume Targeting Computer. Done must not cancel Combined Attack.
         var scn = GetScenario();
@@ -363,7 +374,7 @@ public class Card_1_75_Tests {
     }
 
     @Test
-    public void TargetingComputerInsideCombinedAttackCanChooseAmongMultipleComputersOrNone() {
+    public void CombinedAttackCanChooseAmongMultipleTargetingComputersOrNone() {
         // Two unused Targeting Computers on the firing starship: click one specific card, or Done for none.
         var scn = GetScenario();
         var ca = scn.GetLSCard("ca");
@@ -906,7 +917,7 @@ public class Card_1_75_Tests {
     }
 
     @Test
-    public void BoringConversationAnywayCancelsCombinedAttackBeforeWeaponsFire() {
+    public void CombinedAttackCanBeCanceled() {
         // Sense (1_267) / Boring Conversation Anyway (1_235) cancel Combined Attack (1_75)
         // before any weapon fires. Weapons may still fire normally afterward.
         // This test uses Boring Conversation Anyway because it names Combined Attack and

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/framework/Battles.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/framework/Battles.java
@@ -1,5 +1,6 @@
 package com.gempukku.swccgo.framework;
 
+import com.gempukku.swccgo.common.Phase;
 import com.gempukku.swccgo.common.Zone;
 import com.gempukku.swccgo.game.PhysicalCardImpl;
 
@@ -61,6 +62,59 @@ public interface Battles extends Decisions, GameProcedures, PileProperties {
         PassBattleStartResponses();
     }
 
+
+    /**
+     * Skips to the Light Side Battle phase, initiates battle at the Light Side starting location, and arrives at
+     * LS weapons segment actions.
+     */
+    default void StartBattleAndSkipToWeaponsSegment() {
+        StartBattleAndSkipToWeaponsSegment(LS, GetLSStartingLocation());
+    }
+
+    /**
+     * Skips to the Light Side Battle phase, initiates battle at the given location, and arrives at LS weapons segment actions.
+     * @param location The location to start battle at.
+     */
+    default void StartBattleAndSkipToWeaponsSegment(PhysicalCardImpl location) {
+        StartBattleAndSkipToWeaponsSegment(LS, location);
+    }
+
+    /**
+     * Skips to the given player's Battle phase, has that player initiate battle at the given location, and arrives at
+     * that player's weapons segment actions.
+     * @param player The player who should initiate.
+     * @param location The location to start battle at.
+     */
+    default void StartBattleAndSkipToWeaponsSegment(String player, PhysicalCardImpl location) {
+        if(player.equals(LS)) {
+            SkipToLSTurn(Phase.BATTLE);
+            LSInitiateBattle(location);
+            PassAllResponses();
+            assertTrue("Expected LS weapons segment actions after initiating battle", AwaitingLSWeaponsSegmentActions());
+        }
+        else {
+            SkipToDSTurn(Phase.BATTLE);
+            DSInitiateBattle(location);
+            PassAllResponses();
+            assertTrue("Expected DS weapons segment actions after initiating battle", AwaitingDSWeaponsSegmentActions());
+        }
+    }
+
+    /**
+     * Skips to the Light Side Battle phase, initiates battle at the given location, and arrives at LS weapons segment actions.
+     * @param location The location to start battle at.
+     */
+    default void LSStartBattleAndSkipToWeaponsSegment(PhysicalCardImpl location) {
+        StartBattleAndSkipToWeaponsSegment(LS, location);
+    }
+
+    /**
+     * Skips to the Dark Side Battle phase, initiates battle at the given location, and arrives at DS weapons segment actions.
+     * @param location The location to start battle at.
+     */
+    default void DSStartBattleAndSkipToWeaponsSegment(PhysicalCardImpl location) {
+        StartBattleAndSkipToWeaponsSegment(DS, location);
+    }
 
     /**
      * Right after battle has been initiated, skips to the start of the Power Segment right before the first player is

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/framework/CardProperties.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/framework/CardProperties.java
@@ -320,6 +320,14 @@ public interface CardProperties extends TestBase {
     }
 
     /**
+     * @param card The card to inspect.
+     * @return True if the card currently has any ionization type applied.
+     */
+    default boolean IsIonized(PhysicalCardImpl card) {
+        return card.getIonization() != null && !card.getIonization().isEmpty();
+    }
+
+    /**
      * Checks whether a card is wholly immune to attrition
      * @param card The card to check
      * @return True if no amount of attrition can affect this card, false otherwise.

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/framework/ZoneManipulation.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/framework/ZoneManipulation.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 
 /**
@@ -589,5 +590,61 @@ public interface ZoneManipulation extends TestBase{
 
 
 
+
+
+    /**
+     * Moves cards from the Light Side Reserve Deck onto the Force Pile until it has at least min cards.
+     * Leaves at least 2 cards in Reserve so destiny stubs remain. Fails if the pile cannot reach min.
+     * @param min Minimum Force Pile size to ensure.
+     */
+    default void EnsureLSForcePile(int min) { EnsureForcePile(LS, min); }
+
+    /**
+     * Moves cards from the Dark Side Reserve Deck onto the Force Pile until it has at least min cards.
+     * Leaves at least 2 cards in Reserve so destiny stubs remain. Fails if the pile cannot reach min.
+     * @param min Minimum Force Pile size to ensure.
+     */
+    default void EnsureDSForcePile(int min) { EnsureForcePile(DS, min); }
+
+    /**
+     * Moves cards from the given player's Reserve Deck onto their Force Pile until it has at least min cards.
+     * Leaves at least 2 cards in Reserve so destiny stubs remain. Fails if the pile cannot reach min.
+     * @param player The player whose Force Pile to fill.
+     * @param min Minimum Force Pile size to ensure.
+     */
+    default void EnsureForcePile(String player, int min) {
+        while (gameState().getForcePile(player).size() < min && gameState().getReserveDeck(player).size() > 2) {
+            MoveCardsToTopOfForcePile(player, (PhysicalCardImpl) gameState().getReserveDeck(player).getFirst());
+        }
+        assertTrue("Unable to ensure " + player + " Force Pile has at least " + min
+                + " cards (have " + gameState().getForcePile(player).size() + ")",
+                gameState().getForcePile(player).size() >= min);
+    }
+
+    /**
+     * Moves cards from the Light Side Force Pile into hand until exactly remaining cards are left in the pile.
+     * @param remaining Target Force Pile count.
+     */
+    default void DrainLSForcePileTo(int remaining) { DrainForcePileTo(LS, remaining); }
+
+    /**
+     * Moves cards from the Dark Side Force Pile into hand until exactly remaining cards are left in the pile.
+     * @param remaining Target Force Pile count.
+     */
+    default void DrainDSForcePileTo(int remaining) { DrainForcePileTo(DS, remaining); }
+
+    /**
+     * Moves cards from the given player's Force Pile into hand until exactly remaining cards are left in the pile.
+     * @param player The player whose Force Pile to drain.
+     * @param remaining Target Force Pile count.
+     */
+    default void DrainForcePileTo(String player, int remaining) {
+        while (gameState().getForcePile(player).size() > remaining) {
+            MoveCardsToHand((PhysicalCardImpl) gameState().getForcePile(player).getFirst());
+        }
+        assertTrue(player + " Force Pile should be drained to " + remaining
+                + " (have " + gameState().getForcePile(player).size() + ")",
+                gameState().getForcePile(player).size() == remaining);
+    }
 
 }


### PR DESCRIPTION
Implements Combined Attack (`1_75`).

## Summary
Premiere Light Lost Interrupt: during a battle, target an opponent's starship present with two or more of your fireable starship weapons (including permanent weapons). Encodes Gergall 2015 + 2023 Advanced Rulebook option A combined-fire math.

## Card
- **Id / title:** `1_75` / Combined Attack
- **Type:** Light Lost Interrupt, Premiere, destiny 4, C2
- **Game text:** During a battle, target an opponent's starship present with two or more of your fireable starship weapons (including permanent weapons).

## What changed
- Adds `Card1_075` and shared combined-fire plumbing (`FireWeaponsCombinedAction`, `CombinedAttackFiringState`)
- Draw modifiers stay on each draw; TOTAL weapon destiny modifiers apply **once** to the grand total (same title once unless the card says cumulatively)
- Weapons fire one at a time; results apply only after all fire; attacker chooses result-apply order when 2+ weapons completed
- Targeting Computer may be used **inside** Combined Attack: click-the-card chooser (or Done to skip); both destinies join the Combined Attack pool as draws; TC −1 per draw; consuming a copy increments the same once-per-turn counters as standalone TC
- Sense / Boring Conversation Anyway cancel Combined Attack before weapons fire; already-fired weapons cannot be chosen

## Design choices (Gergall / Advanced Rulebook)
- Combined Attack / Targeting Computer combined is **one action**
- Draw-mod examples: Targeting Computer −1 per draw; B-wing Bomber ion cannon +3 each draw; Defiance +2 each draw
- Total-mod examples: Concussion Missiles +1; Enhanced Proton Torpedoes +1/−1; Intruder Missiles +3; Heavy Turbolaser Battery −1 vs capital / −6 otherwise
- **Gergall Example 2:** Enhanced Proton Torpedoes + two Intruder Missiles, draws 1+2+3, +1 and +3 once (not +6) = **10**
- Heavy Turbolaser Battery −1/−6 is TOTAL once on the grand total (not per firing subtotal); TC twice on one HTB still subtracts once
- Same-title-once for Combined Attack is in `CombinedAttackFiringState.getSameTitleOnceTotalModifier()` (separate from Cumulative Rule #1010)
- Device-per-turn slots still apply: starfighter 1, squadron 3, capital unlimited; Done does not consume the device
- Standalone Targeting Computer three-way (Separately / Combined / Don't Fire) is unchanged on #1006

## Tests
`Card_1_75_Tests` — **26** tests:
1. Stats/keywords
2–3. Cannot play outside battle / with fewer than 2 weapons
4. Happy path: two X-wing Laser Cannons; combined total hits when separate would miss
5–6. Gergall Example 2 vs Stalker (hit) and Executor (miss)
7–8. TC both shots into pool; cannot split one TC in / one out
9. XWLC at X=3 + B-wing Ion Cannon vs TIE: TIE is lost
10–12. Click TC card / Done skips / two unused TCs chooser
13–15. Two HTBs −1/−6 once; Defiance+TC+two HTBs vs Executor
16–20. Starfighter/squadron/capital TC copy limits; Done does not consume device
21. Two Concussion Missiles +1 once
22. Boring Conversation Anyway cancels before fire
23. Already-fired weapon cannot be chosen
24. Different titles (Concussion Missiles + Quad Laser Cannon) stack to +2
25. Prior Ion Cannon enables Intruder Missile +3; EPT + Intruder stack to +4
26. Three Enhanced Proton Torpedoes −1 once (not −3); B-wing Bomber ion-draw +3 does not apply

## Known gaps
- None noted beyond stacking on Targeting Computer

## Depends on
- Depends on #1006

Closes #71

---
Tests follow VHD/PlayersCommittee naming (method names lead with card title + behavior; exclusive BlueprintIconCheck/KeywordCheck where applicable).