### PR TITLE
Implement Sensor Panel (2_029)

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_104.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_104.java
@@ -24,6 +24,7 @@ import com.gempukku.swccgo.logic.effects.UseForceEffect;
 import com.gempukku.swccgo.logic.modifiers.ModifyGameTextType;
 import com.gempukku.swccgo.logic.timing.Action;
 import com.gempukku.swccgo.logic.timing.PassthruEffect;
+import com.gempukku.swccgo.logic.timing.results.PeekedAtOpponentsHandResult;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -40,6 +41,21 @@ public class Card1_104 extends AbstractUsedInterrupt {
         super(Side.LIGHT, 3, Title.Radar_Scanner, Uniqueness.UNRESTRICTED, ExpansionSet.PREMIERE, Rarity.C2);
         setLore("Sensor on Luke's landspeeder. Many possible settings. Can scan for life forms, movement or concentrations of metal. Used for traffic control on settled worlds.");
         setGameText("If you have at least one vehicle or starship on table, use 1 Force to glance at the cards in the opponent's hand for 10 seconds. You may move each Jawa (except Dathcha) and Tusken Raider you find there to opponent's Used Pile.");
+    }
+
+    /**
+     * Lets cards such as Sensor Panel respond after the peek, without looking at the hand a second time.
+     */
+    private void emitPeekedAtOpponentsHand(final Action action, final String playerId, final PhysicalCard self, final List<PhysicalCard> peekedAtCards) {
+        action.appendEffect(
+                new PassthruEffect(action) {
+                    @Override
+                    protected void doPlayEffect(SwccgGame game) {
+                        game.getActionsEnvironment().emitEffectResult(
+                                new PeekedAtOpponentsHandResult(playerId, self, peekedAtCards));
+                    }
+                }
+        );
     }
 
     @Override
@@ -84,7 +100,8 @@ public class Card1_104 extends AbstractUsedInterrupt {
                                                                             new LoseCardsFromHandEffect(action, opponent, cardsToLose));
                                                                 }
                                                             }
-                                                            ;
+                                                            // Offer Sensor Panel (and similar) after seeing the hand, before Radar Scanner's Jawa option.
+                                                            emitPeekedAtOpponentsHand(action, playerId, self, peekedAtCards);
                                                             action.appendEffect(
                                                                     new PassthruEffect(action) {
                                                                         @Override
@@ -99,11 +116,14 @@ public class Card1_104 extends AbstractUsedInterrupt {
                                                                                                         game.getGameState().sendMessage(playerId + " chooses to place Jawas and Tusken Raiders in Used Pile");
                                                                                                         action.appendEffect(
                                                                                                                 new PutCardsFromHandOnUsedPileEffect(action, playerId, opponent, jawaAndTuskenRaiderFilter, false));
+                                                                                                        // Second window so Sensor Panel can also be used after the Jawa option.
+                                                                                                        emitPeekedAtOpponentsHand(action, playerId, self, peekedAtCards);
                                                                                                     }
 
                                                                                                     @Override
                                                                                                     protected void no() {
                                                                                                         game.getGameState().sendMessage(playerId + " chooses to not place Jawas and Tusken Raiders in Used Pile");
+                                                                                                        emitPeekedAtOpponentsHand(action, playerId, self, peekedAtCards);
                                                                                                     }
                                                                                                 }
                                                                                         )

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/light/Card2_029.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/light/Card2_029.java
@@ -1,0 +1,108 @@
+package com.gempukku.swccgo.cards.set2.light;
+
+import com.gempukku.swccgo.cards.AbstractDevice;
+import com.gempukku.swccgo.cards.GameConditions;
+import com.gempukku.swccgo.cards.effects.UseDeviceEffect;
+import com.gempukku.swccgo.cards.effects.usage.OncePerTurnEffect;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.PlayCardOptionId;
+import com.gempukku.swccgo.common.PlayCardZoneOption;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.filters.Filter;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.logic.TriggerConditions;
+import com.gempukku.swccgo.logic.actions.OptionalGameTextTriggerAction;
+import com.gempukku.swccgo.logic.effects.PutCardFromHandOnUsedPileEffect;
+import com.gempukku.swccgo.logic.effects.UseForceEffect;
+import com.gempukku.swccgo.logic.modifiers.DefinedByGameTextDeployCostModifier;
+import com.gempukku.swccgo.logic.modifiers.LandspeedModifier;
+import com.gempukku.swccgo.logic.modifiers.Modifier;
+import com.gempukku.swccgo.logic.modifiers.PowerModifier;
+import com.gempukku.swccgo.logic.timing.EffectResult;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Set: A New Hope
+ * Type: Device
+ * Title: Sensor Panel
+ */
+public class Card2_029 extends AbstractDevice {
+    public Card2_029() {
+        super(Side.LIGHT, 3, PlayCardZoneOption.ATTACHED, Title.Sensor_Panel, Uniqueness.UNIQUE, ExpansionSet.A_NEW_HOPE, Rarity.U2);
+        setLore("Monitors all nearby traffic in exterior locations. Takes advantage of multiple backup systems to minimize breakdowns under harsh conditions.");
+        setGameText("Use 1 Force to deploy on your non-creature vehicle. Adds 1 to power and landspeed. Once per turn, when you play Radar Scanner, you may use 1 Force to move one additional Effect or Interrupt card found in opponent's hand to Used Pile.");
+        addIcons(Icon.A_NEW_HOPE);
+    }
+
+    @Override
+    protected List<Modifier> getGameTextAlwaysOnModifiers(SwccgGame game, final PhysicalCard self) {
+        List<Modifier> modifiers = new LinkedList<Modifier>();
+        modifiers.add(new DefinedByGameTextDeployCostModifier(self, 1));
+        return modifiers;
+    }
+
+    @Override
+    protected Filter getGameTextValidDeployTargetFilter(SwccgGame game, PhysicalCard self, PlayCardOptionId playCardOptionId, boolean asReact) {
+        return Filters.and(Filters.your(self), Filters.non_creature_vehicle);
+    }
+
+    @Override
+    protected Filter getGameTextValidToUseDeviceFilter(final SwccgGame game, final PhysicalCard self) {
+        return Filters.non_creature_vehicle;
+    }
+
+    @Override
+    protected Filter getGameTextValidTargetFilterToRemainAttachedTo(final SwccgGame game, final PhysicalCard self) {
+        return Filters.non_creature_vehicle;
+    }
+
+    @Override
+    protected List<Modifier> getGameTextWhileActiveInPlayModifiers(SwccgGame game, final PhysicalCard self) {
+        Filter attachedVehicle = Filters.hasAttached(self);
+
+        List<Modifier> modifiers = new LinkedList<Modifier>();
+        modifiers.add(new PowerModifier(self, attachedVehicle, 1));
+        modifiers.add(new LandspeedModifier(self, attachedVehicle, 1));
+        return modifiers;
+    }
+
+    @Override
+    protected List<OptionalGameTextTriggerAction> getGameTextOptionalAfterTriggers(final String playerId, SwccgGame game, final EffectResult effectResult, final PhysicalCard self, int gameTextSourceCardId) {
+        final String opponent = game.getOpponent(playerId);
+        Filter effectOrInterrupt = Filters.and(Filters.or(Filters.Effect, Filters.Interrupt), Filters.canBeTargetedBy(self));
+
+        // Check condition(s)
+        if (TriggerConditions.justPeekedAtOpponentsHandUsingRadarScanner(game, effectResult, playerId)
+                && GameConditions.isOncePerTurn(game, self, playerId, gameTextSourceCardId)
+                && GameConditions.canUseDevice(game, self)
+                && GameConditions.canUseForce(game, playerId, 1)
+                && GameConditions.hasInHand(game, opponent, effectOrInterrupt)) {
+
+            final OptionalGameTextTriggerAction action = new OptionalGameTextTriggerAction(self, gameTextSourceCardId);
+            action.setText("Place Effect or Interrupt in Used Pile");
+            action.setActionMsg("Move one additional Effect or Interrupt from opponent's hand to Used Pile");
+            // Update usage limit(s)
+            action.appendUsage(
+                    new OncePerTurnEffect(action));
+            action.appendUsage(
+                    new UseDeviceEffect(action, self));
+            // Pay cost(s)
+            action.appendCost(
+                    new UseForceEffect(action, playerId, 1));
+            // Perform result(s)
+            action.appendEffect(
+                    new PutCardFromHandOnUsedPileEffect(action, playerId, opponent, effectOrInterrupt, false));
+            return Collections.singletonList(action);
+        }
+        return null;
+    }
+}

--- a/src/gemp-swccg-common/src/main/java/com/gempukku/swccgo/common/Title.java
+++ b/src/gemp-swccg-common/src/main/java/com/gempukku/swccgo/common/Title.java
@@ -1047,6 +1047,7 @@ public interface Title {
     String Senate_Hovercam = "Senate Hovercam";
     String Send_A_Detachment_Down = "Send A Detachment Down";
     String Sense = "Sense";
+    String Sensor_Panel = "Sensor Panel";
     String Separatist_Command_Center = "Separatist Command Center";
     String Set_For_Stun = "Set For Stun";
     String Set_Your_Course_For_Alderaan = "Set Your Course For Alderaan";

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
@@ -19237,6 +19237,7 @@ public class Filters {
     public static final Filter Senate_Hovercam = Filters.title(Title.Senate_Hovercam);
     public static final Filter senator = Filters.keyword(Keyword.SENATOR);
     public static final Filter Sense = Filters.title(Title.Sense);
+    public static final Filter Sensor_Panel = Filters.title(Title.Sensor_Panel);
     public static final Filter Separatist_Command_Center = Filters.title(Title.Separatist_Command_Center);
     public static final Filter Set_For_Stun = Filters.title(Title.Set_For_Stun);
     public static final Filter Set_Your_Course_For_Alderaan = Filters.title(Title.Set_Your_Course_For_Alderaan);

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/TriggerConditions.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/TriggerConditions.java
@@ -1882,6 +1882,23 @@ public class TriggerConditions {
     }
 
     /**
+     * Determines if the specified player just peeked at opponent's hand using Radar Scanner.
+     * Sensor Panel uses this so it can respond during Radar Scanner without a second look at the hand.
+     * @param game the game
+     * @param effectResult the effect result
+     * @param playerId the player who peeked
+     * @return true or false
+     */
+    public static boolean justPeekedAtOpponentsHandUsingRadarScanner(SwccgGame game, EffectResult effectResult, String playerId) {
+        if (effectResult.getType() == EffectResult.Type.PEEKED_AT_OPPONENTS_HAND) {
+            PeekedAtOpponentsHandResult result = (PeekedAtOpponentsHandResult) effectResult;
+            return playerId.equals(result.getPerformingPlayerId())
+                    && result.getSource() != null
+                    && Filters.Radar_Scanner.accepts(game, result.getSource());
+        }
+        return false;
+    }
+    /**
      * Determines if the specified player is about to look at opponents hand by using a card accepted by the card filter.
      * @param game the game
      * @param effect the effect

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/EffectResult.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/EffectResult.java
@@ -183,6 +183,7 @@ public abstract class EffectResult implements Snapshotable<EffectResult> {
         STACKED_FROM_CARD_PILE,
         STACKED_FROM_HAND,
         LOOKED_AT_CARDS_IN_CARD_PILE,
+        PEEKED_AT_OPPONENTS_HAND,
         RECIRCULATED,
 
         // Canceling/restoring game text

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/results/PeekedAtOpponentsHandResult.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/results/PeekedAtOpponentsHandResult.java
@@ -1,0 +1,42 @@
+package com.gempukku.swccgo.logic.timing.results;
+
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.timing.EffectResult;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Result emitted after a player peeks at opponent's hand (for example, with Radar Scanner).
+ * Other cards such as Sensor Panel can respond without causing a second look at the hand.
+ */
+public class PeekedAtOpponentsHandResult extends EffectResult {
+    private final PhysicalCard _source;
+    private final List<PhysicalCard> _peekedAtCards;
+
+    /**
+     * @param playerId the player who peeked
+     * @param source the card that caused the peek
+     * @param peekedAtCards the cards that were seen
+     */
+    public PeekedAtOpponentsHandResult(String playerId, PhysicalCard source, List<PhysicalCard> peekedAtCards) {
+        super(Type.PEEKED_AT_OPPONENTS_HAND, playerId);
+        _source = source;
+        _peekedAtCards = peekedAtCards != null ? peekedAtCards : Collections.emptyList();
+    }
+
+    public PhysicalCard getSource() {
+        return _source;
+    }
+
+    public List<PhysicalCard> getPeekedAtCards() {
+        return _peekedAtCards;
+    }
+
+    @Override
+    public String getText(SwccgGame game) {
+        return getPerformingPlayerId() + " just peeked at opponent's hand using " + GameUtils.getCardLink(_source);
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/light/Card_2_029_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/light/Card_2_029_Tests.java
@@ -1,0 +1,408 @@
+package com.gempukku.swccgo.cards.set2.light;
+
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.game.PhysicalCardImpl;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class Card_2_029_Tests {
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>()
+                {{
+                    put("sensorPanel", "2_029");
+                    put("landspeeder", "1_149");
+                    put("bantha", "2_076");
+                    put("radarScanner", "1_104");
+                    put("radarScanner2", "1_104");
+                }},
+                new HashMap<>()
+                {{
+                    put("barrier", "1_215");
+                    put("elis", "1_251");
+                    put("trooper", "1_194");
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    /**
+     * Puts Luke's X-34 Landspeeder on the starting site with a Rebel Trooper driving,
+     * Sensor Panel attached, and Radar Scanner in hand.
+     */
+    private void setupSensorPanelOnLandspeeder(VirtualTableScenario scn) {
+        var site = scn.GetLSStartingLocation();
+        var landspeeder = scn.GetLSCard("landspeeder");
+        var sensorPanel = scn.GetLSCard("sensorPanel");
+        var driver = scn.GetLSFiller(1);
+        scn.MoveCardsToLocation(site, landspeeder);
+        scn.BoardAsPilot(landspeeder, driver);
+        scn.AttachCardsTo(landspeeder, sensorPanel);
+        scn.MoveCardsToHand(scn.GetLSCard("radarScanner"));
+    }
+
+    /**
+     * Moves Light Side Force Pile cards back to Reserve Deck until the pile has the given size.
+     */
+    private void leaveExactlyLSForce(VirtualTableScenario scn, int remaining) {
+        for (var card : List.copyOf(scn.GetLSForcePile())) {
+            if (scn.GetLSForcePileCount() <= remaining) {
+                break;
+            }
+            scn.MoveCardsToTopOfOwnReserveDeck((PhysicalCardImpl) card);
+        }
+    }
+
+    /**
+     * Drains Light Side Force Pile so Sensor Panel cannot pay its 1 Force cost.
+     */
+    private void emptyLSForcePile(VirtualTableScenario scn) {
+        leaveExactlyLSForce(scn, 0);
+    }
+
+    /**
+     * Current Dark Side and Light Side decision text, used when a test cannot find the next window.
+     */
+    private String currentDecisionText(VirtualTableScenario scn) {
+        String ds = scn.DSGetDecision() == null ? "ds=none" : "ds=" + scn.DSGetDecision().getText();
+        String ls = scn.LSGetDecision() == null ? "ls=none" : "ls=" + scn.LSGetDecision().getText();
+        return ds + " | " + ls;
+    }
+
+    /**
+     * True if Light Side is being offered Sensor Panel's Radar Scanner optional.
+     */
+    private boolean sensorPanelOptionalAvailable(VirtualTableScenario scn) {
+        return scn.LSAnyDecisionsAvailable()
+                && scn.LSCardActionAvailable(scn.GetLSCard("sensorPanel"), "Place Effect or Interrupt in Used Pile");
+    }
+
+    /**
+     * Plays Radar Scanner, answers the vehicle target if asked, passes play and Force responses,
+     * and dismisses the single peek window. Does not pass Sensor Panel's optional window.
+     */
+    private void playRadarScannerAndPeek(VirtualTableScenario scn) {
+        playRadarScannerAndPeek(scn, scn.GetLSCard("radarScanner"));
+    }
+
+    private void playRadarScannerAndPeek(VirtualTableScenario scn, PhysicalCardImpl radarScanner) {
+        var landspeeder = scn.GetLSCard("landspeeder");
+        assertTrue("Radar Scanner should be playable", scn.LSCardPlayAvailable(radarScanner));
+        scn.LSPlayCard(radarScanner);
+        if (scn.LSAnyDecisionsAvailable() && scn.LSDecisionAvailable("Choose vehicle or starship")) {
+            scn.LSChooseCard(landspeeder);
+        }
+        scn.PassAllResponses();
+        assertTrue("Radar Scanner should show opponent's hand once. Decision: " + currentDecisionText(scn),
+                scn.LSAnyDecisionsAvailable() && scn.LSDecisionAvailable("Opponent's hand"));
+        scn.LSDecided("");
+        settleAfterRadarScannerPeek(scn);
+    }
+
+    /**
+     * After Radar Scanner's peek, Dark Side may be asked to pass an empty optional window
+     * before Light Side sees Sensor Panel.
+     */
+    private void settleAfterRadarScannerPeek(VirtualTableScenario scn) {
+        for (int i = 0; i < 12; i++) {
+            if (sensorPanelOptionalAvailable(scn)) {
+                return;
+            }
+            if (scn.LSAnyDecisionsAvailable() && scn.LSDecisionAvailable("Opponent's hand")) {
+                fail("Radar Scanner showed opponent's hand a second time");
+            }
+            if ((scn.LSAnyDecisionsAvailable() && scn.LSDecisionAvailable("Do you want to place Jawas"))
+                    || scn.AwaitingLSControlPhaseActions()) {
+                return;
+            }
+            String text = currentDecisionText(scn).toLowerCase();
+            if (text.contains("optional response")) {
+                if (scn.DSAnyDecisionsAvailable() && !scn.LSAnyDecisionsAvailable()) {
+                    scn.DSPass();
+                    continue;
+                }
+                if (scn.LSAnyDecisionsAvailable() && !sensorPanelOptionalAvailable(scn)) {
+                    scn.LSPass();
+                    continue;
+                }
+            }
+            return;
+        }
+    }
+
+    /**
+     * Passes leftover Radar Scanner windows until Light Side is back at Control phase actions.
+     */
+    private void finishRadarScannerToControl(VirtualTableScenario scn) {
+        for (int i = 0; i < 20; i++) {
+            if (scn.AwaitingLSControlPhaseActions()) {
+                return;
+            }
+            if (scn.LSDecisionAvailable("Do you want to place Jawas")) {
+                scn.LSChooseNo();
+                continue;
+            }
+            String text = currentDecisionText(scn).toLowerCase();
+            if (text.contains("optional response")) {
+                scn.PassResponses("optional");
+                continue;
+            }
+            if (scn.DSAnyDecisionsAvailable()) {
+                scn.DSPass();
+                continue;
+            }
+            if (scn.LSAnyDecisionsAvailable()) {
+                scn.LSPass();
+                continue;
+            }
+            return;
+        }
+    }
+
+    @Test
+    public void SensorPanelStatsAndKeywordsAreCorrect() {
+        /**
+         * Title: Sensor Panel
+         * Uniqueness: Unique
+         * Side: Light
+         * Type: Device
+         * Destiny: 3
+         * Game Text: Use 1 Force to deploy on your non-creature vehicle. Adds 1 to power and landspeed.
+         *      Once per turn, when you play Radar Scanner, you may use 1 Force to move one additional Effect or Interrupt
+         *      card found in opponent's hand to Used Pile.
+         * Lore: Monitors all nearby traffic in exterior locations. Takes advantage of multiple backup systems to minimize breakdowns under harsh conditions.
+         * Set: A New Hope
+         * Rarity: U2
+         */
+        var scn = GetScenario();
+        var card = scn.GetLSCard("sensorPanel").getBlueprint();
+
+        assertEquals("Sensor Panel", card.getTitle());
+        assertEquals(Uniqueness.UNIQUE, card.getUniqueness());
+        assertEquals(Side.LIGHT, card.getSide());
+        assertEquals(3, card.getDestiny(), scn.epsilon);
+        scn.BlueprintCardTypeCheck(card, new ArrayList<>() {{
+            add(CardType.DEVICE);
+        }});
+        scn.BlueprintIconCheck(card, new ArrayList<>() {{
+            add(Icon.DEVICE);
+            add(Icon.A_NEW_HOPE);
+        }});
+        assertEquals(ExpansionSet.A_NEW_HOPE, card.getExpansionSet());
+        assertEquals(Rarity.U2, card.getRarity());
+    }
+
+    @Test
+    public void SensorPanelCanDeployOnOwnersNonCreatureVehicle() {
+        var scn = GetScenario();
+        var sensorPanel = scn.GetLSCard("sensorPanel");
+        var landspeeder = scn.GetLSCard("landspeeder");
+        var site = scn.GetLSStartingLocation();
+
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, landspeeder);
+        scn.MoveCardsToHand(sensorPanel);
+
+        scn.SkipToLSTurn(Phase.DEPLOY);
+        assertTrue("Sensor Panel should deploy on owner's non-creature vehicle", scn.LSDeployAvailable(sensorPanel));
+        scn.LSDeployCard(sensorPanel);
+        if (scn.LSHasCardChoiceAvailable(landspeeder)) {
+            scn.LSChooseCard(landspeeder);
+        }
+        scn.PassAllResponses();
+        assertTrue(scn.IsAttachedTo(landspeeder, sensorPanel));
+    }
+
+    @Test
+    public void SensorPanelMayNotDeployOnCreatureVehicle() {
+        var scn = GetScenario();
+        var sensorPanel = scn.GetLSCard("sensorPanel");
+        var landspeeder = scn.GetLSCard("landspeeder");
+        var bantha = scn.GetLSCard("bantha");
+        var site = scn.GetLSStartingLocation();
+
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, landspeeder, bantha);
+        scn.MoveCardsToHand(sensorPanel);
+
+        scn.SkipToLSTurn(Phase.DEPLOY);
+        scn.LSDeployCard(sensorPanel);
+        assertTrue("Luke's X-34 Landspeeder is a legal non-creature vehicle", scn.LSHasCardChoiceAvailable(landspeeder));
+        assertFalse("Rogue Bantha is a creature vehicle and is not a legal target", scn.LSHasCardChoiceAvailable(bantha));
+    }
+
+    @Test
+    public void SensorPanelMayNotDeployWithoutOneForce() {
+        var scn = GetScenario();
+        var sensorPanel = scn.GetLSCard("sensorPanel");
+        var landspeeder = scn.GetLSCard("landspeeder");
+        var site = scn.GetLSStartingLocation();
+
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, landspeeder);
+        scn.MoveCardsToHand(sensorPanel);
+
+        // Empty Force after activate, then enter Deploy so the action list is built with 0 Force.
+        scn.SkipToLSTurn(Phase.CONTROL);
+        emptyLSForcePile(scn);
+        scn.SkipToPhase(Phase.DEPLOY);
+        assertEquals(0, scn.GetLSForcePileCount());
+        assertFalse("Sensor Panel costs 1 Force to deploy", scn.LSDeployAvailable(sensorPanel));
+    }
+
+    @Test
+    public void SensorPanelAddsOneToVehiclePowerAndLandspeed() {
+        var scn = GetScenario();
+        var landspeeder = scn.GetLSCard("landspeeder");
+        var sensorPanel = scn.GetLSCard("sensorPanel");
+        var driver = scn.GetLSFiller(1);
+        var site = scn.GetLSStartingLocation();
+
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, landspeeder);
+        scn.BoardAsPilot(landspeeder, driver);
+
+        assertEquals("Luke's X-34 Landspeeder printed power", 1, scn.GetPower(landspeeder));
+        assertEquals("Luke's X-34 Landspeeder printed landspeed", 4, scn.GetLandspeed(landspeeder));
+
+        scn.AttachCardsTo(landspeeder, sensorPanel);
+
+        assertEquals("Sensor Panel adds 1 to power", 2, scn.GetPower(landspeeder));
+        assertEquals("Sensor Panel adds 1 to landspeed", 5, scn.GetLandspeed(landspeeder));
+    }
+
+    @Test
+    public void SensorPanelOptionalActionUnavailableWithoutOneForce() {
+        var scn = GetScenario();
+        var sensorPanel = scn.GetLSCard("sensorPanel");
+        var barrier = scn.GetDSCard("barrier");
+
+        scn.StartGame();
+        setupSensorPanelOnLandspeeder(scn);
+        scn.MoveCardsToHand(barrier);
+
+        scn.SkipToLSTurn(Phase.CONTROL);
+        // Radar Scanner costs 1 Force; leave exactly 1 so Sensor Panel cannot pay afterwards.
+        leaveExactlyLSForce(scn, 1);
+        assertEquals(1, scn.GetLSForcePileCount());
+
+        playRadarScannerAndPeek(scn);
+        assertEquals(0, scn.GetLSForcePileCount());
+        assertFalse("Sensor Panel optional action costs 1 Force", sensorPanelOptionalAvailable(scn));
+    }
+
+    @Test
+    public void SensorPanelOptionalActionUnavailableIfNoEffectOrInterruptInHand() {
+        var scn = GetScenario();
+        var sensorPanel = scn.GetLSCard("sensorPanel");
+        var trooper = scn.GetDSCard("trooper");
+
+        scn.StartGame();
+        setupSensorPanelOnLandspeeder(scn);
+        scn.MoveCardsToHand(trooper);
+
+        scn.SkipToLSTurn(Phase.CONTROL);
+        playRadarScannerAndPeek(scn);
+        assertFalse("Stormtrooper is not an Effect or Interrupt", sensorPanelOptionalAvailable(scn));
+    }
+
+    @Test
+    public void SensorPanelMayBeUsedWhenRadarScannerDoesNotRemoveACard() {
+        var scn = GetScenario();
+        var sensorPanel = scn.GetLSCard("sensorPanel");
+        var barrier = scn.GetDSCard("barrier");
+
+        scn.StartGame();
+        setupSensorPanelOnLandspeeder(scn);
+        scn.MoveCardsToHand(barrier);
+
+        scn.SkipToLSTurn(Phase.CONTROL);
+        playRadarScannerAndPeek(scn);
+        assertTrue("Sensor Panel may be used even if Radar Scanner found no Jawa or Tusken Raider",
+                sensorPanelOptionalAvailable(scn));
+    }
+
+    @Test
+    public void SensorPanelMovesOneEffectFromOpponentsHandToUsedPile() {
+        var scn = GetScenario();
+        var sensorPanel = scn.GetLSCard("sensorPanel");
+        var barrier = scn.GetDSCard("barrier");
+        var elis = scn.GetDSCard("elis");
+
+        scn.StartGame();
+        setupSensorPanelOnLandspeeder(scn);
+        scn.MoveCardsToHand(barrier, elis);
+
+        scn.SkipToLSTurn(Phase.CONTROL);
+        int forceBefore = scn.GetLSForcePileCount();
+        playRadarScannerAndPeek(scn);
+
+        assertTrue(sensorPanelOptionalAvailable(scn));
+        scn.LSUseCardAction(sensorPanel, "Place Effect or Interrupt in Used Pile");
+        scn.PassAllResponses();
+        assertTrue("Imperial Barrier should be a legal Sensor Panel target. Decision: " + currentDecisionText(scn),
+                scn.LSAnyDecisionsAvailable() && scn.LSHasCardChoiceAvailable(barrier));
+        assertTrue("Elis Helrot should be a legal Sensor Panel target", scn.LSHasCardChoiceAvailable(elis));
+        scn.LSChooseCard(barrier);
+        scn.PassAllResponses();
+
+        assertTrue("Imperial Barrier should be in Used Pile, not " + barrier.getZone(),
+                barrier.getZone() == Zone.USED_PILE || barrier.getZone() == Zone.TOP_OF_USED_PILE);
+        assertTrue(scn.GetDSUsedPile().contains(barrier));
+        assertEquals(Zone.HAND, elis.getZone());
+        assertEquals("Sensor Panel uses 1 Force after Radar Scanner's 1 Force", forceBefore - 2, scn.GetLSForcePileCount());
+    }
+
+    @Test
+    public void SensorPanelOncePerTurnEnforced() {
+        var scn = GetScenario();
+        var sensorPanel = scn.GetLSCard("sensorPanel");
+        var radarScanner2 = scn.GetLSCard("radarScanner2");
+        var barrier = scn.GetDSCard("barrier");
+        var elis = scn.GetDSCard("elis");
+
+        scn.StartGame();
+        setupSensorPanelOnLandspeeder(scn);
+        scn.MoveCardsToHand(radarScanner2);
+        scn.MoveCardsToHand(barrier, elis);
+
+        scn.SkipToLSTurn(Phase.CONTROL);
+        playRadarScannerAndPeek(scn);
+        assertTrue(sensorPanelOptionalAvailable(scn));
+        scn.LSUseCardAction(sensorPanel, "Place Effect or Interrupt in Used Pile");
+        scn.PassAllResponses();
+        assertTrue("Imperial Barrier should be a legal Sensor Panel target. Decision: " + currentDecisionText(scn),
+                scn.LSAnyDecisionsAvailable() && scn.LSHasCardChoiceAvailable(barrier));
+        scn.LSChooseCard(barrier);
+        scn.PassAllResponses();
+        finishRadarScannerToControl(scn);
+
+        playRadarScannerAndPeek(scn, radarScanner2);
+        assertFalse("Sensor Panel is once per turn", sensorPanelOptionalAvailable(scn));
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/light/Card_2_029_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/light/Card_2_029_Tests.java
@@ -213,6 +213,8 @@ public class Card_2_029_Tests {
             add(Icon.DEVICE);
             add(Icon.A_NEW_HOPE);
         }});
+		scn.BlueprintKeywordCheck(card, new ArrayList<>() {{
+		}});
         assertEquals(ExpansionSet.A_NEW_HOPE, card.getExpansionSet());
         assertEquals(Rarity.U2, card.getRarity());
     }


### PR DESCRIPTION
Implements Sensor Panel (`2_029`).

## Summary
A New Hope Light Device: deploy on your non-creature vehicle for +1 power and landspeed; once per turn after Radar Scanner, may pay 1 Force to move one Effect or Interrupt from opponent's hand to Used Pile.

## Card
- **Id / title:** `2_029` / Sensor Panel
- **Type:** Light Device, A New Hope
- **Game text:** Use 1 Force to deploy on your non-creature vehicle. Adds 1 to power and landspeed. Once per turn, when you play Radar Scanner, you may use 1 Force to move one additional Effect or Interrupt card found in opponent's hand to Used Pile.

## What changed
- Adds `Card2_029` with deploy-on-non-creature-vehicle, power/landspeed +1, and once-per-turn Radar Scanner follow-up
- Radar Scanner now emits a peek result so Sensor Panel can respond after a **single** look at opponent's hand (no second peek)
- Owner may resolve Radar Scanner's *may* and Sensor Panel's *may* in either order

## Design choices
- Creature vehicles (e.g. Rogue Bantha) are illegal deploy targets
- Sensor Panel still available if Radar Scanner found no Jawa / Tusken Raider, as long as opponent's hand has an Effect or Interrupt and 1 Force remains

## Tests
`Card_2_029_Tests` — **10** tests:
- Stats/keywords
- Deploy on owner's non-creature vehicle (Luke's X-34 Landspeeder)
- May not deploy on a creature vehicle
- May not deploy unless 1 Force is available
- Adds 1 to power and landspeed
- Optional action unavailable without 1 Force
- Optional action unavailable if hand has no Effect/Interrupt
- May use even when Radar Scanner found no Jawa/Tusken
- Pay 1 Force to move Effect/Interrupt to Used Pile
- Once per turn across a second Radar Scanner

## Known gaps
- None noted for this card

Closes #79

---
Tests follow VHD/PlayersCommittee naming (method names lead with card title + behavior; exclusive BlueprintIconCheck/KeywordCheck where applicable).