### PR TITLE
Fix Cumulative Rule in the modifier engine (issues 38 and 697)

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set112/dark/Card112_013.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set112/dark/Card112_013.java
@@ -6,6 +6,7 @@ import com.gempukku.swccgo.cards.conditions.DrivingCondition;
 import com.gempukku.swccgo.cards.effects.AddBattleDestinyEffect;
 import com.gempukku.swccgo.cards.effects.usage.OncePerTurnEffect;
 import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.GameTextActionId;
 import com.gempukku.swccgo.common.Icon;
 import com.gempukku.swccgo.common.Keyword;
 import com.gempukku.swccgo.common.Rarity;
@@ -46,7 +47,9 @@ public class Card112_013 extends AbstractAlien {
         List<Modifier> modifiers = new LinkedList<Modifier>();
         modifiers.add(new AddsPowerToPilotedBySelfModifier(self, 2));
         modifiers.add(new AddsPowerToDrivenBySelfModifier(self, 2));
-        modifiers.add(new AddsBattleDestinyModifier(self, new DrivingCondition(self, Filters.transport_vehicle), 1, self.getOwner()));
+        AddsBattleDestinyModifier drivingDestiny = new AddsBattleDestinyModifier(self, new DrivingCondition(self, Filters.transport_vehicle), 1, self.getOwner());
+        drivingDestiny.setClauseIdentity(GameTextActionId.OTHER_CARD_ACTION_1);
+        modifiers.add(drivingDestiny);
         return modifiers;
     }
 
@@ -54,11 +57,11 @@ public class Card112_013 extends AbstractAlien {
     protected List<RequiredGameTextTriggerAction> getGameTextRequiredAfterTriggers(SwccgGame game, EffectResult effectResult, PhysicalCard self, int gameTextSourceCardId) {
         // Check condition(s)
         if (TriggerConditions.battleInitiatedAt(game, effectResult, Filters.and(Filters.exterior_site, Filters.relatedSite(self)))
-                && GameConditions.isOncePerTurn(game, self, gameTextSourceCardId)
+                && GameConditions.isOncePerTurn(game, self, gameTextSourceCardId, GameTextActionId.OTHER_CARD_ACTION_2)
                 && GameConditions.isPilotingAt(game, self, Filters.cloud_sector)
                 && GameConditions.canAddBattleDestinyDraws(game, self)) {
 
-            final RequiredGameTextTriggerAction action = new RequiredGameTextTriggerAction(self, gameTextSourceCardId);
+            final RequiredGameTextTriggerAction action = new RequiredGameTextTriggerAction(self, gameTextSourceCardId, GameTextActionId.OTHER_CARD_ACTION_2);
             action.setText("Add one battle destiny");
             // Update usage limit(s)
             action.appendUsage(

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set112/dark/Card112_013.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set112/dark/Card112_013.java
@@ -16,7 +16,7 @@ import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.game.SwccgGame;
 import com.gempukku.swccgo.logic.TriggerConditions;
-import com.gempukku.swccgo.logic.actions.RequiredGameTextTriggerAction;
+import com.gempukku.swccgo.logic.actions.OptionalGameTextTriggerAction;
 import com.gempukku.swccgo.logic.modifiers.AddsBattleDestinyModifier;
 import com.gempukku.swccgo.logic.modifiers.AddsPowerToDrivenBySelfModifier;
 import com.gempukku.swccgo.logic.modifiers.AddsPowerToPilotedBySelfModifier;
@@ -37,7 +37,7 @@ public class Card112_013 extends AbstractAlien {
     public Card112_013() {
         super(Side.DARK, 2, 2, 2, 1, 3, "Mercenary Pilot", Uniqueness.UNRESTRICTED, ExpansionSet.JPSD, Rarity.PM);
         setLore("Smugglers. Candidates who resent authority often abandon Imperial academies to sell their piloting skills to criminals. Will work for any high paying crime syndicate.");
-        setGameText("Adds 2 to power of anything he pilots or drives. When driving a transport vehicle, adds one battle destiny. When piloting at a cloud sector, once per turn adds one battle destiny during battle at a related exterior site.");
+        setGameText("Adds 2 to power of anything he pilots or drives. When driving a transport vehicle, adds one battle destiny. When piloting at a cloud sector, once per turn may add one battle destiny during battle at a related exterior site.");
         addIcons(Icon.PREMIUM, Icon.PILOT, Icon.WARRIOR);
         addKeywords(Keyword.MERCENARY, Keyword.SMUGGLER);
     }
@@ -54,14 +54,14 @@ public class Card112_013 extends AbstractAlien {
     }
 
     @Override
-    protected List<RequiredGameTextTriggerAction> getGameTextRequiredAfterTriggers(SwccgGame game, EffectResult effectResult, PhysicalCard self, int gameTextSourceCardId) {
+    protected List<OptionalGameTextTriggerAction> getGameTextOptionalAfterTriggers(final String playerId, SwccgGame game, EffectResult effectResult, PhysicalCard self, int gameTextSourceCardId) {
         // Check condition(s)
         if (TriggerConditions.battleInitiatedAt(game, effectResult, Filters.and(Filters.exterior_site, Filters.relatedSite(self)))
-                && GameConditions.isOncePerTurn(game, self, gameTextSourceCardId, GameTextActionId.OTHER_CARD_ACTION_2)
+                && GameConditions.isOncePerTurn(game, self, playerId, gameTextSourceCardId, GameTextActionId.OTHER_CARD_ACTION_2)
                 && GameConditions.isPilotingAt(game, self, Filters.cloud_sector)
                 && GameConditions.canAddBattleDestinyDraws(game, self)) {
 
-            final RequiredGameTextTriggerAction action = new RequiredGameTextTriggerAction(self, gameTextSourceCardId, GameTextActionId.OTHER_CARD_ACTION_2);
+            final OptionalGameTextTriggerAction action = new OptionalGameTextTriggerAction(self, gameTextSourceCardId, GameTextActionId.OTHER_CARD_ACTION_2);
             action.setText("Add one battle destiny");
             // Update usage limit(s)
             action.appendUsage(

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set4/light/Card4_014.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set4/light/Card4_014.java
@@ -63,20 +63,19 @@ public class Card4_014 extends AbstractCharacterDevice {
                 )
         );
 
-        modifiers.add(
-                new ManeuverModifier(
+        ManeuverModifier matchingPilotManeuver = new ManeuverModifier(
                         //The pilot is marked as the source of the +2 maneuver so that it gets limited alongside any
                         // other maneuver bonus that they provide due to the "limit +2" clause.
                         self.getAttachedTo(),
                         Filters.hasPiloting(self, Filters.hasAttached(self)),
                         new OnTableCondition(self, AttachedPilotMatchesShip(self)),
                         2,
-                        //Although this is not a true cumulative modifier, because we are pretending that this is
-                        // "from" the pilot and not the flight suit, we do not want to run awry of the cumulative
-                        // rule stomping out one of the maneuver bonuses due to being "from" the same source.
-                        true
-                )
-        );
+                        false
+                );
+        // Distinct from the pilot's own printed maneuver bonus so both may apply, then the limit +2 caps them.
+        // Two copies of Rebel Flight Suit on two pilots of the same title still share this clause and do not stack.
+        matchingPilotManeuver.setClauseIdentity("REBEL_FLIGHT_SUIT_MATCHING_PILOT_MANEUVER");
+        modifiers.add(matchingPilotManeuver);
 
         modifiers.add(
                 new ManeuverLimitFromPilotModifier(

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/AddModifierWithDurationEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/AddModifierWithDurationEffect.java
@@ -23,6 +23,9 @@ abstract class AddModifierWithDurationEffect extends AbstractSuccessfulEffect {
         super(action);
         _modifier = modifier;
         _actionMsg = actionMsg;
+        if (_modifier != null) {
+            _modifier.applyClauseIdentityFromAction(action);
+        }
     }
 
     protected String getMsgText(SwccgGame game) {

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/ModifyPowerUntilEndOfBattleEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/ModifyPowerUntilEndOfBattleEffect.java
@@ -71,8 +71,9 @@ public class ModifyPowerUntilEndOfBattleEffect extends AbstractSuccessfulEffect 
         // Filter for same card while it is in play
         Filter cardFilter = Filters.and(Filters.sameCardId(_cardToModify), Filters.in_play);
 
-        modifiersEnvironment.addUntilEndOfBattleModifier(
-                new PowerModifier(source, cardFilter, _modifierAmount));
+        PowerModifier powerModifier = new PowerModifier(source, cardFilter, _modifierAmount);
+        powerModifier.applyClauseIdentityFromAction(_action);
+        modifiersEnvironment.addUntilEndOfBattleModifier(powerModifier);
 
         actionsEnvironment.emitEffectResult(new ResetOrModifyCardAttributeResult(performingPlayerId, _cardToModify));
     }

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/ModifyPowerUntilEndOfTurnEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/ModifyPowerUntilEndOfTurnEffect.java
@@ -84,8 +84,9 @@ public class ModifyPowerUntilEndOfTurnEffect extends AbstractSuccessfulEffect {
         // Filter for same card while it is in play
         Filter cardFilter = Filters.and(Filters.sameCardId(_cardToModify), Filters.in_play);
 
-        modifiersEnvironment.addUntilEndOfTurnModifier(
-                new PowerModifier(source, cardFilter, _modifierAmount, _cumulatively));
+        PowerModifier powerModifier = new PowerModifier(source, cardFilter, _modifierAmount, _cumulatively);
+        powerModifier.applyClauseIdentityFromAction(_action);
+        modifiersEnvironment.addUntilEndOfTurnModifier(powerModifier);
 
         actionsEnvironment.emitEffectResult(new ResetOrModifyCardAttributeResult(performingPlayerId, _cardToModify));
     }

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/AbstractModifier.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/AbstractModifier.java
@@ -18,6 +18,7 @@ import com.gempukku.swccgo.game.state.GameState;
 import com.gempukku.swccgo.logic.conditions.AndCondition;
 import com.gempukku.swccgo.logic.conditions.Condition;
 import com.gempukku.swccgo.logic.modifiers.querying.ModifiersQuerying;
+import com.gempukku.swccgo.logic.actions.GameTextAction;
 import com.gempukku.swccgo.logic.timing.Action;
 
 import java.util.Collection;
@@ -35,6 +36,11 @@ public abstract class AbstractModifier implements Modifier {
     private boolean _fromPermanentPilot;
     private boolean _fromPermanentAstromech;
     private boolean _cumulative;
+    /**
+     * Which portion of the source card's game text produced this modifier.
+     * Null is the default clause for this title and modifier type.
+     */
+    private String _clauseIdentity;
     private boolean _persistent;
     private boolean _skipSettingNotRemovedOnRestoreToNormal;
     private boolean _notRemovedOnRestoreToNormal;
@@ -125,6 +131,39 @@ public abstract class AbstractModifier implements Modifier {
     @Override
     public boolean isCumulative() {
         return _cumulative;
+    }
+
+    @Override
+    public void setCumulative(boolean value) {
+        _cumulative = value;
+    }
+
+    @Override
+    public String getClauseIdentity() {
+        return _clauseIdentity;
+    }
+
+    @Override
+    public void setClauseIdentity(String clauseIdentity) {
+        _clauseIdentity = clauseIdentity;
+    }
+
+    @Override
+    public void setClauseIdentity(GameTextActionId gameTextActionId) {
+        _clauseIdentity = gameTextActionId != null ? gameTextActionId.name() : null;
+    }
+
+    @Override
+    public void applyClauseIdentityFromAction(Action action) {
+        if (_clauseIdentity != null) {
+            return;
+        }
+        if (action instanceof GameTextAction) {
+            GameTextActionId gameTextActionId = ((GameTextAction) action).getGameTextActionId();
+            if (gameTextActionId != null) {
+                _clauseIdentity = gameTextActionId.name();
+            }
+        }
     }
 
     @Override

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/Modifier.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/Modifier.java
@@ -44,6 +44,33 @@ public interface Modifier {
     void setFromPermanentAstromech(boolean value);
     boolean isFromPermanentAstromech();
     boolean isCumulative();
+    void setCumulative(boolean value);
+
+    /**
+     * Identifies which portion of a card's game text produced this modifier.
+     * Null means the default unspecified clause for this card title and modifier type.
+     * Same title + type + clause may not stack unless the modifier is marked Cumulatively.
+     */
+    String getClauseIdentity();
+
+    /**
+     * Sets the game-text clause this modifier came from. Use this when two portions of
+     * the same title produce the same modifier type and should both be allowed to apply.
+     */
+    void setClauseIdentity(String clauseIdentity);
+
+    /**
+     * Sets the game-text clause from a GameTextActionId. Action-created modifiers often
+     * share this id so a second application of the same text (for example Concentrate All Fire)
+     * is recognized as the same clause.
+     */
+    void setClauseIdentity(GameTextActionId gameTextActionId);
+
+    /**
+     * If this modifier has no clause yet, copy the GameTextActionId off the action that created it.
+     */
+    void applyClauseIdentityFromAction(Action action);
+
     String getText(GameState gameState, ModifiersQuerying modifiersQuerying, PhysicalCard self);
     ModifierType getModifierType();
     Condition getCondition();

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/ModifiersLogic.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/ModifiersLogic.java
@@ -2752,68 +2752,65 @@ public class ModifiersLogic implements ModifiersEnvironment, ModifiersState, Mod
         return result;
     }
 
+    /**
+     * Returns true when adding modifier would violate the Cumulative Rule against modifiers
+     * already kept in modifierList.
+     *
+     * No modifiers stack unless they say Cumulatively. Multiple copies of a card, or multiple
+     * applications of the same game-text clause, may not increasingly modify the same thing.
+     * Different portions of the same title's game text are different clauses and may both apply.
+     */
     private boolean foundCumulativeConflict(GameState gameState, Collection<Modifier> modifierList, Modifier modifier) {
-        // If modifier is not cumulative, then check if modifiers from another copy
-        // card of same title is already in the list
-        if (!modifier.isCumulative() && modifier.getSource(gameState) != null) {
+        if (modifier.isCumulative()) {
+            return false;
+        }
 
-            ModifierType modifierType = modifier.getModifierType();
-            String cardTitle = modifier.getSource(gameState).getTitle();
-            String forPlayer = modifier.getForPlayer();
-            Icon icon = modifier.getIcon();
+        PhysicalCard source = modifier.getSource(gameState);
+        if (source == null) {
+            return false;
+        }
 
-            for (Modifier liveModifier : modifierList) {
-                if (
-                        // Modifiers that affect different things cannot be said to be cumulative in any sense
-                        liveModifier.getModifierType() == modifierType
-                        // Non-card modifiers must be from a game rule, and those cannot violate the cumulative rule.
-                        && liveModifier.getSource(gameState) != null
-                        && (
-                                liveModifier.isFromPermanentPilot() == modifier.isFromPermanentPilot()
-                                && liveModifier.isFromPermanentAstromech() == modifier.isFromPermanentAstromech())
-                                // The cumulative rule is all about 'copies" of the same card, which is to say cards
-                                // with the same title.
-                                && liveModifier.getSource(gameState).getTitle().equals(cardTitle)
-                                && (
-                                        //Non-unique cards with the same title and same modifier type are the main
-                                        // reason the cumulative rule exists at all.
-                                        modifier.getSource(gameState).getBlueprint().getUniqueness() != Uniqueness.UNIQUE
-                                        || liveModifier.getSource(gameState).getBlueprint().getUniqueness() != Uniqueness.UNIQUE
-                                        //This is for checking for persistent modifiers that were emitted by a previous
-                                        // incarnation of a unique card.  For example, if a unique card modifies a force
-                                        // drain amount and then leaves play and re-enters, they are considered a new
-                                        // card, but since another "copy" of that card already modified the force drain
-                                        // amount, the new one cannot also alter it without violating the cumulative rule.
-                                        || modifier.getSource(gameState).getCardId() != liveModifier.getSource(gameState).getCardId()
+        ModifierType modifierType = modifier.getModifierType();
+        String cardTitle = source.getTitle();
+        String forPlayer = modifier.getForPlayer();
+        Icon icon = modifier.getIcon();
+        String clauseIdentity = modifier.getClauseIdentity();
+        boolean fromPermanentPilot = modifier.isFromPermanentPilot();
+        boolean fromPermanentAstromech = modifier.isFromPermanentAstromech();
 
-                                        /*
-                                        The above section is the reason for the Rebel Flight Suit failure when you attach
-                                        2 copies of it to 2 different Ralltiir Freighter Captains on the same ship.
-                                        Either RFS marks its maneuver modifier as cumulative and you end up with two +2
-                                        bonuses from nonuniques, or you mark it as non-cumulative and the pilot's own +1
-                                        crushes the RFS +2 for cumulative reasons.
-
-                                        This entire for loop should be broken up to use fewer && checks and more standalone
-                                        if blocks in the future. (Use "continue" upon finding a relationship that can't
-                                        possibly be cumulative rather than endlessly chaining.)
-
-                                        This subsection should then be broken up into two categories:
-                                        - a check for both sources being unique
-                                            - same current id is the same card with two different unrelated modifiers that should combine
-                                            - different current id is a past life invocation that violates cumulative
-                                        - a check for both sources being nonunique:
-                                            - same permanent id is the same card with two different unrelated modifiers that should combine
-                                            - different permanent ids are two different cards violating cumulative
-
-                                         */
-                                )
-                                // Presumably cards with the same title on different sides do not interfere cumulatively
-                                && liveModifier.isForPlayer(forPlayer)
-                                && liveModifier.getIcon() == icon
-                        ) {
-                    return true;
-                }
+        for (Modifier liveModifier : modifierList) {
+            PhysicalCard liveSource = liveModifier.getSource(gameState);
+            if (liveSource == null) {
+                continue;
             }
+            if (liveModifier.getModifierType() != modifierType) {
+                continue;
+            }
+            if (liveModifier.isFromPermanentPilot() != fromPermanentPilot) {
+                continue;
+            }
+            if (liveModifier.isFromPermanentAstromech() != fromPermanentAstromech) {
+                continue;
+            }
+            if (!liveSource.getTitle().equals(cardTitle)) {
+                continue;
+            }
+            if (!liveModifier.isForPlayer(forPlayer)) {
+                continue;
+            }
+            if (liveModifier.getIcon() != icon) {
+                continue;
+            }
+            // Issue 697: different game-text clauses of the same title may both apply.
+            if (!java.util.Objects.equals(liveModifier.getClauseIdentity(), clauseIdentity)) {
+                continue;
+            }
+
+            // Same clause and not cumulative: this is a conflict.
+            // Unique same cardId, same clause twice is Concentrate All Fire firing twice.
+            // Unique different cardId is a past-life persistent modifier from the same title.
+            // Nonunique different copies is Sandcrawler / Targeting Computer / two Rebel Flight Suits.
+            return true;
         }
         return false;
     }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/dark/Card_1_309_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/dark/Card_1_309_Tests.java
@@ -1,0 +1,81 @@
+package com.gempukku.swccgo.cards.set1.dark;
+
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+
+public class Card_1_309_Tests {
+    /**
+     * Sandcrawler adds 1 to forfeit of each Jawa at the same exterior site.
+     * That bonus does not say Cumulatively, so extra copies still add only 1.
+     */
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("luke", "1_19");
+                }},
+                new HashMap<>() {{
+                    put("crawler1", "1_309");
+                    put("crawler2", "1_309");
+                    put("crawler3", "1_309");
+                    put("jawa", "1_182");
+                    put("driver1", "1_169");
+                    put("driver2", "1_169");
+                    put("driver3", "1_169");
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void SandcrawlerStatsAreCorrect() {
+        var scn = GetScenario();
+        var card = scn.GetDSCard("crawler1").getBlueprint();
+        assertEquals("Sandcrawler", card.getTitle());
+        assertEquals(Uniqueness.UNRESTRICTED, card.getUniqueness());
+    }
+
+    /**
+     * One Sandcrawler makes a Jawa forfeit 2 (printed 1 plus 1).
+     * Three Sandcrawlers at the same exterior site still make that Jawa forfeit 2, not 4.
+     */
+    @Test
+    public void SandcrawlerJawaForfeitBonusDoesNotStackFromMultipleCopies() {
+        var scn = GetScenario();
+
+        var crawler1 = scn.GetDSCard("crawler1");
+        var crawler2 = scn.GetDSCard("crawler2");
+        var crawler3 = scn.GetDSCard("crawler3");
+        var jawa = scn.GetDSCard("jawa");
+        var driver1 = scn.GetDSCard("driver1");
+        var driver2 = scn.GetDSCard("driver2");
+        var driver3 = scn.GetDSCard("driver3");
+        var site = scn.GetDSStartingLocation();
+
+        scn.StartGame();
+
+        scn.MoveCardsToLocation(site, crawler1, crawler2, crawler3, jawa);
+        scn.BoardAsPilot(crawler1, driver1);
+        scn.BoardAsPilot(crawler2, driver2);
+        scn.BoardAsPilot(crawler3, driver3);
+
+        scn.SkipToPhase(Phase.CONTROL);
+
+        // Jawa printed forfeit 1, plus 1 from Sandcrawler, not plus 3 from three copies
+        assertEquals(2, scn.GetForfeit(jawa));
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_064_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_064_Tests.java
@@ -1,0 +1,81 @@
+package com.gempukku.swccgo.cards.set1.light;
+
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.PlayCardOptionId;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+
+public class Card_1_064_Tests {
+    /**
+     * Sai'torr Kal Fas (1_64) is an unrestricted Effect. Deployed on a warrior it is power +1.
+     * That bonus does not say Cumulatively, so extra copies still add only 1.
+     */
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("luke", "1_19");
+                    put("skf1", "1_64");
+                    put("skf2", "1_64");
+                    put("skf3", "1_64");
+                    put("skf4", "1_64");
+                }},
+                new HashMap<>() {{
+                    put("vader", "1_168");
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void SaitorrKalFasStatsAreCorrect() {
+        var scn = GetScenario();
+        var card = scn.GetLSCard("skf1").getBlueprint();
+        assertEquals("Sai'torr Kal Fas", card.getTitle());
+        assertEquals(Uniqueness.UNRESTRICTED, card.getUniqueness());
+    }
+
+    /**
+     * Luke Skywalker (1_19) is a Light warrior with printed power 3.
+     * Four copies of Sai'torr Kal Fas (1_64) on him still add only 1 power, not 4.
+     * AttachCardsTo resets play option, so option 2 (Deploy on warrior) is set after attach.
+     */
+    @Test
+    public void SaitorrKalFasWarriorPowerBonusDoesNotStackFromFourCopies() {
+        var scn = GetScenario();
+
+        var luke = scn.GetLSCard("luke");
+        var skf1 = scn.GetLSCard("skf1");
+        var skf2 = scn.GetLSCard("skf2");
+        var skf3 = scn.GetLSCard("skf3");
+        var skf4 = scn.GetLSCard("skf4");
+        var site = scn.GetLSStartingLocation();
+
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, luke);
+
+        scn.AttachCardsTo(luke, skf1, skf2, skf3, skf4);
+        skf1.setPlayCardOptionId(PlayCardOptionId.PLAY_CARD_OPTION_2);
+        skf2.setPlayCardOptionId(PlayCardOptionId.PLAY_CARD_OPTION_2);
+        skf3.setPlayCardOptionId(PlayCardOptionId.PLAY_CARD_OPTION_2);
+        skf4.setPlayCardOptionId(PlayCardOptionId.PLAY_CARD_OPTION_2);
+
+        scn.SkipToPhase(Phase.CONTROL);
+
+        // Luke printed power 3, plus 1 from Sai'torr Kal Fas, not plus 4 from four copies
+        assertEquals(4, scn.GetPower(luke));
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set112/dark/Card_112_013_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set112/dark/Card_112_013_Tests.java
@@ -1,0 +1,117 @@
+package com.gempukku.swccgo.cards.set112.dark;
+
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Card_112_013_Tests {
+    /**
+     * Mercenary Pilot has two different battle-destiny texts: driving a transport, and piloting at a cloud sector.
+     * Those are different game-text clauses. The same clause from two copies still does not stack.
+     */
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("luke", "1_19");
+                    put("ywing", "1_147");
+                    put("clouds", "5_85");
+                    put("platform", "5_83");
+                }},
+                new HashMap<>() {{
+                    put("pilot1", "112_13");
+                    put("pilot2", "112_13");
+                    put("crawler1", "1_309");
+                    put("crawler2", "1_309");
+                    put("tie", "1_304");
+                    put("bespin", "5_164");
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void MercenaryPilotStatsAreCorrect() {
+        var scn = GetScenario();
+        var card = scn.GetDSCard("pilot1").getBlueprint();
+        assertEquals("Mercenary Pilot", card.getTitle());
+        assertEquals(Uniqueness.UNRESTRICTED, card.getUniqueness());
+    }
+
+    /**
+     * Two Mercenary Pilots both driving transports add only one battle destiny.
+     * The driving text is one clause and does not say Cumulatively.
+     */
+    @Test
+    public void MercenaryPilotDrivingBattleDestinyDoesNotStackFromTwoCopies() {
+        var scn = GetScenario();
+
+        var pilot1 = scn.GetDSCard("pilot1");
+        var pilot2 = scn.GetDSCard("pilot2");
+        var crawler1 = scn.GetDSCard("crawler1");
+        var crawler2 = scn.GetDSCard("crawler2");
+        var luke = scn.GetLSCard("luke");
+        var site = scn.GetDSStartingLocation();
+
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, crawler1, crawler2, luke);
+        scn.BoardAsPilot(crawler1, pilot1);
+        scn.BoardAsPilot(crawler2, pilot2);
+
+        scn.SkipToPhase(Phase.BATTLE);
+        scn.DSInitiateBattle(site);
+        scn.SkipToPowerSegment();
+
+        assertTrue(scn.DSDecisionAvailable("Do you want to draw 1 battle destiny?"));
+        assertFalse(scn.DSDecisionAvailable("Do you want to draw 2 battle destiny?"));
+    }
+
+    /**
+     * Issue 697: one copy driving a transport and one copy piloting at a related cloud sector
+     * are different game-text clauses, so both add a battle destiny.
+     * Battle is at Cloud City: Platform 327 (exterior) so the cloud-sector required trigger can fire.
+     */
+    @Test
+    public void MercenaryPilotDrivingAndCloudSectorTextsBothAddBattleDestiny() {
+        var scn = GetScenario();
+
+        var pilot1 = scn.GetDSCard("pilot1");
+        var pilot2 = scn.GetDSCard("pilot2");
+        var crawler = scn.GetDSCard("crawler1");
+        var tie = scn.GetDSCard("tie");
+        var clouds = scn.GetLSCard("clouds");
+        var bespin = scn.GetDSCard("bespin");
+        var luke = scn.GetLSCard("luke");
+        var site = scn.GetLSCard("platform");
+
+        scn.StartGame();
+        scn.MoveLocationToTable(bespin);
+        scn.MoveLocationToTable(clouds);
+        scn.MoveLocationToTable(site);
+        scn.MoveCardsToLocation(site, crawler, luke);
+        scn.BoardAsPilot(crawler, pilot1);
+        scn.MoveCardsToLocation(clouds, tie);
+        scn.BoardAsPilot(tie, pilot2);
+
+        scn.SkipToPhase(Phase.BATTLE);
+        scn.DSInitiateBattle(site);
+        scn.SkipToPowerSegment();
+
+        assertTrue(scn.DSDecisionAvailable("Do you want to draw 2 battle destiny?"));
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set112/dark/Card_112_013_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set112/dark/Card_112_013_Tests.java
@@ -4,6 +4,7 @@ import com.gempukku.swccgo.common.Phase;
 import com.gempukku.swccgo.common.Uniqueness;
 import com.gempukku.swccgo.framework.StartingSetup;
 import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.game.PhysicalCardImpl;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -84,7 +85,8 @@ public class Card_112_013_Tests {
     /**
      * Issue 697: one copy driving a transport and one copy piloting at a related cloud sector
      * are different game-text clauses, so both add a battle destiny.
-     * Battle is at Cloud City: Platform 327 (exterior) so the cloud-sector required trigger can fire.
+     * Cloud-sector destiny is optional; the test accepts that popup.
+     * Battle is at Cloud City: Platform 327 (exterior).
      */
     @Test
     public void MercenaryPilotDrivingAndCloudSectorTextsBothAddBattleDestiny() {
@@ -108,10 +110,24 @@ public class Card_112_013_Tests {
         scn.MoveCardsToLocation(clouds, tie);
         scn.BoardAsPilot(tie, pilot2);
 
-        scn.SkipToPhase(Phase.BATTLE);
-        scn.DSInitiateBattle(site);
+        scn.SkipToDSTurn(Phase.BATTLE);
+        InitiateBattleKeepingStartResponses(scn, site);
+        assertTrue(scn.DSAnyDecisionsAvailable() && scn.DSCardActionAvailable(pilot2, "Add one battle destiny"));
+        scn.DSUseCardAction(pilot2, "Add one battle destiny");
         scn.SkipToPowerSegment();
 
         assertTrue(scn.DSDecisionAvailable("Do you want to draw 2 battle destiny?"));
+    }
+
+    /**
+     * Starts a Dark Side battle but leaves the battle-initiated optional window open so Mercenary Pilot can be clicked.
+     */
+    private void InitiateBattleKeepingStartResponses(VirtualTableScenario scn, PhysicalCardImpl location) {
+        assertTrue("Unable to initiate battle at location", scn.DSCanInitiateBattle(location));
+        scn.DSUseCardAction(location, "Initiate battle");
+        scn.PassForceUseResponses();
+        if (scn.LSDecisionAvailable("BATTLE_INITIATED")) {
+            scn.LSPass();
+        }
     }
 }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set12/dark/Card_12_101_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set12/dark/Card_12_101_Tests.java
@@ -1,0 +1,66 @@
+package com.gempukku.swccgo.cards.set12.dark;
+
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class Card_12_101_Tests {
+    /**
+     * Darth Maul, Young Apprentice is unique. His different modifier types must both apply.
+     * His Jedi Master power -3 uses the same until-end-of-battle path as Concentrate All Fire.
+     */
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("depa", "12_4");
+                    put("luke", "1_19");
+                }},
+                new HashMap<>() {{
+                    put("maul", "12_101");
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void DarthMaulYoungApprenticeStatsAreCorrect() {
+        var scn = GetScenario();
+        var card = scn.GetDSCard("maul").getBlueprint();
+        assertEquals("Darth Maul, Young Apprentice", card.getTitle());
+        assertEquals(Uniqueness.UNIQUE, card.getUniqueness());
+    }
+
+    /**
+     * A unique card can still apply two different modifier types at once.
+     * Maul is immune to attrition less than 5 and immune to Clash Of Sabers.
+     */
+    @Test
+    public void DarthMaulYoungApprenticeAppliesTwoDifferentModifierTypesTogether() {
+        var scn = GetScenario();
+
+        var maul = scn.GetDSCard("maul");
+        var site = scn.GetDSStartingLocation();
+
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, maul);
+
+        float immunity = scn.game().getModifiersQuerying().getImmunityToAttritionLessThan(scn.gameState(), maul);
+        assertEquals(5, immunity, scn.epsilon);
+        assertTrue(scn.game().getModifiersQuerying().isImmuneToCardTitle(scn.gameState(), maul, Title.Clash_Of_Sabers));
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set12/dark/Card_12_101_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set12/dark/Card_12_101_Tests.java
@@ -1,5 +1,6 @@
 package com.gempukku.swccgo.cards.set12.dark;
 
+import com.gempukku.swccgo.common.Phase;
 import com.gempukku.swccgo.common.Title;
 import com.gempukku.swccgo.common.Uniqueness;
 import com.gempukku.swccgo.framework.StartingSetup;
@@ -13,8 +14,9 @@ import static org.junit.Assert.assertTrue;
 
 public class Card_12_101_Tests {
     /**
-     * Darth Maul, Young Apprentice is unique. His different modifier types must both apply.
-     * His Jedi Master power -3 uses the same until-end-of-battle path as Concentrate All Fire.
+     * Darth Maul, Young Apprentice (12_101) is unique. His different modifier types must both apply.
+     * His Jedi Master power -3 uses the same until-end-of-battle path as Concentrate All Fire (9_003).
+     * Maul's Double-Bladed Lightsaber (13_75) can hit the same Jedi Master twice in one battle.
      */
     protected VirtualTableScenario GetScenario() {
         return new VirtualTableScenario(
@@ -24,6 +26,7 @@ public class Card_12_101_Tests {
                 }},
                 new HashMap<>() {{
                     put("maul", "12_101");
+                    put("saber", "13_75");
                 }},
                 10,
                 10,
@@ -47,7 +50,7 @@ public class Card_12_101_Tests {
 
     /**
      * A unique card can still apply two different modifier types at once.
-     * Maul is immune to attrition less than 5 and immune to Clash Of Sabers.
+     * Darth Maul, Young Apprentice (12_101) is immune to attrition less than 5 and immune to Clash Of Sabers.
      */
     @Test
     public void DarthMaulYoungApprenticeAppliesTwoDifferentModifierTypesTogether() {
@@ -62,5 +65,65 @@ public class Card_12_101_Tests {
         float immunity = scn.game().getModifiersQuerying().getImmunityToAttritionLessThan(scn.gameState(), maul);
         assertEquals(5, immunity, scn.epsilon);
         assertTrue(scn.game().getModifiersQuerying().isImmuneToCardTitle(scn.gameState(), maul, Title.Clash_Of_Sabers));
+    }
+
+    /**
+     * Maul's Double-Bladed Lightsaber (13_75) may fire twice per battle. If both hits land on the same
+     * Jedi Master (Depa Billaba (12_4)), that Master is power -3 once, not -6. The until-end-of-battle
+     * POWER clause is the same unique source, so the Cumulative Rule makes the second -3 conflict.
+     */
+    @Test
+    public void DarthMaulYoungApprenticeJediMasterPowerLossIsNotCumulativeFromTwoHitsInOneBattle() {
+        var scn = GetScenario();
+
+        var maul = scn.GetDSCard("maul");
+        var saber = scn.GetDSCard("saber");
+        var depa = scn.GetLSCard("depa");
+        var site = scn.GetDSStartingLocation();
+
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, maul, depa);
+        scn.AttachCardsTo(maul, saber);
+
+        scn.SkipToDSTurn(Phase.BATTLE);
+        assertTrue(scn.AwaitingDSBattlePhaseActions());
+        assertTrue(scn.GetDSForcePileCount() >= 1);
+        assertTrue(scn.DSCanInitiateBattle());
+        scn.DSInitiateBattle(site);
+
+        // Depa Billaba (12_4) printed power 4
+        assertEquals(4, scn.GetPower(depa));
+
+        scn.PrepareDSDestiny(7);
+        scn.PrepareDSDestiny(6);
+        assertTrue(scn.DSCardActionAvailable(saber));
+        scn.DSUseCardAction(saber);
+        assertTrue(scn.DSHasCardChoiceAvailable(depa));
+        scn.DSChooseCard(depa);
+        scn.PassAllResponses();
+        if (scn.DSDecisionAvailable("Reduce")) {
+            scn.DSDecided(0);
+            scn.PassAllResponses();
+        }
+
+        // First hit: printed 4 plus -3
+        assertEquals(1, scn.GetPower(depa));
+
+        scn.LSPass();
+
+        scn.PrepareDSDestiny(5);
+        scn.PrepareDSDestiny(4);
+        assertTrue(scn.DSCardActionAvailable(saber));
+        scn.DSUseCardAction(saber);
+        assertTrue(scn.DSHasCardChoiceAvailable(depa));
+        scn.DSChooseCard(depa);
+        scn.PassAllResponses();
+        if (scn.DSDecisionAvailable("Reduce")) {
+            scn.DSDecided(0);
+            scn.PassAllResponses();
+        }
+
+        // Same unique Maul POWER clause must not stack a second -3
+        assertEquals(1, scn.GetPower(depa));
     }
 }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/light/Card_2_019_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/light/Card_2_019_Tests.java
@@ -1,0 +1,70 @@
+package com.gempukku.swccgo.cards.set2.light;
+
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+
+public class Card_2_019_Tests {
+    /**
+     * Rebel Tech says Cumulatively adds 1 to total of Attack Run when at your war room.
+     * Three copies should add 3.
+     */
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("tech1", "2_19");
+                    put("tech2", "2_19");
+                    put("tech3", "2_19");
+                    put("warRoom", "1_139");
+                    put("attackRun", "2_42");
+                }},
+                new HashMap<>() {{
+                    put("vader", "1_168");
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void RebelTechStatsAreCorrect() {
+        var scn = GetScenario();
+        var card = scn.GetLSCard("tech1").getBlueprint();
+        assertEquals("Rebel Tech", card.getTitle());
+        assertEquals(Uniqueness.RESTRICTED_3, card.getUniqueness());
+    }
+
+    /**
+     * Three Rebel Techs at your war room each add 1 to Attack Run because the text says Cumulatively.
+     */
+    @Test
+    public void RebelTechAttackRunBonusStacksCumulativelyFromMultipleCopies() {
+        var scn = GetScenario();
+
+        var tech1 = scn.GetLSCard("tech1");
+        var tech2 = scn.GetLSCard("tech2");
+        var tech3 = scn.GetLSCard("tech3");
+        var warRoom = scn.GetLSCard("warRoom");
+        var attackRun = scn.GetLSCard("attackRun");
+
+        scn.StartGame();
+        scn.MoveLocationToTable(warRoom);
+        scn.MoveCardsToLocation(warRoom, tech1, tech2, tech3);
+        scn.MoveCardsToLSSideOfTable(attackRun);
+
+        float total = scn.game().getModifiersQuerying().getEpicEventCalculationTotal(scn.gameState(), attackRun, 0);
+        assertEquals(3, total, scn.epsilon);
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set4/light/Card_4_014_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set4/light/Card_4_014_Tests.java
@@ -4,7 +4,6 @@ import com.gempukku.swccgo.common.*;
 import com.gempukku.swccgo.framework.StartingSetup;
 import com.gempukku.swccgo.framework.VirtualTableScenario;
 import com.gempukku.swccgo.logic.modifiers.querying.Battle;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -331,7 +330,6 @@ public class Card_4_014_Tests {
         assertEquals(8, scn.GetManeuver(falcon));
     }
 
-    @Ignore("RFS cumulative violation; see the block comment in ModifiersLogic.foundCumulativeConflict()")
     @Test
     public void RebelFlightSuitManeuverBonusDoesNotStackCumulativelyFromMultiplePilotsWithSameTitle() {
         var scn = GetScenario();

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set9/dark/Card_9_093_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set9/dark/Card_9_093_Tests.java
@@ -1,13 +1,11 @@
-package com.gempukku.swccgo.cards.set9.light;
+package com.gempukku.swccgo.cards.set9.dark;
 
-import com.gempukku.swccgo.common.CardSubtype;
 import com.gempukku.swccgo.common.CardType;
 import com.gempukku.swccgo.common.ExpansionSet;
 import com.gempukku.swccgo.common.Icon;
 import com.gempukku.swccgo.common.Phase;
 import com.gempukku.swccgo.common.Rarity;
 import com.gempukku.swccgo.common.Side;
-import com.gempukku.swccgo.common.Title;
 import com.gempukku.swccgo.common.Uniqueness;
 import com.gempukku.swccgo.framework.StartingSetup;
 import com.gempukku.swccgo.framework.VirtualTableScenario;
@@ -17,21 +15,24 @@ import java.util.ArrayList;
 import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-public class Card_9_003_Tests {
+public class Card_9_093_Tests {
+    /**
+     * Dark Side Fighter Cover uses the same +3 power text as Concentrate All Fire.
+     * We put Fighter Cover on table and fire two weapons from a Light Side B-wing,
+     * because that ship is allowed to fire more than one weapon in battle.
+     */
     protected VirtualTableScenario GetScenario() {
         return new VirtualTableScenario(
                 new HashMap<>() {{
-                    put("concentrateAllFire", "9_3");
                     put("bwing", "9_66");
                     put("weapon1", "9_87");
                     put("weapon2", "2_81");
                     put("hoth", "3_55");
                 }},
                 new HashMap<>() {{
+                    put("fighterCover", "9_93");
                     put("executor", "4_167");
                 }},
                 10,
@@ -47,26 +48,24 @@ public class Card_9_003_Tests {
     }
 
     @Test
-    public void ConcentrateAllFireStatsAndKeywordsAreCorrect() {
+    public void FighterCoverStatsAndKeywordsAreCorrect() {
         /**
-         * Title: Concentrate All Fire
+         * Title: Fighter Cover
          * Uniqueness: Unique
-         * Side: Light
+         * Side: Dark
          * Type: Admirals Order
          * Destiny: 6
          * Icons: Admirals Order, Death Star II
-         * Game Text: Each starfighter that fires a weapon in battle is power +3 for the remainder of battle. Once per turn you may cancel and redraw your starship weapon destiny just drawn. At sites related to systems you occupy, your characters who have immunity to attrition each add 2 to immunity and 1 to each of that character's weapon destiny draws.
+         * Game Text: Each starfighter that fires a weapon in battle is power +3 for the remainder of battle.
          * Set: Death Star II
          * Rarity: R
          */
-
         var scn = GetScenario();
+        var card = scn.GetDSCard("fighterCover").getBlueprint();
 
-        var card = scn.GetLSCard("concentrateAllFire").getBlueprint();
-
-        assertEquals("Concentrate All Fire", card.getTitle());
+        assertEquals("Fighter Cover", card.getTitle());
         assertEquals(Uniqueness.UNIQUE, card.getUniqueness());
-        assertEquals(Side.LIGHT, card.getSide());
+        assertEquals(Side.DARK, card.getSide());
         scn.BlueprintCardTypeCheck(card, new ArrayList<>() {{
             add(CardType.ADMIRALS_ORDER);
         }});
@@ -75,67 +74,60 @@ public class Card_9_003_Tests {
             add(Icon.ADMIRALS_ORDER);
             add(Icon.DEATH_STAR_II);
         }});
-        assertEquals(ExpansionSet.DEATH_STAR_II,card.getExpansionSet());
+        assertEquals(ExpansionSet.DEATH_STAR_II, card.getExpansionSet());
         assertEquals(Rarity.R, card.getRarity());
     }
 
+    /**
+     * Fighter Cover adds 3 power the first time a starfighter fires in a battle.
+     * A second weapon fire from the same ship does not add another 3.
+     */
     @Test
-    public void ConcentrateAllFirePowerBonusIsNotCumulative() {
-        // Issue 38: Concentrate All Fire +3 power is not cumulative per starship per battle.
-
+    public void FighterCoverPowerBonusIsNotCumulativePerStarshipPerBattle() {
         var scn = GetScenario();
 
-        var concentrateAllFire = scn.GetLSCard("concentrateAllFire");
+        var fighterCover = scn.GetDSCard("fighterCover");
         var bwing = scn.GetLSCard("bwing");
         var weapon1 = scn.GetLSCard("weapon1");
         var weapon2 = scn.GetLSCard("weapon2");
         var hoth = scn.GetLSCard("hoth");
-
         var executor = scn.GetDSCard("executor");
 
         scn.StartGame();
 
-        scn.MoveCardsToLSHand(concentrateAllFire);
-
         scn.MoveLocationToTable(hoth);
         scn.MoveCardsToLocation(hoth, bwing, executor);
         scn.AttachCardsTo(bwing, weapon1, weapon2);
+        scn.MoveCardsToDSSideOfTable(fighterCover);
 
-        scn.SkipToLSTurn(Phase.DEPLOY);
-        assertTrue(scn.AwaitingLSDeployPhaseActions());
-
-        assertTrue(scn.LSDeployAvailable(concentrateAllFire));
-        scn.LSDeployCard(concentrateAllFire);
-
-        scn.SkipToPhase(Phase.BATTLE);
-
+        scn.SkipToLSTurn(Phase.BATTLE);
         assertTrue(scn.AwaitingLSBattlePhaseActions());
-        assertTrue(scn.GetLSForcePileCount() >= 2); //enough to initiate and fire both weapons
+        assertTrue(scn.GetLSForcePileCount() >= 2);
         assertTrue(scn.LSCanInitiateBattle());
         scn.LSInitiateBattle(hoth);
         scn.PassBattleStartResponses();
 
-        // -- base power 4
-        assertEquals(4,scn.GetLSTotalPower());
+        // B-wing Bomber printed power 4
+        assertEquals(4, scn.GetLSTotalPower());
 
         assertTrue(scn.LSCardActionAvailable(weapon1));
-        scn.LSUseCardAction(weapon1); //cost: free
+        scn.LSUseCardAction(weapon1);
         assertTrue(scn.LSHasCardChoiceAvailable(executor));
         scn.LSChooseCard(executor);
         scn.PassAllResponses();
 
-        // -- concentrate all fire adds 3
-        assertEquals(7,scn.GetLSTotalPower());
+        // Fighter Cover adds 3 once
+        assertEquals(7, scn.GetLSTotalPower());
 
         scn.DSPass();
 
         assertTrue(scn.LSCardActionAvailable(weapon2));
-        scn.LSUseCardAction(weapon2); //cost: 1
+        scn.LSUseCardAction(weapon2);
         assertTrue(scn.LSHasCardChoiceAvailable(executor));
         scn.LSChooseCard(executor);
         scn.PassAllResponses();
 
-        // -- concentrate all fire should not add further (not cumulative)
-        assertEquals(7,scn.GetLSTotalPower());
+        // Same clause from the same unique card must not add another 3
+        assertEquals(7, scn.GetLSTotalPower());
     }
 }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set9/dark/Card_9_093_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set9/dark/Card_9_093_Tests.java
@@ -9,6 +9,7 @@ import com.gempukku.swccgo.common.Side;
 import com.gempukku.swccgo.common.Uniqueness;
 import com.gempukku.swccgo.framework.StartingSetup;
 import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.logic.modifiers.MayFireAnyNumberOfWeaponsModifier;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -19,9 +20,12 @@ import static org.junit.Assert.assertTrue;
 
 public class Card_9_093_Tests {
     /**
-     * Dark Side Fighter Cover uses the same +3 power text as Concentrate All Fire.
-     * We put Fighter Cover on table and fire two weapons from a Light Side B-wing,
-     * because that ship is allowed to fire more than one weapon in battle.
+     * Fighter Cover (9_093) uses the same +3 power text as Concentrate All Fire (9_003).
+     * The original case fires two weapons from a Light Side B-wing Bomber (9_66), because that
+     * ship is allowed to fire more than one weapon in battle.
+     * A second case uses a Dark TIE Fighter (1_304) (same side as Fighter Cover) firing two
+     * SFS L-s7.2 TIE Cannon (9_181). Fighter Cover only boosts starfighters, so a capital
+     * Star Destroyer would never get this +3.
      */
     protected VirtualTableScenario GetScenario() {
         return new VirtualTableScenario(
@@ -34,6 +38,9 @@ public class Card_9_093_Tests {
                 new HashMap<>() {{
                     put("fighterCover", "9_93");
                     put("executor", "4_167");
+                    put("tie", "1_304");
+                    put("cannon1", "9_181");
+                    put("cannon2", "9_181");
                 }},
                 10,
                 10,
@@ -79,8 +86,8 @@ public class Card_9_093_Tests {
     }
 
     /**
-     * Fighter Cover adds 3 power the first time a starfighter fires in a battle.
-     * A second weapon fire from the same ship does not add another 3.
+     * Fighter Cover (9_093) adds 3 power the first time a starfighter fires in a battle.
+     * A second weapon fire from the same B-wing Bomber (9_66) does not add another 3.
      */
     @Test
     public void FighterCoverPowerBonusIsNotCumulativePerStarshipPerBattle() {
@@ -129,5 +136,63 @@ public class Card_9_093_Tests {
 
         // Same clause from the same unique card must not add another 3
         assertEquals(7, scn.GetLSTotalPower());
+    }
+
+    /**
+     * Dark TIE Fighter (1_304) is a starfighter on the same side as Fighter Cover (9_093).
+     * Capitals such as Dominator (9_155) never get this bonus. With two SFS L-s7.2 TIE Cannon (9_181)
+     * aboard, the Dark TIE fires both in one battle and is power +3 once, not +6.
+     */
+    @Test
+    public void FighterCoverPowerBonusIsNotCumulativeWhenDarkStarDestroyerFiresTwoWeapons() {
+        var scn = GetScenario();
+
+        var fighterCover = scn.GetDSCard("fighterCover");
+        var tie = scn.GetDSCard("tie");
+        var cannon1 = scn.GetDSCard("cannon1");
+        var cannon2 = scn.GetDSCard("cannon2");
+        var bwing = scn.GetLSCard("bwing");
+        var hoth = scn.GetLSCard("hoth");
+
+        scn.StartGame();
+
+        scn.MoveLocationToTable(hoth);
+        scn.MoveCardsToLocation(hoth, tie, bwing);
+        scn.AttachCardsTo(tie, cannon1, cannon2);
+        scn.MoveCardsToDSSideOfTable(fighterCover);
+        // No Dark starfighter prints may fire any number of weapons; B-wing Bomber (9_66) is Light.
+        scn.ApplyAdHocModifier(new MayFireAnyNumberOfWeaponsModifier(tie));
+
+        scn.SkipToDSTurn(Phase.BATTLE);
+        assertTrue(scn.AwaitingDSBattlePhaseActions());
+        assertTrue(scn.GetDSForcePileCount() >= 3);
+        assertTrue(scn.DSCanInitiateBattle());
+        scn.DSInitiateBattle(hoth);
+
+        // TIE Fighter printed power 1
+        assertEquals(1, scn.GetPower(tie));
+        assertEquals(1, scn.GetDSTotalPower());
+
+        assertTrue(scn.DSCardActionAvailable(cannon1));
+        scn.DSUseCardAction(cannon1);
+        assertTrue(scn.DSHasCardChoiceAvailable(bwing));
+        scn.DSChooseCard(bwing);
+        scn.PassAllResponses();
+
+        // Fighter Cover adds 3 once to the firing Dark starfighter
+        assertEquals(4, scn.GetPower(tie));
+        assertEquals(4, scn.GetDSTotalPower());
+
+        scn.LSPass();
+
+        assertTrue(scn.DSCardActionAvailable(cannon2));
+        scn.DSUseCardAction(cannon2);
+        assertTrue(scn.DSHasCardChoiceAvailable(bwing));
+        scn.DSChooseCard(bwing);
+        scn.PassAllResponses();
+
+        // Same unique Fighter Cover POWER clause must not add another 3
+        assertEquals(4, scn.GetPower(tie));
+        assertEquals(4, scn.GetDSTotalPower());
     }
 }


### PR DESCRIPTION
Fixes Cumulative Rule in the modifier engine so non-cumulative modifiers do not stack unless they say Cumulatively.

## Summary
Engine-level Cumulative Rule for issues #38 and #697. Not a Concentrate All Fire title special-case — the hole was unique same-`cardId` re-emission of the same `ModifierType`, plus same-title copies and same game-text clause from two cards.

## Card / scope
- Engine change (`foundCumulativeConflict` / clause identity), with card tags only where needed
- Touches Concentrate All Fire (`9_003`), Fighter Cover (`9_093`), Rebel Flight Suit (`4_014`), Mercenary Pilot (`112_013`) clause tags, Darth Maul Young Apprentice (`12_101`), Sai'torr Kal Fas (`1_64`), Jawa Sandcrawler (`1_309`), Rebel Tech (`2_019`)

## What changed
Conflict when a new modifier matches an already-kept one on: not cumulative, has source, same `ModifierType`, same permanent-pilot/astromech flags, same source title, same `forPlayer`/icon, and same **clause identity**.

Clause identity API on `Modifier` / `AbstractModifier`:
- `setCumulative` / `getClauseIdentity` / `setClauseIdentity` / `applyClauseIdentityFromAction`
- Auto-tag from `AddModifierWithDurationEffect`, `ModifyPowerUntilEndOfBattleEffect`, `ModifyPowerUntilEndOfTurnEffect`

Card tags:
- **Mercenary Pilot** (`112_013`): driving → `OTHER_CARD_ACTION_1`; cloud-sector optional → `OTHER_CARD_ACTION_2` (optional behavior itself is #1011)
- **Rebel Flight Suit** (`4_014`): removed fake `cumulative=true`; clause so matching-pilot maneuver combines with pilot native +1 then limit +2

## Design choices
- Different clause identities do not conflict (issue 697)
- `isCumulative()` always stacks (Rebel Tech)
- Power summing still adds every surviving POWER modifier; de-dupe is only at conflict check
- Against master (not stacked on #1006 / #1007 / #1011); #1011 is mergeable first

## Tests
Engine suite **33** + Mercenary Pilot **3** (classes: `Card_9_003_Tests`, `Card_4_014_Tests`, `Card_9_093_Tests`, `Card_1_309_Tests`, `Card_2_019_Tests`, `Card_112_013_Tests`, `Card_12_101_Tests`, `Card_1_064_Tests`):
- Concentrate All Fire second fire stays power 7, not 10
- Fighter Cover +3 once per ship (including Dark TIE firing two weapons)
- Rebel Flight Suit maneuver does not stack from multiple same-title pilots
- Jawa Sandcrawler forfeit +1 not +3; three Rebel Tech still +3 Cumulatively
- Mercenary Pilot: two drivers one destiny; driving + cloud-sector both after accepting optional
- Darth Maul: two different modifier types together; Jedi Master power −3 not −6 from two hits
- Four Sai'torr Kal Fas +1 power total, not +4

## Known gaps
- Cards with two different game-text portions emitting the same `ModifierType` still need distinct `setClauseIdentity` (Mercenary Pilot is the known case)
- Targeting Computer fire-twice remains on #1006; unused TC +1 maneuver de-dupe unchanged here

Closes #38
Closes #697
Closes #46
