### PR TITLE
Stay Sharp: errata gametext/JSON and total weapon destiny stacking fix

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set7/light/Card7_104.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set7/light/Card7_104.java
@@ -20,8 +20,8 @@ import com.gempukku.swccgo.logic.actions.OptionalGameTextTriggerAction;
 import com.gempukku.swccgo.logic.actions.PlayInterruptAction;
 import com.gempukku.swccgo.logic.actions.TriggerAction;
 import com.gempukku.swccgo.logic.effects.FireWeaponEffect;
-import com.gempukku.swccgo.logic.effects.ModifyDestinyEffect;
 import com.gempukku.swccgo.logic.effects.ModifyTotalPowerUntilEndOfBattleEffect;
+import com.gempukku.swccgo.logic.effects.ModifyTotalWeaponDestinyBeforeDrawingDestinyEffect;
 import com.gempukku.swccgo.logic.effects.RespondablePlayCardEffect;
 import com.gempukku.swccgo.logic.effects.choose.ChooseCardOnTableEffect;
 import com.gempukku.swccgo.logic.timing.Action;
@@ -44,7 +44,7 @@ public class Card7_104 extends AbstractUsedInterrupt {
     public Card7_104() {
         super(Side.LIGHT, 4, "Stay Sharp!", Uniqueness.UNIQUE, ExpansionSet.SPECIAL_EDITION, Rarity.U);
         setLore("'Ha haaaaaa!'");
-        setGameText("During your control phase, fire one of your starship weapons (for free). If Han or any gunner is aboard that starship, may add 2 to destiny draw. 'Hit' target is lost. OR If you just fired a weapon in battle, add that weapon's destiny number to your total power.");
+        setGameText("During your control phase, fire one of your starship weapons (for free). If Han or any gunner is aboard that starship, may add 2 to the total weapon destiny. 'Hit' target is lost. OR If you just fired a weapon in battle, add that weapon's destiny number to your total power.");
         addIcons(Icon.SPECIAL_EDITION);
     }
 
@@ -105,7 +105,8 @@ public class Card7_104 extends AbstractUsedInterrupt {
                                                                     public List<TriggerAction> getOptionalAfterTriggers(String playerId3, SwccgGame game, EffectResult effectResult) {
                                                                         List<TriggerAction> actions = new LinkedList<TriggerAction>();
                                                                         // Offer after each weapon destiny draw until the player accepts once.
-                                                                        // Accepting adds 2 to that draw (and thus the weapon destiny total).
+                                                                        // Accepting adds 2 to the TOTAL weapon destiny for the rest of this firing
+                                                                        // (until-end-of-weapon-firing), so a cancel/redraw keeps the bonus.
                                                                         // Declining leaves it available on a later draw of this same firing.
                                                                         // The same Stay Sharp bonus does not stack if it is somehow accepted twice.
                                                                         if (playerId.equals(playerId3)
@@ -114,7 +115,7 @@ public class Card7_104 extends AbstractUsedInterrupt {
                                                                                 && TriggerConditions.isWeaponDestinyJustDrawnBy(game, effectResult, playerId, weapon)) {
 
                                                                             final OptionalGameTextTriggerAction action1 = new OptionalGameTextTriggerAction(self, gameTextSourceCardId);
-                                                                            action1.setText("Add 2 to weapon destiny");
+                                                                            action1.setText("Add 2 to total weapon destiny");
                                                                             action1.setPerformingPlayer(playerId);
                                                                             // Perform result(s)
                                                                             action1.appendEffect(
@@ -126,7 +127,7 @@ public class Card7_104 extends AbstractUsedInterrupt {
                                                                                             }
                                                                                             staySharpBonusAccepted = true;
                                                                                             action1.appendEffect(
-                                                                                                    new ModifyDestinyEffect(action1, 2));
+                                                                                                    new ModifyTotalWeaponDestinyBeforeDrawingDestinyEffect(action1, 2));
                                                                                         }
                                                                                     }
                                                                             );

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set7/light/Card7_104.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set7/light/Card7_104.java
@@ -27,6 +27,7 @@ import com.gempukku.swccgo.logic.effects.choose.ChooseCardOnTableEffect;
 import com.gempukku.swccgo.logic.timing.Action;
 import com.gempukku.swccgo.logic.timing.EffectResult;
 import com.gempukku.swccgo.logic.timing.GuiUtils;
+import com.gempukku.swccgo.logic.timing.PassthruEffect;
 import com.gempukku.swccgo.logic.timing.results.FiredWeaponResult;
 
 import java.util.Collections;
@@ -74,20 +75,61 @@ public class Card7_104 extends AbstractUsedInterrupt {
                                                         new FireWeaponEffect(action, weapon, true, Filters.canBeTargetedBy(self)) {
                                                             @Override
                                                             protected List<ActionProxy> getWeaponFiringActionProxies(String playerId2, SwccgGame game, final PhysicalCard weapon) {
+                                                                // Stay Sharp is already off table when destinies are drawn, so it is a poor
+                                                                // spotting source. Check Han/gunner aboard the firing starship now.
+                                                                final PhysicalCard starship = weapon.getAttachedTo();
+                                                                boolean hanOrGunnerFound = false;
+                                                                if (starship != null && Filters.starship.accepts(game, starship)) {
+                                                                    Filter hanOrGunner = Filters.and(Filters.your(self), Filters.or(Filters.Han, Filters.gunner));
+                                                                    for (PhysicalCard cardAboard : game.getGameState().getPilotCardsAboard(game.getModifiersQuerying(), starship, false)) {
+                                                                        if (hanOrGunner.accepts(game, cardAboard)) {
+                                                                            hanOrGunnerFound = true;
+                                                                            break;
+                                                                        }
+                                                                    }
+                                                                    if (!hanOrGunnerFound) {
+                                                                        for (PhysicalCard cardAboard : game.getGameState().getPassengerCardsAboard(starship)) {
+                                                                            if (hanOrGunner.accepts(game, cardAboard)) {
+                                                                                hanOrGunnerFound = true;
+                                                                                break;
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                                final boolean hanOrGunnerAboard = hanOrGunnerFound;
+
                                                                 ActionProxy actionProxy = new AbstractActionProxy() {
+                                                                    private boolean staySharpBonusAccepted;
+
                                                                     @Override
                                                                     public List<TriggerAction> getOptionalAfterTriggers(String playerId3, SwccgGame game, EffectResult effectResult) {
                                                                         List<TriggerAction> actions = new LinkedList<TriggerAction>();
-                                                                        // Check condition(s)
+                                                                        // Offer after each weapon destiny draw until the player accepts once.
+                                                                        // Accepting adds 2 to that draw (and thus the weapon destiny total).
+                                                                        // Declining leaves it available on a later draw of this same firing.
+                                                                        // The same Stay Sharp bonus does not stack if it is somehow accepted twice.
                                                                         if (playerId.equals(playerId3)
-                                                                                && TriggerConditions.isWeaponDestinyJustDrawnBy(game, effectResult, playerId, weapon,
-                                                                                Filters.and(Filters.starship, Filters.hasAboard(self, Filters.and(Filters.your(self), Filters.or(Filters.Han, Filters.gunner)))))) {
+                                                                                && hanOrGunnerAboard
+                                                                                && !staySharpBonusAccepted
+                                                                                && TriggerConditions.isWeaponDestinyJustDrawnBy(game, effectResult, playerId, weapon)) {
 
                                                                             final OptionalGameTextTriggerAction action1 = new OptionalGameTextTriggerAction(self, gameTextSourceCardId);
                                                                             action1.setText("Add 2 to weapon destiny");
+                                                                            action1.setPerformingPlayer(playerId);
                                                                             // Perform result(s)
                                                                             action1.appendEffect(
-                                                                                    new ModifyDestinyEffect(action1, 2));
+                                                                                    new PassthruEffect(action1) {
+                                                                                        @Override
+                                                                                        protected void doPlayEffect(SwccgGame game) {
+                                                                                            if (staySharpBonusAccepted) {
+                                                                                                return;
+                                                                                            }
+                                                                                            staySharpBonusAccepted = true;
+                                                                                            action1.appendEffect(
+                                                                                                    new ModifyDestinyEffect(action1, 2));
+                                                                                        }
+                                                                                    }
+                                                                            );
                                                                             actions.add(action1);
                                                                         }
                                                                         return actions;

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
@@ -112529,7 +112529,7 @@
     ],
     "cardSubtype": "USED",
     "lore": "'Ha haaaaaa!'",
-    "gameText": "During your control phase, fire one of your starship weapons (for free). If Han or any gunner is aboard that starship, may add 2 to destiny draw. 'Hit' target is lost. OR If you just fired a weapon in battle, add that weapon's destiny number to your total power.",
+    "gameText": "During your control phase, fire one of your starship weapons (for free). If Han or any gunner is aboard that starship, may add 2 to the total weapon destiny. 'Hit' target is lost. OR If you just fired a weapon in battle, add that weapon's destiny number to your total power.",
     "destiny": 4,
     "icons": [
       {

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_light.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_light.json
@@ -57705,7 +57705,7 @@
     ],
     "cardSubtype": "USED",
     "lore": "'Ha haaaaaa!'",
-    "gameText": "During your control phase, fire one of your starship weapons (for free). If Han or any gunner is aboard that starship, may add 2 to destiny draw. 'Hit' target is lost. OR If you just fired a weapon in battle, add that weapon's destiny number to your total power.",
+    "gameText": "During your control phase, fire one of your starship weapons (for free). If Han or any gunner is aboard that starship, may add 2 to the total weapon destiny. 'Hit' target is lost. OR If you just fired a weapon in battle, add that weapon's destiny number to your total power.",
     "destiny": 4,
     "icons": [
       {

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set7/light/Card_7_104_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set7/light/Card_7_104_Tests.java
@@ -1,0 +1,265 @@
+package com.gempukku.swccgo.cards.set7.light;
+
+import com.gempukku.swccgo.common.CardSubtype;
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.game.PhysicalCardImpl;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Card_7_104_Tests {
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>()
+                {{
+                    put("stay_sharp", "7_104");
+                    put("htb", "9_089");
+                    put("cruiser", "9_079");
+                    put("han", "1_011");
+                }},
+                new HashMap<>()
+                {{
+                    put("destroyer", "1_302");
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSSpaceSystem,
+                StartingSetup.DefaultDSSpaceSystem,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void StaySharpStatsAndKeywordsAreCorrect() {
+        /**
+         * Title: Stay Sharp!
+         * Uniqueness: Unique
+         * Side: Light
+         * Type: Interrupt
+         * Subtype: Used
+         * Destiny: 4
+         * Icons: Special Edition
+         * Game Text: During your control phase, fire one of your starship weapons (for free). If Han or any gunner
+         *      is aboard that starship, may add 2 to destiny draw. 'Hit' target is lost. OR If you just fired a
+         *      weapon in battle, add that weapon's destiny number to your total power.
+         * Lore: 'Ha haaaaaa!'
+         * Set: Special Edition
+         * Rarity: U
+         */
+        var scn = GetScenario();
+
+        var card = scn.GetLSCard("stay_sharp").getBlueprint();
+
+        assertEquals("Stay Sharp!", card.getTitle());
+        assertEquals(Uniqueness.UNIQUE, card.getUniqueness());
+        assertEquals(Side.LIGHT, card.getSide());
+        assertTrue(card.getCardTypes().contains(CardType.INTERRUPT));
+        assertEquals(CardSubtype.USED, card.getCardSubtype());
+        assertEquals(4, card.getDestiny(), scn.epsilon);
+        assertEquals(1, card.getIconCount(Icon.SPECIAL_EDITION));
+        assertEquals(ExpansionSet.SPECIAL_EDITION, card.getExpansionSet());
+        assertEquals(Rarity.U, card.getRarity());
+    }
+
+    @Test
+    public void StaySharpHeavyTurbolaserBatteryCannotStackPlusFourToHitDuringControlPhase() {
+        // Heavy Turbolaser Battery draws two weapon destinies. Stay Sharp may add 2 to the
+        // destiny total once, not +2 after each draw. Destinies 1 and 3 vs a capital:
+        // 1 + 3 - 1 = 3. Plus 2 = 5, which does not beat Imperial-Class Star Destroyer
+        // armor 6. Plus 4 would be 7 and would hit. Always take Stay Sharp +2 when it
+        // is offered so a second illegal accept would make this test fail by hitting.
+        var scn = GetScenario();
+        var staySharp = scn.GetLSCard("stay_sharp");
+        var htb = scn.GetLSCard("htb");
+        var destroyer = scn.GetDSCard("destroyer");
+
+        setupStaySharpHeavyTurbolaserBatteryTable(scn);
+        assertEquals(6, scn.GetDefense(destroyer));
+
+        playStaySharpAndChooseHeavyTurbolaserBattery(scn, staySharp, htb);
+        int offered = resolveHeavyTurbolaserBatteryFiringWithStaySharp(scn, destroyer, true, true);
+
+        assertEquals("Stay Sharp +2 should be offered once after it is accepted", 1, offered);
+        assertTargetWasNotHitByStaySharpPlusFour(scn, destroyer);
+    }
+
+    @Test
+    public void StaySharpPlusTwoStillOfferedOnSecondDrawIfDeclinedOnFirst() {
+        // Declining Stay Sharp on the first Heavy Turbolaser Battery destiny draw must
+        // still offer it on the second draw. Accepting that later offer is still only +2
+        // total, so the Star Destroyer is not hit with the same 1+3-1 destiny math.
+        var scn = GetScenario();
+        var staySharp = scn.GetLSCard("stay_sharp");
+        var htb = scn.GetLSCard("htb");
+        var destroyer = scn.GetDSCard("destroyer");
+
+        setupStaySharpHeavyTurbolaserBatteryTable(scn);
+
+        playStaySharpAndChooseHeavyTurbolaserBattery(scn, staySharp, htb);
+        int offered = resolveHeavyTurbolaserBatteryFiringWithStaySharp(scn, destroyer, false, true);
+
+        assertEquals("Stay Sharp +2 should be offered on the first draw, then again after a decline", 2, offered);
+        assertTargetWasNotHitByStaySharpPlusFour(scn, destroyer);
+    }
+
+    /**
+     * Puts a Mon Calamari Star Cruiser with Han aboard and Heavy Turbolaser Battery attached
+     * at the Light Side system, facing an Imperial-Class Star Destroyer. Stacks weapon destinies
+     * 1 then 3 so the Heavy Turbolaser Battery total is 3 before Stay Sharp.
+     */
+    private void setupStaySharpHeavyTurbolaserBatteryTable(VirtualTableScenario scn) {
+        var staySharp = scn.GetLSCard("stay_sharp");
+        var htb = scn.GetLSCard("htb");
+        var cruiser = scn.GetLSCard("cruiser");
+        var han = scn.GetLSCard("han");
+        var destroyer = scn.GetDSCard("destroyer");
+        var system = scn.GetLSStartingLocation();
+
+        scn.StartGame();
+
+        scn.MoveCardsToLocation(system, cruiser, destroyer, han);
+        scn.BoardAsPilot(cruiser, han);
+        scn.AttachCardsTo(cruiser, htb);
+        scn.MoveCardsToLSHand(staySharp);
+
+        scn.SkipToLSTurn(Phase.CONTROL);
+        assertTrue("Han must be piloting the Star Cruiser for Stay Sharp +2", scn.IsAboardAsPilot(cruiser, han));
+        assertTrue("Han must remain in play aboard the Star Cruiser", han.getZone().isInPlay());
+
+        // Second draw is 3, first draw is 1 (placed on top last). 1+3-1 = 3 vs capital.
+        scn.PrepareLSDestiny(3);
+        scn.PrepareLSDestiny(1);
+    }
+
+    /**
+     * Plays Stay Sharp during the control phase and chooses Heavy Turbolaser Battery.
+     */
+    private void playStaySharpAndChooseHeavyTurbolaserBattery(VirtualTableScenario scn,
+            PhysicalCardImpl staySharp, PhysicalCardImpl htb) {
+        assertTrue(scn.AwaitingLSControlPhaseActions());
+        assertTrue(scn.LSCardPlayAvailable(staySharp));
+        scn.LSPlayCard(staySharp);
+        assertTrue(scn.LSHasCardChoiceAvailable(htb));
+        scn.LSChooseCard(htb);
+    }
+
+    /**
+     * Finishes firing Heavy Turbolaser Battery after Stay Sharp has been played.
+     * Whenever "Add 2 to weapon destiny" is offered, takes it on the first offer if
+     * takeFirstOffer is true, and on later offers if takeLaterOffers is true.
+     * Returns how many times that optional was offered.
+     */
+    private int resolveHeavyTurbolaserBatteryFiringWithStaySharp(VirtualTableScenario scn,
+            PhysicalCardImpl destroyer, boolean takeFirstOffer, boolean takeLaterOffers) {
+        int offered = 0;
+        java.util.List<String> seen = new java.util.ArrayList<>();
+        for (int i = 0; i < 60; i++) {
+            seen.add(describeDecisions(scn));
+            if (scn.AwaitingLSControlPhaseActions() && i > 0) {
+                if (offered == 0) {
+                    throw new AssertionError("Back at control phase with no Stay Sharp offers. Decisions: " + seen);
+                }
+                return offered;
+            }
+
+            if (scn.LSAnyDecisionsAvailable() && staySharpBonusActionAvailable(scn)) {
+                offered++;
+                boolean take = (offered == 1) ? takeFirstOffer : takeLaterOffers;
+                if (take) {
+                    scn.LSChooseAction("Add 2 to weapon destiny");
+                }
+                else {
+                    scn.LSDecline();
+                }
+                continue;
+            }
+
+            if (scn.LSAnyDecisionsAvailable() && scn.LSHasCardChoiceAvailable(destroyer)) {
+                scn.LSChooseCard(destroyer);
+                continue;
+            }
+
+            // Pass one player at a time. PassResponses("optional") would also decline
+            // Light Side's Stay Sharp prompt if both players have an optional window.
+            if (scn.DSAnyDecisionsAvailable()) {
+                scn.DSPass();
+                continue;
+            }
+            if (scn.LSAnyDecisionsAvailable()) {
+                scn.LSPass();
+                continue;
+            }
+
+            throw new AssertionError("No pending decision while firing Heavy Turbolaser Battery after "
+                    + i + " steps; Stay Sharp offers seen: " + offered + "; seen=" + seen);
+        }
+        throw new AssertionError("Did not finish firing Heavy Turbolaser Battery. Stay Sharp offers seen: "
+                + offered + "; last decision: " + describeDecisions(scn));
+    }
+
+    /**
+     * True if Light Side currently has the Stay Sharp optional to add 2 to weapon destiny.
+     */
+    private boolean staySharpBonusActionAvailable(VirtualTableScenario scn) {
+        if (!scn.LSAnyDecisionsAvailable()) {
+            return false;
+        }
+        var params = scn.LSGetDecision().getDecisionParameters();
+        String[] actionTexts = params.get("actionText");
+        if (actionTexts == null) {
+            return false;
+        }
+        for (String text : actionTexts) {
+            if (text != null && text.contains("Add 2 to weapon destiny")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Light and Dark pending decision text, including any Light Side action labels.
+     */
+    private String describeDecisions(VirtualTableScenario scn) {
+        String ls = "LS=none";
+        if (scn.LSAnyDecisionsAvailable()) {
+            var decision = scn.LSGetDecision();
+            String[] actionTexts = decision.getDecisionParameters().get("actionText");
+            ls = "LS=" + decision.getText() + " actions=" + java.util.Arrays.toString(actionTexts);
+        }
+        String ds = "DS=none";
+        if (scn.DSAnyDecisionsAvailable()) {
+            ds = "DS=" + scn.DSGetDecision().getText();
+        }
+        return ls + " | " + ds + " | phase=" + scn.GetCurrentPhase();
+    }
+
+    /**
+     * The Star Destroyer is hit only if Stay Sharp stacked to +4. A miss (Stay Sharp +2)
+     * leaves it in play and not hit.
+     */
+    private void assertTargetWasNotHitByStaySharpPlusFour(VirtualTableScenario scn, PhysicalCardImpl destroyer) {
+        assertFalse("Imperial-Class Star Destroyer must not be hit; that would mean Stay Sharp stacked to +4",
+                destroyer.isHit());
+        assertEquals("Imperial-Class Star Destroyer must still be at the system after a miss",
+                Zone.AT_LOCATION, destroyer.getZone());
+        assertEquals(0, scn.GetDSLostPileCount());
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set7/light/Card_7_104_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set7/light/Card_7_104_Tests.java
@@ -21,6 +21,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class Card_7_104_Tests {
+    private static final String STAY_SHARP_BONUS_TEXT = "Add 2 to total weapon destiny";
+    private static final String CONCENTRATE_ALL_FIRE_REDRAW_TEXT = "Cancel destiny and cause re-draw";
+
     protected VirtualTableScenario GetScenario() {
         return new VirtualTableScenario(
                 new HashMap<>()
@@ -29,6 +32,7 @@ public class Card_7_104_Tests {
                     put("htb", "9_089");
                     put("cruiser", "9_079");
                     put("han", "1_011");
+                    put("concentrate_all_fire", "9_3");
                 }},
                 new HashMap<>()
                 {{
@@ -57,8 +61,8 @@ public class Card_7_104_Tests {
          * Destiny: 4
          * Icons: Special Edition
          * Game Text: During your control phase, fire one of your starship weapons (for free). If Han or any gunner
-         *      is aboard that starship, may add 2 to destiny draw. 'Hit' target is lost. OR If you just fired a
-         *      weapon in battle, add that weapon's destiny number to your total power.
+         *      is aboard that starship, may add 2 to the total weapon destiny. 'Hit' target is lost. OR If you just
+         *      fired a weapon in battle, add that weapon's destiny number to your total power.
          * Lore: 'Ha haaaaaa!'
          * Set: Special Edition
          * Rarity: U
@@ -81,22 +85,23 @@ public class Card_7_104_Tests {
     @Test
     public void StaySharpHeavyTurbolaserBatteryCannotStackPlusFourToHitDuringControlPhase() {
         // Heavy Turbolaser Battery draws two weapon destinies. Stay Sharp may add 2 to the
-        // destiny total once, not +2 after each draw. Destinies 1 and 3 vs a capital:
+        // total weapon destiny once, not +2 after each draw. Destinies 1 and 3 vs a capital:
         // 1 + 3 - 1 = 3. Plus 2 = 5, which does not beat Imperial-Class Star Destroyer
-        // armor 6. Plus 4 would be 7 and would hit. Always take Stay Sharp +2 when it
-        // is offered so a second illegal accept would make this test fail by hitting.
+        // armor 6 (hit if total destiny > defense value). Plus 4 would be 7 and would hit.
+        // Always take Stay Sharp +2 when it is offered so a second illegal accept would
+        // make this test fail by hitting.
         var scn = GetScenario();
         var staySharp = scn.GetLSCard("stay_sharp");
         var htb = scn.GetLSCard("htb");
         var destroyer = scn.GetDSCard("destroyer");
 
-        setupStaySharpHeavyTurbolaserBatteryTable(scn);
+        setupStaySharpHeavyTurbolaserBatteryTable(scn, false);
         assertEquals(6, scn.GetDefense(destroyer));
 
         playStaySharpAndChooseHeavyTurbolaserBattery(scn, staySharp, htb);
-        int offered = resolveHeavyTurbolaserBatteryFiringWithStaySharp(scn, destroyer, true, true);
+        StaySharpFiringResult result = resolveHeavyTurbolaserBatteryFiring(scn, destroyer, true, true, false, true);
 
-        assertEquals("Stay Sharp +2 should be offered once after it is accepted", 1, offered);
+        assertEquals("Stay Sharp +2 should be offered once after it is accepted", 1, result.staySharpOffered);
         assertTargetWasNotHitByStaySharpPlusFour(scn, destroyer);
     }
 
@@ -110,21 +115,73 @@ public class Card_7_104_Tests {
         var htb = scn.GetLSCard("htb");
         var destroyer = scn.GetDSCard("destroyer");
 
-        setupStaySharpHeavyTurbolaserBatteryTable(scn);
+        setupStaySharpHeavyTurbolaserBatteryTable(scn, false);
 
         playStaySharpAndChooseHeavyTurbolaserBattery(scn, staySharp, htb);
-        int offered = resolveHeavyTurbolaserBatteryFiringWithStaySharp(scn, destroyer, false, true);
+        StaySharpFiringResult result = resolveHeavyTurbolaserBatteryFiring(scn, destroyer, false, true, false, true);
 
-        assertEquals("Stay Sharp +2 should be offered on the first draw, then again after a decline", 2, offered);
+        assertEquals("Stay Sharp +2 should be offered on the first draw, then again after a decline", 2, result.staySharpOffered);
         assertTargetWasNotHitByStaySharpPlusFour(scn, destroyer);
+    }
+
+    @Test
+    public void StaySharpPlusTwoSurvivesConcentrateAllFireRedrawAfterAccept() {
+        // Accept Stay Sharp +2 after the first Heavy Turbolaser Battery destiny, then use
+        // Concentrate All Fire to cancel and redraw that destiny. The +2 is a total weapon
+        // destiny modifier until end of weapon firing, so it must still apply after the
+        // redraw and must not be offered again. Final destinies 2 then 4 vs capital:
+        // 2 + 4 - 1 = 5 miss; +2 = 7 hits Imperial-Class Star Destroyer armor 6 (need total
+        // destiny > 6). If the modifier vanished with the canceled draw, the Destroyer
+        // would miss. Stacking to +4 would also hit, so offer-once is asserted separately.
+        var scn = GetScenario();
+        var staySharp = scn.GetLSCard("stay_sharp");
+        var htb = scn.GetLSCard("htb");
+        var destroyer = scn.GetDSCard("destroyer");
+
+        setupStaySharpHeavyTurbolaserBatteryTable(scn, true);
+        assertEquals(6, scn.GetDefense(destroyer));
+
+        playStaySharpAndChooseHeavyTurbolaserBattery(scn, staySharp, htb);
+        StaySharpFiringResult result = resolveHeavyTurbolaserBatteryFiring(scn, destroyer, true, true, true, true);
+
+        assertEquals("Stay Sharp +2 should be accepted once and not offered again after Concentrate All Fire redraw", 1, result.staySharpOffered);
+        assertEquals("Stay Sharp +2 should be accepted once", 1, result.staySharpAccepted);
+        assertEquals("Concentrate All Fire should cancel and redraw one weapon destiny", 1, result.concentrateAllFireTaken);
+        assertTargetWasHitByStaySharpPlusTwoAfterRedraw(scn, destroyer);
+    }
+
+    @Test
+    public void StaySharpStillOfferedAfterConcentrateAllFireRedrawIfNotYetAccepted() {
+        // Skip Stay Sharp on the first Heavy Turbolaser Battery destiny by taking Concentrate
+        // All Fire instead. After the redraw, Stay Sharp must still be offered until it is
+        // accepted once. Same 2+4-1 destiny math: miss without +2, hit with +2.
+        var scn = GetScenario();
+        var staySharp = scn.GetLSCard("stay_sharp");
+        var htb = scn.GetLSCard("htb");
+        var destroyer = scn.GetDSCard("destroyer");
+
+        setupStaySharpHeavyTurbolaserBatteryTable(scn, true);
+
+        playStaySharpAndChooseHeavyTurbolaserBattery(scn, staySharp, htb);
+        StaySharpFiringResult result = resolveHeavyTurbolaserBatteryFiring(scn, destroyer, true, true, true, false);
+
+        assertTrue("Stay Sharp +2 should still be offered after Concentrate All Fire redraws a destiny",
+                result.staySharpOfferedAfterConcentrateAllFire >= 1);
+        assertEquals("Stay Sharp +2 should be accepted once", 1, result.staySharpAccepted);
+        assertEquals("Concentrate All Fire should cancel and redraw one weapon destiny", 1, result.concentrateAllFireTaken);
+        assertTrue("Stay Sharp +2 must not be offered again after it is accepted",
+                result.staySharpOffered <= 2);
+        assertTargetWasHitByStaySharpPlusTwoAfterRedraw(scn, destroyer);
     }
 
     /**
      * Puts a Mon Calamari Star Cruiser with Han aboard and Heavy Turbolaser Battery attached
-     * at the Light Side system, facing an Imperial-Class Star Destroyer. Stacks weapon destinies
-     * 1 then 3 so the Heavy Turbolaser Battery total is 3 before Stay Sharp.
+     * at the Light Side system, facing an Imperial-Class Star Destroyer.
+     * Without Concentrate All Fire, stacks weapon destinies 1 then 3 so the total is 3
+     * before Stay Sharp. With Concentrate All Fire in play, stacks 1 (canceled), then
+     * redraw 2 and second draw 4 so the final total is 5 before Stay Sharp.
      */
-    private void setupStaySharpHeavyTurbolaserBatteryTable(VirtualTableScenario scn) {
+    private void setupStaySharpHeavyTurbolaserBatteryTable(VirtualTableScenario scn, boolean includeConcentrateAllFire) {
         var staySharp = scn.GetLSCard("stay_sharp");
         var htb = scn.GetLSCard("htb");
         var cruiser = scn.GetLSCard("cruiser");
@@ -138,14 +195,25 @@ public class Card_7_104_Tests {
         scn.BoardAsPilot(cruiser, han);
         scn.AttachCardsTo(cruiser, htb);
         scn.MoveCardsToLSHand(staySharp);
+        if (includeConcentrateAllFire) {
+            scn.MoveCardsToLSSideOfTable(scn.GetLSCard("concentrate_all_fire"));
+        }
 
         scn.SkipToLSTurn(Phase.CONTROL);
         assertTrue("Han must be piloting the Star Cruiser for Stay Sharp +2", scn.IsAboardAsPilot(cruiser, han));
         assertTrue("Han must remain in play aboard the Star Cruiser", han.getZone().isInPlay());
 
-        // Second draw is 3, first draw is 1 (placed on top last). 1+3-1 = 3 vs capital.
-        scn.PrepareLSDestiny(3);
-        scn.PrepareLSDestiny(1);
+        if (includeConcentrateAllFire) {
+            // Last Prepare is drawn first. First draw 1 is canceled; redraw 2 then second draw 4.
+            scn.PrepareLSDestiny(4);
+            scn.PrepareLSDestiny(2);
+            scn.PrepareLSDestiny(1);
+        }
+        else {
+            // Second draw is 3, first draw is 1 (placed on top last). 1+3-1 = 3 vs capital.
+            scn.PrepareLSDestiny(3);
+            scn.PrepareLSDestiny(1);
+        }
     }
 
     /**
@@ -162,32 +230,71 @@ public class Card_7_104_Tests {
 
     /**
      * Finishes firing Heavy Turbolaser Battery after Stay Sharp has been played.
-     * Whenever "Add 2 to weapon destiny" is offered, takes it on the first offer if
-     * takeFirstOffer is true, and on later offers if takeLaterOffers is true.
-     * Returns how many times that optional was offered.
+     * Takes or skips Stay Sharp and Concentrate All Fire optionals according to the flags.
+     * preferStaySharpFirst true means accept Stay Sharp before Concentrate All Fire when both
+     * are showing. False means take Concentrate All Fire first (skipping Stay Sharp that window).
      */
-    private int resolveHeavyTurbolaserBatteryFiringWithStaySharp(VirtualTableScenario scn,
-            PhysicalCardImpl destroyer, boolean takeFirstOffer, boolean takeLaterOffers) {
-        int offered = 0;
+    private StaySharpFiringResult resolveHeavyTurbolaserBatteryFiring(VirtualTableScenario scn,
+            PhysicalCardImpl destroyer, boolean takeFirstStaySharpOffer, boolean takeLaterStaySharpOffers,
+            boolean takeConcentrateAllFireOnce, boolean preferStaySharpFirst) {
+        StaySharpFiringResult result = new StaySharpFiringResult();
         java.util.List<String> seen = new java.util.ArrayList<>();
-        for (int i = 0; i < 60; i++) {
+        for (int i = 0; i < 80; i++) {
             seen.add(describeDecisions(scn));
             if (scn.AwaitingLSControlPhaseActions() && i > 0) {
-                if (offered == 0) {
+                if (result.staySharpOffered == 0) {
                     throw new AssertionError("Back at control phase with no Stay Sharp offers. Decisions: " + seen);
                 }
-                return offered;
+                return result;
             }
 
-            if (scn.LSAnyDecisionsAvailable() && staySharpBonusActionAvailable(scn)) {
-                offered++;
-                boolean take = (offered == 1) ? takeFirstOffer : takeLaterOffers;
-                if (take) {
-                    scn.LSChooseAction("Add 2 to weapon destiny");
+            boolean staySharpNow = scn.LSAnyDecisionsAvailable() && staySharpBonusActionAvailable(scn);
+            boolean concentrateNow = scn.LSAnyDecisionsAvailable() && concentrateAllFireRedrawActionAvailable(scn);
+
+            if (staySharpNow && concentrateNow) {
+                result.staySharpOffered++;
+                if (result.concentrateAllFireTaken > 0) {
+                    result.staySharpOfferedAfterConcentrateAllFire++;
+                }
+                if (takeConcentrateAllFireOnce && result.concentrateAllFireTaken == 0 && !preferStaySharpFirst) {
+                    scn.LSChooseAction(CONCENTRATE_ALL_FIRE_REDRAW_TEXT);
+                    result.concentrateAllFireTaken++;
+                    continue;
+                }
+                boolean takeStaySharp = (result.staySharpOffered == 1) ? takeFirstStaySharpOffer : takeLaterStaySharpOffers;
+                if (takeStaySharp) {
+                    scn.LSChooseAction(STAY_SHARP_BONUS_TEXT);
+                    result.staySharpAccepted++;
+                    continue;
+                }
+                if (takeConcentrateAllFireOnce && result.concentrateAllFireTaken == 0) {
+                    scn.LSChooseAction(CONCENTRATE_ALL_FIRE_REDRAW_TEXT);
+                    result.concentrateAllFireTaken++;
+                    continue;
+                }
+                scn.LSDecline();
+                continue;
+            }
+
+            if (staySharpNow) {
+                result.staySharpOffered++;
+                if (result.concentrateAllFireTaken > 0) {
+                    result.staySharpOfferedAfterConcentrateAllFire++;
+                }
+                boolean takeStaySharp = (result.staySharpOffered == 1) ? takeFirstStaySharpOffer : takeLaterStaySharpOffers;
+                if (takeStaySharp) {
+                    scn.LSChooseAction(STAY_SHARP_BONUS_TEXT);
+                    result.staySharpAccepted++;
                 }
                 else {
                     scn.LSDecline();
                 }
+                continue;
+            }
+
+            if (concentrateNow && takeConcentrateAllFireOnce && result.concentrateAllFireTaken == 0) {
+                scn.LSChooseAction(CONCENTRATE_ALL_FIRE_REDRAW_TEXT);
+                result.concentrateAllFireTaken++;
                 continue;
             }
 
@@ -208,16 +315,30 @@ public class Card_7_104_Tests {
             }
 
             throw new AssertionError("No pending decision while firing Heavy Turbolaser Battery after "
-                    + i + " steps; Stay Sharp offers seen: " + offered + "; seen=" + seen);
+                    + i + " steps; Stay Sharp offers seen: " + result.staySharpOffered + "; seen=" + seen);
         }
         throw new AssertionError("Did not finish firing Heavy Turbolaser Battery. Stay Sharp offers seen: "
-                + offered + "; last decision: " + describeDecisions(scn));
+                + result.staySharpOffered + "; last decision: " + describeDecisions(scn));
     }
 
     /**
-     * True if Light Side currently has the Stay Sharp optional to add 2 to weapon destiny.
+     * True if Light Side currently has the Stay Sharp optional to add 2 to total weapon destiny.
      */
     private boolean staySharpBonusActionAvailable(VirtualTableScenario scn) {
+        return actionTextContains(scn, STAY_SHARP_BONUS_TEXT);
+    }
+
+    /**
+     * True if Light Side currently has Concentrate All Fire's cancel and redraw optional.
+     */
+    private boolean concentrateAllFireRedrawActionAvailable(VirtualTableScenario scn) {
+        return actionTextContains(scn, CONCENTRATE_ALL_FIRE_REDRAW_TEXT);
+    }
+
+    /**
+     * True if any Light Side action label contains the given text.
+     */
+    private boolean actionTextContains(VirtualTableScenario scn, String needle) {
         if (!scn.LSAnyDecisionsAvailable()) {
             return false;
         }
@@ -227,7 +348,7 @@ public class Card_7_104_Tests {
             return false;
         }
         for (String text : actionTexts) {
-            if (text != null && text.contains("Add 2 to weapon destiny")) {
+            if (text != null && text.contains(needle)) {
                 return true;
             }
         }
@@ -261,5 +382,24 @@ public class Card_7_104_Tests {
         assertEquals("Imperial-Class Star Destroyer must still be at the system after a miss",
                 Zone.AT_LOCATION, destroyer.getZone());
         assertEquals(0, scn.GetDSLostPileCount());
+    }
+
+    /**
+     * With destinies 2 and 4 vs capital, Stay Sharp +2 makes total 7, which hits armor 6.
+     * Without the +2 the total is 5 and would miss, so a miss here means the bonus was lost.
+     */
+    private void assertTargetWasHitByStaySharpPlusTwoAfterRedraw(VirtualTableScenario scn, PhysicalCardImpl destroyer) {
+        assertTrue("Imperial-Class Star Destroyer must be hit; Stay Sharp +2 should still apply after Concentrate All Fire redraw",
+                destroyer.isHit() || destroyer.getZone() == Zone.LOST_PILE || scn.GetDSLostPileCount() > 0);
+    }
+
+    /**
+     * Counts Stay Sharp and Concentrate All Fire choices while Heavy Turbolaser Battery is firing.
+     */
+    private static class StaySharpFiringResult {
+        int staySharpOffered;
+        int staySharpAccepted;
+        int staySharpOfferedAfterConcentrateAllFire;
+        int concentrateAllFireTaken;
     }
 }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set7/light/Card_7_104_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set7/light/Card_7_104_Tests.java
@@ -15,6 +15,7 @@ import com.gempukku.swccgo.game.PhysicalCardImpl;
 import org.junit.Test;
 
 import java.util.HashMap;
+import java.util.ArrayList;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -77,7 +78,12 @@ public class Card_7_104_Tests {
         assertTrue(card.getCardTypes().contains(CardType.INTERRUPT));
         assertEquals(CardSubtype.USED, card.getCardSubtype());
         assertEquals(4, card.getDestiny(), scn.epsilon);
-        assertEquals(1, card.getIconCount(Icon.SPECIAL_EDITION));
+        scn.BlueprintIconCheck(card, new ArrayList<>() {{
+            add(Icon.INTERRUPT);
+            add(Icon.SPECIAL_EDITION);
+        }});
+        scn.BlueprintKeywordCheck(card, new ArrayList<>() {{
+        }});
         assertEquals(ExpansionSet.SPECIAL_EDITION, card.getExpansionSet());
         assertEquals(Rarity.U, card.getRarity());
     }


### PR DESCRIPTION
Two Stay Sharp! fixes: Advanced Rulebook errata text (Java + JSON), and a bug where the +2 could stack onto each Heavy Turbolaser Battery destiny draw instead of applying once to the total weapon destiny.

## 1. Errata gametext
GEMP Java `setGameText` and JSON (`7_104` in `card_blueprint_database.json` and `card_blueprint_database_light.json`) were still on the old wording (*may add 2 to destiny draw*). They now match the [2023 Advanced Rulebook](https://res.starwarsccg.org/rules/SWCCG_2023_AdvancedRulebook.pdf):

> During your control phase, fire one of your starship weapons (for free). If Han or any gunner is aboard that starship, may add 2 to the total weapon destiny. 'Hit' target is lost. OR If you just fired a weapon in battle, add that weapon's destiny number to your total power.

## 2. Total weapon destiny stacking bug
Heavy Turbolaser Battery draws two destinies. Stay Sharp was using `ModifyDestinyEffect` (per-draw), so the optional "Add 2" after each draw could stack to +4. The errata adds 2 to the **total** weapon destiny once.

- Optional is still offered after each weapon destiny draw of that Stay Sharp firing until it is accepted once. Declining the first draw still offers it on the second (or on a Concentrate All Fire redraw). Accepting it does not offer it again, and the same bonus cannot stack to +4.
- The +2 is applied with `ModifyTotalWeaponDestinyBeforeDrawingDestinyEffect` (until-end-of-weapon-firing `TotalWeaponDestinyModifier`), so it survives a canceled/redrawn individual destiny.
- Han/gunner is checked on the firing starship at fire time (Stay Sharp is already off table).
- Card-level only (`Card7_104`). No engine cumulative changes, and no Targeting Computer / Combined Attack / Local Trouble / Frustration edits.

## Tests
`Card_7_104_Tests` (5 tests, 0 fail via docker Maven). Latest: [`c63adef`](https://github.com/PlayersCommittee/gemp-swccg-public/commit/c63adef74e3c357cb3b2788a07e35b47f52e3f3d).

- [x] `StaySharpStatsAndKeywordsAreCorrect`
- [x] `StaySharpHeavyTurbolaserBatteryCannotStackPlusFourToHitDuringControlPhase` — take +2 whenever offered. Destinies 1 then 3 vs Imperial-Class Star Destroyer armor 6: base `1+3-1=3`; +2 = 5 miss; +4 = 7 would hit (`>` defense). Assert the Destroyer is **not** hit.
- [x] `StaySharpPlusTwoStillOfferedOnSecondDrawIfDeclinedOnFirst` — decline on draw 1, accept on draw 2, still only +2 (same miss).
- [x] `StaySharpPlusTwoSurvivesConcentrateAllFireRedrawAfterAccept` — accept Stay Sharp +2 after the first draw, then Concentrate All Fire (`9_3`) cancels and redraws that destiny. Final destinies 2 then 4: `2+4-1=5` miss without the bonus, `7` hits armor 6. Assert hit, offer-once, no +4 stack.
- [x] `StaySharpStillOfferedAfterConcentrateAllFireRedrawIfNotYetAccepted` — skip Stay Sharp by taking Concentrate All Fire first; Stay Sharp is still offered on the redraw and accepted once; same hit math.

---
Tests follow VHD/PlayersCommittee naming (method names lead with card title + behavior; exclusive BlueprintIconCheck/KeywordCheck where applicable).