### PR TITLE
Make Mercenary Pilot (112_013) cloud-sector battle destiny optional

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set112/dark/Card112_013.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set112/dark/Card112_013.java
@@ -15,7 +15,7 @@ import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.game.SwccgGame;
 import com.gempukku.swccgo.logic.TriggerConditions;
-import com.gempukku.swccgo.logic.actions.RequiredGameTextTriggerAction;
+import com.gempukku.swccgo.logic.actions.OptionalGameTextTriggerAction;
 import com.gempukku.swccgo.logic.modifiers.AddsBattleDestinyModifier;
 import com.gempukku.swccgo.logic.modifiers.AddsPowerToDrivenBySelfModifier;
 import com.gempukku.swccgo.logic.modifiers.AddsPowerToPilotedBySelfModifier;
@@ -36,7 +36,7 @@ public class Card112_013 extends AbstractAlien {
     public Card112_013() {
         super(Side.DARK, 2, 2, 2, 1, 3, "Mercenary Pilot", Uniqueness.UNRESTRICTED, ExpansionSet.JPSD, Rarity.PM);
         setLore("Smugglers. Candidates who resent authority often abandon Imperial academies to sell their piloting skills to criminals. Will work for any high paying crime syndicate.");
-        setGameText("Adds 2 to power of anything he pilots or drives. When driving a transport vehicle, adds one battle destiny. When piloting at a cloud sector, once per turn adds one battle destiny during battle at a related exterior site.");
+        setGameText("Adds 2 to power of anything he pilots or drives. When driving a transport vehicle, adds one battle destiny. When piloting at a cloud sector, once per turn may add one battle destiny during battle at a related exterior site.");
         addIcons(Icon.PREMIUM, Icon.PILOT, Icon.WARRIOR);
         addKeywords(Keyword.MERCENARY, Keyword.SMUGGLER);
     }
@@ -51,14 +51,14 @@ public class Card112_013 extends AbstractAlien {
     }
 
     @Override
-    protected List<RequiredGameTextTriggerAction> getGameTextRequiredAfterTriggers(SwccgGame game, EffectResult effectResult, PhysicalCard self, int gameTextSourceCardId) {
+    protected List<OptionalGameTextTriggerAction> getGameTextOptionalAfterTriggers(final String playerId, SwccgGame game, EffectResult effectResult, PhysicalCard self, int gameTextSourceCardId) {
         // Check condition(s)
         if (TriggerConditions.battleInitiatedAt(game, effectResult, Filters.and(Filters.exterior_site, Filters.relatedSite(self)))
-                && GameConditions.isOncePerTurn(game, self, gameTextSourceCardId)
+                && GameConditions.isOncePerTurn(game, self, playerId, gameTextSourceCardId)
                 && GameConditions.isPilotingAt(game, self, Filters.cloud_sector)
                 && GameConditions.canAddBattleDestinyDraws(game, self)) {
 
-            final RequiredGameTextTriggerAction action = new RequiredGameTextTriggerAction(self, gameTextSourceCardId);
+            final OptionalGameTextTriggerAction action = new OptionalGameTextTriggerAction(self, gameTextSourceCardId);
             action.setText("Add one battle destiny");
             // Update usage limit(s)
             action.appendUsage(

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set112/dark/Card_112_013_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set112/dark/Card_112_013_Tests.java
@@ -1,0 +1,282 @@
+package com.gempukku.swccgo.cards.set112.dark;
+
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.game.PhysicalCardImpl;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for Mercenary Pilot (112_013).
+ * Cloud-sector destiny is an optional once-per-turn popup. Driving a transport still adds destiny automatically.
+ * See the Testing Rig helpers in VirtualTableScenario for battle and optional-action control.
+ */
+public class Card_112_013_Tests {
+    /**
+     * Dark Side Mercenary Pilot, TIE Fighters, and Cloud City locations.
+     * Light Side only supplies opponents to battle and one related exterior site.
+     */
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("luke", "1_19");
+                    put("leia", "1_17");
+                    put("platform327", "5_83");
+                }},
+                new HashMap<>() {{
+                    put("pilot1", "112_13");
+                    put("pilot2", "112_13");
+                    put("tie1", "1_304");
+                    put("tie2", "1_304");
+                    put("crawler", "1_309");
+                    put("trooper1", "1_194");
+                    put("trooper2", "1_194");
+                    put("bespin", "5_164");
+                    put("cloudCity", "5_165");
+                    put("eastPlatform", "5_169");
+                }},
+                20,
+                20,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void MercenaryPilotStatsAreCorrect() {
+        var scn = GetScenario();
+        var card = scn.GetDSCard("pilot1").getBlueprint();
+        assertEquals("Mercenary Pilot", card.getTitle());
+        assertEquals(Uniqueness.UNRESTRICTED, card.getUniqueness());
+    }
+
+    /**
+     * Mercenary Pilot piloting at a cloud sector is offered an optional add-one-battle-destiny
+     * during battle at a related exterior site. Accepting it adds one destiny.
+     */
+    @Test
+    public void MercenaryPilotPilotingAtCloudSectorIsOfferedOptionalBattleDestinyAtRelatedExteriorSite() {
+        var scn = GetScenario();
+        var board = PlaceCloudSectorPilotAndRelatedExteriorBattle(scn, false);
+
+        scn.SkipToDSTurn(Phase.BATTLE);
+        InitiateBattleKeepingStartResponses(scn, board.eastPlatform);
+
+        String debug = "decision=" + (scn.DSGetDecision() == null ? "none" : scn.DSGetDecision().getText())
+                + " ls=" + (scn.LSGetDecision() == null ? "none" : scn.LSGetDecision().getText())
+                + " actions=" + scn.GetDSAvailableActions();
+        assertTrue(debug, scn.DSAnyDecisionsAvailable() && scn.DSCardActionAvailable(board.pilot1, "Add one battle destiny"));
+        scn.DSUseCardAction(board.pilot1, "Add one battle destiny");
+
+        scn.SkipToPowerSegment();
+        assertEquals(1, scn.GetDSBattleDestinyCount());
+        assertTrue(scn.DSDecisionAvailable("Do you want to draw 1 battle destiny?"));
+    }
+
+    /**
+     * The same Mercenary Pilot cannot offer the cloud-sector destiny more than once per turn.
+     * After it is used in one battle, a later battle this turn at another related exterior site has no option.
+     */
+    @Test
+    public void MercenaryPilotCannotAddCloudSectorBattleDestinyMoreThanOncePerTurn() {
+        var scn = GetScenario();
+        var board = PlaceCloudSectorPilotAndRelatedExteriorBattle(scn, true);
+
+        scn.SkipToDSTurn(Phase.BATTLE);
+        InitiateBattleKeepingStartResponses(scn, board.eastPlatform);
+        assertTrue(scn.DSAnyDecisionsAvailable() && scn.DSCardActionAvailable(board.pilot1, "Add one battle destiny"));
+        scn.DSUseCardAction(board.pilot1, "Add one battle destiny");
+        EndCurrentBattle(scn);
+
+        assertTrue(scn.DSCanInitiateBattle(board.platform327));
+        InitiateBattleKeepingStartResponses(scn, board.platform327);
+        String oncePerTurnDebug = "decision=" + (scn.DSGetDecision() == null ? "none" : scn.DSGetDecision().getText())
+                + " actions=" + scn.GetDSAvailableActions();
+        assertFalse(oncePerTurnDebug, scn.DSAnyDecisionsAvailable() && scn.DSCardActionAvailable(board.pilot1, "Add one battle destiny"));
+
+        scn.SkipToPowerSegment();
+        assertEquals(0, scn.GetDSBattleDestinyCount());
+        assertFalse(scn.DSDecisionAvailable("Do you want to draw 1 battle destiny?"));
+    }
+
+    /**
+     * A different Mercenary Pilot still has its own once-per-turn, even if the first copy already used the option.
+     * Second battle at another related exterior site: the unused copy is offered.
+     */
+    @Test
+    public void DifferentMercenaryPilotCanAddCloudSectorBattleDestinyAfterFirstCopyUsedItsOncePerTurn() {
+        var scn = GetScenario();
+        var board = PlaceCloudSectorPilotAndRelatedExteriorBattle(scn, true);
+
+        scn.MoveCardsToLocation(board.cloudCity, board.tie2);
+        scn.BoardAsPilot(board.tie2, board.pilot2);
+
+        scn.SkipToDSTurn(Phase.BATTLE);
+        InitiateBattleKeepingStartResponses(scn, board.eastPlatform);
+        assertTrue(scn.DSAnyDecisionsAvailable() && scn.DSCardActionAvailable(board.pilot1, "Add one battle destiny"));
+        assertTrue(scn.DSAnyDecisionsAvailable() && scn.DSCardActionAvailable(board.pilot2, "Add one battle destiny"));
+        scn.DSUseCardAction(board.pilot1, "Add one battle destiny");
+        if (scn.DSAnyDecisionsAvailable() && scn.DSCardActionAvailable(board.pilot2, "Add one battle destiny")) {
+            scn.DSDecline();
+        }
+        EndCurrentBattle(scn);
+
+        InitiateBattleKeepingStartResponses(scn, board.platform327);
+        String twoCopyDebug = "decision=" + (scn.DSGetDecision() == null ? "none" : scn.DSGetDecision().getText())
+                + " actions=" + scn.GetDSAvailableActions();
+        assertFalse(twoCopyDebug, scn.DSAnyDecisionsAvailable() && scn.DSCardActionAvailable(board.pilot1, "Add one battle destiny"));
+        assertTrue(twoCopyDebug, scn.DSAnyDecisionsAvailable() && scn.DSCardActionAvailable(board.pilot2, "Add one battle destiny"));
+        scn.DSUseCardAction(board.pilot2, "Add one battle destiny");
+
+        scn.SkipToPowerSegment();
+        assertEquals(1, scn.GetDSBattleDestinyCount());
+        assertTrue(scn.DSDecisionAvailable("Do you want to draw 1 battle destiny?"));
+    }
+
+    /**
+     * Driving a transport still automatically adds one battle destiny. There is no optional popup for that text.
+     */
+    @Test
+    public void MercenaryPilotDrivingTransportAutomaticallyAddsBattleDestinyWithoutPopup() {
+        var scn = GetScenario();
+
+        var pilot1 = scn.GetDSCard("pilot1");
+        var crawler = scn.GetDSCard("crawler");
+        var luke = scn.GetLSCard("luke");
+        var site = scn.GetDSStartingLocation();
+
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, crawler, luke);
+        scn.BoardAsPilot(crawler, pilot1);
+
+        scn.SkipToDSTurn(Phase.BATTLE);
+        scn.DSUseCardAction(site, "Initiate battle");
+        scn.PassForceUseResponses();
+        assertFalse(scn.DSAnyDecisionsAvailable() && scn.DSCardActionAvailable(pilot1, "Add one battle destiny"));
+        scn.PassBattleStartResponses();
+
+        scn.SkipToPowerSegment();
+        assertEquals(1, scn.GetDSBattleDestinyCount());
+        assertTrue(scn.DSDecisionAvailable("Do you want to draw 1 battle destiny?"));
+    }
+
+    /**
+     * Puts Mercenary Pilot in a TIE at Bespin: Cloud City, with Dark Side and Light Side presence at related exterior sites.
+     * @param includeSecondSite true if a second related exterior site should also be ready for battle this turn
+     */
+    private CloudBoard PlaceCloudSectorPilotAndRelatedExteriorBattle(VirtualTableScenario scn, boolean includeSecondSite) {
+        var board = new CloudBoard();
+        board.pilot1 = scn.GetDSCard("pilot1");
+        board.pilot2 = scn.GetDSCard("pilot2");
+        board.tie1 = scn.GetDSCard("tie1");
+        board.tie2 = scn.GetDSCard("tie2");
+        board.trooper1 = scn.GetDSCard("trooper1");
+        board.trooper2 = scn.GetDSCard("trooper2");
+        board.bespin = scn.GetDSCard("bespin");
+        board.cloudCity = scn.GetDSCard("cloudCity");
+        board.eastPlatform = scn.GetDSCard("eastPlatform");
+        board.platform327 = scn.GetLSCard("platform327");
+        board.luke = scn.GetLSCard("luke");
+        board.leia = scn.GetLSCard("leia");
+
+        scn.StartGame();
+        scn.MoveLocationToTable(board.bespin);
+        scn.MoveLocationToTable(board.cloudCity);
+        scn.MoveLocationToTable(board.eastPlatform);
+        scn.MoveLocationToTable(board.platform327);
+
+        scn.MoveCardsToLocation(board.cloudCity, board.tie1);
+        scn.BoardAsPilot(board.tie1, board.pilot1);
+        scn.MoveCardsToLocation(board.eastPlatform, board.trooper1, board.luke);
+        if (includeSecondSite) {
+            scn.MoveCardsToLocation(board.platform327, board.trooper2, board.leia);
+        }
+        return board;
+    }
+
+    /**
+     * Starts a Dark Side battle but leaves the battle-initiated optional window open so Mercenary Pilot can be clicked.
+     */
+    private void InitiateBattleKeepingStartResponses(VirtualTableScenario scn, PhysicalCardImpl location) {
+        assertTrue("Unable to initiate battle at location", scn.DSCanInitiateBattle(location));
+        scn.DSUseCardAction(location, "Initiate battle");
+        scn.PassForceUseResponses();
+        // Opponent is asked first; pass Light Side so Dark Side sees Mercenary Pilot's optional.
+        if (scn.LSDecisionAvailable("BATTLE_INITIATED")) {
+            scn.LSPass();
+        }
+    }
+
+    /**
+     * Ends the current battle without drawing destiny so another battle can start this turn.
+     * Leftover battle damage is paid from Reserve Deck.
+     */
+    private void EndCurrentBattle(VirtualTableScenario scn) {
+        if (!scn.IsReachedPowerSegment()) {
+            scn.SkipToPowerSegment();
+        }
+        scn.SkipBattleDestinyDraws(false);
+        scn.PassResponses("INITIAL_ATTRITION_CALCULATED");
+        for (int i = 0; i < 25; i++) {
+            if (scn.AwaitingDSBattlePhaseActions()) {
+                return;
+            }
+            if (scn.AwaitingDSBattleDamagePayment()) {
+                scn.DSPayRemainingBattleDamageFromReserveDeck();
+                continue;
+            }
+            if (scn.AwaitingLSBattleDamagePayment()) {
+                scn.LSPayRemainingBattleDamageFromReserveDeck();
+                continue;
+            }
+            if (scn.DSDecisionAvailable("battle destiny?")) {
+                scn.DSChooseNo();
+                scn.PassDestinyDrawResponses();
+                continue;
+            }
+            if (scn.LSDecisionAvailable("battle destiny?")) {
+                scn.LSChooseNo();
+                scn.PassDestinyDrawResponses();
+                continue;
+            }
+            if (scn.LSAnyDecisionsAvailable() && !scn.DSAnyDecisionsAvailable()) {
+                scn.LSPass();
+                continue;
+            }
+            if (scn.DSAnyDecisionsAvailable()) {
+                scn.DSPass();
+                continue;
+            }
+            return;
+        }
+        throw new RuntimeException("Could not finish battle. decision=" +
+                (scn.GetCurrentDecision() == null ? "none" : scn.GetCurrentDecision().getText()));
+    }
+
+    private static class CloudBoard {
+        PhysicalCardImpl pilot1;
+        PhysicalCardImpl pilot2;
+        PhysicalCardImpl tie1;
+        PhysicalCardImpl tie2;
+        PhysicalCardImpl trooper1;
+        PhysicalCardImpl trooper2;
+        PhysicalCardImpl bespin;
+        PhysicalCardImpl cloudCity;
+        PhysicalCardImpl eastPlatform;
+        PhysicalCardImpl platform327;
+        PhysicalCardImpl luke;
+        PhysicalCardImpl leia;
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set112/dark/Card_112_013_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set112/dark/Card_112_013_Tests.java
@@ -1,6 +1,12 @@
 package com.gempukku.swccgo.cards.set112.dark;
 
 import com.gempukku.swccgo.common.Phase;
+import java.util.ArrayList;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Keyword;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.Side;
 import com.gempukku.swccgo.common.Uniqueness;
 import com.gempukku.swccgo.framework.StartingSetup;
 import com.gempukku.swccgo.framework.VirtualTableScenario;
@@ -12,6 +18,7 @@ import java.util.HashMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for Mercenary Pilot (112_013).
@@ -55,11 +62,41 @@ public class Card_112_013_Tests {
     }
 
     @Test
-    public void MercenaryPilotStatsAreCorrect() {
+    public void MercenaryPilotStatsAndKeywordsAreCorrect() {
+        /**
+         * Title: Mercenary Pilot
+         * Uniqueness: Unrestricted
+         * Side: Dark
+         * Type: Alien
+         * Destiny: 2 / Power: 2 / Ability: 1 / Deploy: 2 / Forfeit: 3
+         * Icons: Pilot, Warrior (Jabba's Palace Sealed Deck)
+         * Keywords: Mercenary, Smuggler
+         * Set: JPSD
+         */
         var scn = GetScenario();
         var card = scn.GetDSCard("pilot1").getBlueprint();
         assertEquals("Mercenary Pilot", card.getTitle());
         assertEquals(Uniqueness.UNRESTRICTED, card.getUniqueness());
+        assertEquals(Side.DARK, card.getSide());
+        scn.BlueprintCardTypeCheck(card, new ArrayList<>() {{
+            add(CardType.ALIEN);
+        }});
+        assertEquals(2, card.getDestiny(), scn.epsilon);
+        assertEquals(2, card.getPower(), scn.epsilon);
+        assertEquals(1, card.getAbility(), scn.epsilon);
+        assertEquals(2, card.getDeployCost(), scn.epsilon);
+        assertEquals(3, card.getForfeit(), scn.epsilon);
+        scn.BlueprintIconCheck(card, new ArrayList<>() {{
+            add(Icon.ALIEN);
+            add(Icon.PILOT);
+            add(Icon.WARRIOR);
+            add(Icon.PREMIUM);
+        }});
+        scn.BlueprintKeywordCheck(card, new ArrayList<>() {{
+            add(Keyword.MERCENARY);
+            add(Keyword.SMUGGLER);
+        }});
+        assertEquals(ExpansionSet.JPSD, card.getExpansionSet());
     }
 
     /**
@@ -74,10 +111,7 @@ public class Card_112_013_Tests {
         scn.SkipToDSTurn(Phase.BATTLE);
         InitiateBattleKeepingStartResponses(scn, board.eastPlatform);
 
-        String debug = "decision=" + (scn.DSGetDecision() == null ? "none" : scn.DSGetDecision().getText())
-                + " ls=" + (scn.LSGetDecision() == null ? "none" : scn.LSGetDecision().getText())
-                + " actions=" + scn.GetDSAvailableActions();
-        assertTrue(debug, scn.DSAnyDecisionsAvailable() && scn.DSCardActionAvailable(board.pilot1, "Add one battle destiny"));
+        assertTrue(scn.DSAnyDecisionsAvailable() && scn.DSCardActionAvailable(board.pilot1, "Add one battle destiny"));
         scn.DSUseCardAction(board.pilot1, "Add one battle destiny");
 
         scn.SkipToPowerSegment();
@@ -261,8 +295,7 @@ public class Card_112_013_Tests {
             }
             return;
         }
-        throw new RuntimeException("Could not finish battle. decision=" +
-                (scn.GetCurrentDecision() == null ? "none" : scn.GetCurrentDecision().getText()));
+        fail("Could not finish battle. decision=" + (scn.GetCurrentDecision() == null ? "none" : scn.GetCurrentDecision().getText()));
     }
 
     private static class CloudBoard {


### PR DESCRIPTION
Mercenary Pilot (112_013) cloud-sector battle destiny is **once per turn may** add one battle destiny during battle at a related exterior site (Advanced Rulebook). That is an optional popup, not a required trigger.

Driving a transport vehicle still **adds** one battle destiny automatically (`AddsBattleDestinyModifier`); that text is not "may".

## Card
Cloud-sector text now matches other Decipher "may add one battle destiny" cards:
- `getGameTextOptionalAfterTriggers`
- `OptionalGameTextTriggerAction`
- `OncePerTurnEffect`
- `AddBattleDestinyEffect`
- `GameConditions.isOncePerTurn(..., playerId, ...)` so usage and the once-per-turn check use the same player key (per copy)

No ModifiersLogic / clause-identity engine changes. Independent of Targeting Computer #1006, Combined Attack #1007, and Cumulative Rule #1010. Mergeable before #1010.

## Tests (`Card_112_013_Tests`)
Docker Maven: **5 run, 0 fail**

- `MercenaryPilotStatsAreCorrect`
- `MercenaryPilotPilotingAtCloudSectorIsOfferedOptionalBattleDestinyAtRelatedExteriorSite`
- `MercenaryPilotCannotAddCloudSectorBattleDestinyMoreThanOncePerTurn`
- `DifferentMercenaryPilotCanAddCloudSectorBattleDestinyAfterFirstCopyUsedItsOncePerTurn`
- `MercenaryPilotDrivingTransportAutomaticallyAddsBattleDestinyWithoutPopup`

HEAD: `d42f8b4e0ac03c0f72d748e92eae360fc70a994b`

---
Tests follow VHD/PlayersCommittee naming (method names lead with card title + behavior; exclusive BlueprintIconCheck/KeywordCheck where applicable).