### PR TITLE
Fix Destroyed Homestead (7_226) required Control-phase Force loss

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set7/dark/Card7_226.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set7/dark/Card7_226.java
@@ -122,8 +122,8 @@ public class Card7_226 extends AbstractUtinniEffect {
         GameTextActionId gameTextActionId = GameTextActionId.OTHER_CARD_ACTION_1;
 
         // Check condition(s)
-        // Check if reached end of control phase and action was not performed yet.
-        if (TriggerConditions.isEndOfOpponentsPhase(game, self, effectResult, Phase.CONTROL)
+        // Check if reached end of owner's control phase and action was not performed yet.
+        if (TriggerConditions.isEndOfYourPhase(game, self, effectResult, Phase.CONTROL)
                 && GameConditions.isOnceDuringYourPhase(game, self, playerId, gameTextSourceCardId, gameTextActionId, Phase.CONTROL)) {
 
             final RequiredGameTextTriggerAction action = new RequiredGameTextTriggerAction(self, gameTextSourceCardId, gameTextActionId);

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set7/dark/Card_7_226_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set7/dark/Card_7_226_Tests.java
@@ -1,0 +1,218 @@
+package com.gempukku.swccgo.cards.set7.dark;
+
+import com.gempukku.swccgo.common.CardSubtype;
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.TargetId;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Card_7_226_Tests {
+
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("luke", "1_019");
+                }},
+                new HashMap<>() {{
+                    put("homestead", "7_226");
+                    put("farm", "1_294");
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    /** Farm on table, Luke elsewhere so the Utinni is not canceled, Homestead attached targeting Luke. */
+    private void putHomesteadInPlay(VirtualTableScenario scn) {
+        var farm = scn.GetDSCard("farm");
+        var homestead = scn.GetDSCard("homestead");
+        var luke = scn.GetLSCard("luke");
+
+        scn.MoveLocationToTable(farm);
+        scn.MoveCardsToLocation(scn.GetLSStartingLocation(), luke);
+        scn.AttachCardsTo(farm, homestead);
+        homestead.setTargetedCard(TargetId.UTINNI_EFFECT_TARGET_1, 0, luke, Filters.any);
+        assertTrue(scn.IsAttachedTo(farm, homestead));
+    }
+
+    /** Leave the opening Dark Control empty, then put Homestead in play and arrive at Dark Side's next Control with Light Side Force already activated. */
+    private void reachDSControlWithHomestead(VirtualTableScenario scn) {
+        scn.SkipToPhase(Phase.DEPLOY);
+        putHomesteadInPlay(scn);
+        scn.SkipToLSTurn();
+        scn.SkipToDSTurn(Phase.CONTROL);
+        assertTrue(scn.AwaitingDSControlPhaseActions());
+    }
+
+    /** True when Dark Side can click Homestead's "lose 1 Force" Control action. */
+    private boolean homesteadForceLossAvailable(VirtualTableScenario scn) {
+        if (!scn.DSAnyDecisionsAvailable()) {
+            return false;
+        }
+        var homestead = scn.GetDSCard("homestead");
+        return scn.DSCardActionAvailable(homestead, "lose 1 Force")
+                || scn.DSActionAvailable("lose 1 Force");
+    }
+
+    /** Click Homestead's Control-phase Force loss and have Light Side pay it from Force Pile. */
+    private void clickHomesteadForceLoss(VirtualTableScenario scn) {
+        var homestead = scn.GetDSCard("homestead");
+        assertTrue(homesteadForceLossAvailable(scn));
+        scn.DSUseCardAction(homestead, "lose 1 Force");
+        resolveOpponentLosesOneFromForcePile(scn);
+    }
+
+    /** Pass response windows, then Light Side chooses the top of Force Pile as the 1 Force lost. */
+    private void resolveOpponentLosesOneFromForcePile(VirtualTableScenario scn) {
+        for (int i = 0; i < 12; i++) {
+            if (scn.LSDecisionAvailable("Choose Force to lose")) {
+                assertTrue(scn.GetLSForcePileCount() >= 1);
+                scn.LSChooseCard(scn.GetTopOfLSForcePile());
+                continue;
+            }
+            if (scn.GetCurrentDecision() == null) {
+                return;
+            }
+            String text = scn.GetCurrentDecision().getText().toLowerCase();
+            if (text.contains("optional") || text.contains("about to lose") || text.contains("required")
+                    || text.contains("force loss initiated")) {
+                scn.PassResponses();
+                continue;
+            }
+            return;
+        }
+    }
+
+    @Test
+    public void StatsAndKeywordsAreCorrect_7_226_DestroyedHomestead() {
+        /**
+         * Title: Destroyed Homestead
+         * Uniqueness: Unique
+         * Side: Dark
+         * Type: Effect
+         * Subtype: Utinni
+         * Destiny: 5
+         * Game Text: Deploy on Lars' Moisture Farm. Target Obi-Wan or Luke. Target may not apply ability toward
+         *         drawing destiny for Sense, Alter or battle destiny. Opponent loses 1 Force during each of your
+         *         control phases. Utinni Effect canceled when reached by target.
+         * Set: Special Edition
+         * Rarity: R
+         */
+        var scn = GetScenario();
+        var card = scn.GetDSCard("homestead").getBlueprint();
+
+        assertEquals("Destroyed Homestead", card.getTitle());
+        assertEquals(Uniqueness.UNIQUE, card.getUniqueness());
+        assertEquals(Side.DARK, card.getSide());
+        assertTrue(card.isCardType(CardType.EFFECT));
+        assertEquals(CardSubtype.UTINNI, card.getCardSubtype());
+        assertEquals(5, card.getDestiny(), scn.epsilon);
+        assertEquals(ExpansionSet.SPECIAL_EDITION, card.getExpansionSet());
+        assertEquals(Rarity.R, card.getRarity());
+        assertEquals(1, card.getIconCount(Icon.SPECIAL_EDITION));
+        assertEquals(1, card.getIconCount(Icon.EFFECT));
+    }
+
+    @Test
+    public void ManualClickDuringYourControlPhaseMakesOpponentLoseOneForce_7_226_DestroyedHomestead() {
+        var scn = GetScenario();
+        scn.StartGame();
+        reachDSControlWithHomestead(scn);
+
+        int lsForce = scn.GetLSForcePileCount();
+        int dsForce = scn.GetDSForcePileCount();
+        int lsLost = scn.GetLSLostPileCount();
+        assertTrue(lsForce >= 1);
+
+        clickHomesteadForceLoss(scn);
+
+        assertEquals(lsForce - 1, scn.GetLSForcePileCount());
+        assertEquals(lsLost + 1, scn.GetLSLostPileCount());
+        assertEquals(dsForce, scn.GetDSForcePileCount());
+        assertFalse(homesteadForceLossAvailable(scn));
+    }
+
+    @Test
+    public void BothPlayersPassingStillMakesOpponentLoseOneForce_7_226_DestroyedHomestead() {
+        var scn = GetScenario();
+        scn.StartGame();
+        reachDSControlWithHomestead(scn);
+
+        int lsForce = scn.GetLSForcePileCount();
+        int dsForce = scn.GetDSForcePileCount();
+        int lsLost = scn.GetLSLostPileCount();
+        assertTrue(lsForce >= 1);
+        assertTrue(homesteadForceLossAvailable(scn));
+
+        scn.PassControlActions();
+        resolveOpponentLosesOneFromForcePile(scn);
+
+        assertEquals(lsForce - 1, scn.GetLSForcePileCount());
+        assertEquals(lsLost + 1, scn.GetLSLostPileCount());
+        assertEquals(dsForce, scn.GetDSForcePileCount());
+    }
+
+    @Test
+    public void ClickingOnceDoesNotLoseASecondForceAtEndOfPhase_7_226_DestroyedHomestead() {
+        var scn = GetScenario();
+        scn.StartGame();
+        reachDSControlWithHomestead(scn);
+
+        int lsForce = scn.GetLSForcePileCount();
+        int lsLost = scn.GetLSLostPileCount();
+        assertTrue(lsForce >= 1);
+
+        clickHomesteadForceLoss(scn);
+        assertEquals(lsForce - 1, scn.GetLSForcePileCount());
+        assertFalse(homesteadForceLossAvailable(scn));
+
+        scn.PassControlActions();
+        resolveOpponentLosesOneFromForcePile(scn);
+
+        assertEquals(lsForce - 1, scn.GetLSForcePileCount());
+        assertEquals(lsLost + 1, scn.GetLSLostPileCount());
+    }
+
+    @Test
+    public void DoesNotFireDuringOpponentsControlPhase_7_226_DestroyedHomestead() {
+        var scn = GetScenario();
+        scn.StartGame();
+        scn.SkipToPhase(Phase.DEPLOY);
+        putHomesteadInPlay(scn);
+        scn.SkipToLSTurn(Phase.CONTROL);
+        assertTrue(scn.AwaitingLSControlPhaseActions());
+
+        int lsForce = scn.GetLSForcePileCount();
+        int dsForce = scn.GetDSForcePileCount();
+        int lsLost = scn.GetLSLostPileCount();
+        int dsLost = scn.GetDSLostPileCount();
+
+        scn.SkipToPhase(Phase.DEPLOY);
+
+        assertEquals(lsForce, scn.GetLSForcePileCount());
+        assertEquals(dsForce, scn.GetDSForcePileCount());
+        assertEquals(lsLost, scn.GetLSLostPileCount());
+        assertEquals(dsLost, scn.GetDSLostPileCount());
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set7/dark/Card_7_226_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set7/dark/Card_7_226_Tests.java
@@ -4,6 +4,7 @@ import com.gempukku.swccgo.common.CardSubtype;
 import com.gempukku.swccgo.common.CardType;
 import com.gempukku.swccgo.common.ExpansionSet;
 import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Keyword;
 import com.gempukku.swccgo.common.Phase;
 import com.gempukku.swccgo.common.Rarity;
 import com.gempukku.swccgo.common.Side;
@@ -13,6 +14,8 @@ import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.framework.StartingSetup;
 import com.gempukku.swccgo.framework.VirtualTableScenario;
 import org.junit.Test;
+
+import java.util.ArrayList;
 
 import java.util.HashMap;
 
@@ -105,7 +108,7 @@ public class Card_7_226_Tests {
     }
 
     @Test
-    public void StatsAndKeywordsAreCorrect_7_226_DestroyedHomestead() {
+    public void DestroyedHomesteadStatsAndKeywordsAreCorrect() {
         /**
          * Title: Destroyed Homestead
          * Uniqueness: Unique
@@ -130,12 +133,16 @@ public class Card_7_226_Tests {
         assertEquals(5, card.getDestiny(), scn.epsilon);
         assertEquals(ExpansionSet.SPECIAL_EDITION, card.getExpansionSet());
         assertEquals(Rarity.R, card.getRarity());
-        assertEquals(1, card.getIconCount(Icon.SPECIAL_EDITION));
-        assertEquals(1, card.getIconCount(Icon.EFFECT));
+        scn.BlueprintIconCheck(card, new ArrayList<>() {{
+            add(Icon.SPECIAL_EDITION);
+            add(Icon.EFFECT);
+        }});
+        scn.BlueprintKeywordCheck(card, new ArrayList<>() {{
+        }});
     }
 
     @Test
-    public void ManualClickDuringYourControlPhaseMakesOpponentLoseOneForce_7_226_DestroyedHomestead() {
+    public void DestroyedHomesteadManualClickDuringYourControlPhaseMakesOpponentLoseOneForce() {
         var scn = GetScenario();
         scn.StartGame();
         reachDSControlWithHomestead(scn);
@@ -154,7 +161,7 @@ public class Card_7_226_Tests {
     }
 
     @Test
-    public void BothPlayersPassingStillMakesOpponentLoseOneForce_7_226_DestroyedHomestead() {
+    public void DestroyedHomesteadBothPlayersPassingStillMakesOpponentLoseOneForce() {
         var scn = GetScenario();
         scn.StartGame();
         reachDSControlWithHomestead(scn);
@@ -174,7 +181,7 @@ public class Card_7_226_Tests {
     }
 
     @Test
-    public void ClickingOnceDoesNotLoseASecondForceAtEndOfPhase_7_226_DestroyedHomestead() {
+    public void DestroyedHomesteadClickingOnceDoesNotLoseASecondForceAtEndOfPhase() {
         var scn = GetScenario();
         scn.StartGame();
         reachDSControlWithHomestead(scn);
@@ -195,7 +202,7 @@ public class Card_7_226_Tests {
     }
 
     @Test
-    public void DoesNotFireDuringOpponentsControlPhase_7_226_DestroyedHomestead() {
+    public void DestroyedHomesteadDoesNotFireDuringOpponentsControlPhase() {
         var scn = GetScenario();
         scn.StartGame();
         scn.SkipToPhase(Phase.DEPLOY);


### PR DESCRIPTION
Fix Destroyed Homestead (`7_226`) so the required Control-phase Force loss still fires when both players pass.

## Card text
**Destroyed Homestead** (Unique, Dark, Utinni Effect, Special Edition, R)

Deploy on Lars' Moisture Farm. Target Obi-Wan or Luke. Target may not apply ability toward drawing destiny for Sense, Alter or battle destiny. Opponent loses 1 Force during each of your control phases. Utinni Effect canceled when reached by target.

## What was wrong
Dark Side could click the Effect during Control and Light Side lost 1 Force. If Dark Side did not click and both players passed, Light Side lost nothing.

The required end-of-phase trigger used `isEndOfOpponentsPhase` together with `isOnceDuringYourPhase`. Those two conditions cannot both be true, so the automatic loss never fired.

## What changed
The required trigger now uses `TriggerConditions.isEndOfYourPhase(..., Phase.CONTROL)`, matching Search And Destroy (`8_131`) and Defel (`2_087`). The top-level click and the required trigger still share `GameTextActionId.OTHER_CARD_ACTION_1`, so clicking once prevents a second loss at the end of the phase.

Deploy, targeting, cancel-when-reached, and ability-destiny modifiers are unchanged. Search And Destroy itself is unchanged.

## Tests
`Card_7_226_Tests` — **5 run / 0 fail**.

- Stats and keywords
- Manual click during your Control: opponent loses 1 Force
- Both players pass during your Control: opponent still loses 1 Force
- Click once, then leave Control: only 1 Force lost
- Does not fire during opponent's Control phase

## Known gaps
None for this Force-loss fix.