### PR TITLE
Show targeting on both sides of Card Information

### DIFF
--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/GameUtils.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/GameUtils.java
@@ -3,8 +3,10 @@ package com.gempukku.swccgo.logic;
 import com.gempukku.swccgo.common.CardCategory;
 import com.gempukku.swccgo.common.Title;
 import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.game.SwccgCardBlueprint;
+import com.gempukku.swccgo.game.state.GameState;
 
 import java.util.*;
 
@@ -279,6 +281,24 @@ public class GameUtils {
             return "none";
         else
             return sb.substring(0, sb.length() - 2);
+    }
+
+    /**
+     * Cards that have this card as an explicit target (Utinni Effects, etc.).
+     * @param gameState the game state
+     * @param card the card that may be targeted
+     * @return unique cards currently in play whose targeting map contains the given card, excluding the card itself
+     */
+    public static List<PhysicalCard> getCardsTargeting(GameState gameState, PhysicalCard card) {
+        List<PhysicalCard> cardsTargeting = new LinkedList<PhysicalCard>();
+        for (PhysicalCard cardInPlay : Filters.filterAllOnTable(gameState.getGame(), Filters.any)) {
+            if (card.getPermanentCardId() != cardInPlay.getPermanentCardId()
+                    && cardInPlay.getTargetedCards(gameState).values().contains(card)
+                    && !cardsTargeting.contains(cardInPlay)) {
+                cardsTargeting.add(cardInPlay);
+            }
+        }
+        return cardsTargeting;
     }
 
     /**

--- a/src/gemp-swccg-server/src/main/java/com/gempukku/swccgo/game/SwccgGameMediator.java
+++ b/src/gemp-swccg-server/src/main/java/com/gempukku/swccgo/game/SwccgGameMediator.java
@@ -851,6 +851,14 @@ public class SwccgGameMediator {
                         sb.append("</div>");
                     }
                 }
+
+                // Cards that have this card as an explicit target (Utinni Effects, etc.)
+                List<PhysicalCard> targetedBy = GameUtils.getCardsTargeting(gameState, card);
+                if (!targetedBy.isEmpty()) {
+                    sb.append("<div>");
+                    sb.append("Targeted by: ").append(GameUtils.getAppendedNames(targetedBy));
+                    sb.append("</div>");
+                }
             }
 
             // 'Insert card' in Reserve Deck information (if applicable)

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/CardInfoTargetedBy_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/CardInfoTargetedBy_Tests.java
@@ -1,0 +1,182 @@
+package com.gempukku.swccgo.cards;
+
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.logic.GameUtils;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Engine/UI reverse-targeting for Card Information: GameUtils.getCardsTargeting
+ * walks getTargetedCards across all cards in play (not limited to one Utinni).
+ */
+public class CardInfoTargetedBy_Tests {
+
+    protected VirtualTableScenario GetHomesteadScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("luke", "1_019"); // Premiere Luke Skywalke
+                    put("farm", "1_132"); // Tatooine: Lars' Moisture Farm
+                }},
+                new HashMap<>() {{
+                    put("homestead", "7_226"); // Destroyed Homestead
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    protected VirtualTableScenario GetLateralDamageScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("falcon", "1_143"); // Millennium Falcon
+                    put("yavin", "1_135"); // Yavin 4 system (Falcon stays here)
+                }},
+                new HashMap<>() {{
+                    put("lateral", "1_222"); // Lateral Damage
+                    put("tatooine", "1_289"); // Tatooine system (Utinni deploys here)
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    // Homestead cancels if Luke is already at the farm, so Luke stays at the Light starting location.
+    private void deployHomesteadTargetingLuke(VirtualTableScenario scn) {
+        var luke = scn.GetLSCard("luke");
+        var farm = scn.GetLSCard("farm");
+        var homestead = scn.GetDSCard("homestead");
+
+        scn.StartGame();
+        scn.MoveLocationToTable(farm);
+        scn.MoveCardsToLocation(scn.GetLSStartingLocation(), luke);
+        scn.MoveCardsToDSHand(homestead);
+        scn.SkipToPhase(Phase.DEPLOY);
+
+        scn.DSDeployCard(homestead);
+        scn.DSChooseCard(farm);
+        scn.DSChooseCard(luke);
+        scn.PassAllResponses();
+    }
+
+    // Lateral Damage cancels/triggers if Falcon is at the same system, so Falcon stays at Yavin 4.
+    private void deployLateralDamageTargetingFalcon(VirtualTableScenario scn) {
+        var falcon = scn.GetLSCard("falcon");
+        var yavin = scn.GetLSCard("yavin");
+        var tatooine = scn.GetDSCard("tatooine");
+        var lateral = scn.GetDSCard("lateral");
+
+        scn.StartGame();
+        scn.MoveLocationToTable(yavin);
+        scn.MoveLocationToTable(tatooine);
+        scn.MoveCardsToLocation(yavin, falcon);
+        scn.MoveCardsToDSHand(lateral);
+        scn.SkipToPhase(Phase.DEPLOY);
+
+        scn.DSDeployCard(lateral);
+        scn.DSChooseCard(tatooine);
+        scn.DSChooseCard(falcon);
+        scn.PassAllResponses();
+    }
+
+    @Test
+    public void DestroyedHomestead_7_226_CardInfoListsLukeAsTarget() {
+        var scn = GetHomesteadScenario();
+        deployHomesteadTargetingLuke(scn);
+
+        var luke = scn.GetLSCard("luke");
+        var homestead = scn.GetDSCard("homestead");
+
+        assertTrue(homestead.getZone().isInPlay());
+        assertTrue(homestead.getTargetedCards(scn.gameState()).containsValue(luke));
+        assertTrue(homestead.getTargetedCards(scn.gameState()).values().stream().anyMatch(c -> "Luke Skywalker".equals(c.getTitle())));
+    }
+
+    @Test
+    public void LukeSkywalker_CardInfoListsDestroyedHomesteadAsTargetedBy_7_226() {
+        var scn = GetHomesteadScenario();
+        deployHomesteadTargetingLuke(scn);
+
+        var luke = scn.GetLSCard("luke");
+        var homestead = scn.GetDSCard("homestead");
+
+        List<PhysicalCard> targetedBy = GameUtils.getCardsTargeting(scn.gameState(), luke);
+        assertEquals(1, targetedBy.size());
+        assertTrue(targetedBy.contains(homestead));
+        assertEquals("Destroyed Homestead", targetedBy.get(0).getTitle());
+    }
+
+    @Test
+    public void LateralDamage_1_222_CardInfoListsFalconAsTarget() {
+        var scn = GetLateralDamageScenario();
+        deployLateralDamageTargetingFalcon(scn);
+
+        var falcon = scn.GetLSCard("falcon");
+        var lateral = scn.GetDSCard("lateral");
+
+        assertTrue(lateral.getZone().isInPlay());
+        assertTrue(lateral.getTargetedCards(scn.gameState()).containsValue(falcon));
+        assertTrue(lateral.getTargetedCards(scn.gameState()).values().stream().anyMatch(c -> "Millennium Falcon".equals(c.getTitle())));
+    }
+
+    @Test
+    public void MillenniumFalcon_CardInfoListsLateralDamageAsTargetedBy_1_222() {
+        var scn = GetLateralDamageScenario();
+        deployLateralDamageTargetingFalcon(scn);
+
+        var falcon = scn.GetLSCard("falcon");
+        var lateral = scn.GetDSCard("lateral");
+
+        List<PhysicalCard> targetedBy = GameUtils.getCardsTargeting(scn.gameState(), falcon);
+        assertEquals(1, targetedBy.size());
+        assertTrue(targetedBy.contains(lateral));
+        assertEquals("Lateral Damage", targetedBy.get(0).getTitle());
+    }
+
+    @Test
+    public void LukeSkywalker_CardInfoHasNoTargetedByWhenNoUtinni() {
+        var scn = GetHomesteadScenario();
+        var luke = scn.GetLSCard("luke");
+
+        scn.StartGame();
+        scn.MoveCardsToLocation(scn.GetLSStartingLocation(), luke);
+        scn.SkipToPhase(Phase.DEPLOY);
+
+        assertTrue(GameUtils.getCardsTargeting(scn.gameState(), luke).isEmpty());
+    }
+
+    @Test
+    public void MillenniumFalcon_CardInfoHasNoTargetedByWhenNoUtinni() {
+        var scn = GetLateralDamageScenario();
+        var falcon = scn.GetLSCard("falcon");
+        var yavin = scn.GetLSCard("yavin");
+
+        scn.StartGame();
+        scn.MoveLocationToTable(yavin);
+        scn.MoveCardsToLocation(yavin, falcon);
+        scn.SkipToPhase(Phase.DEPLOY);
+
+        assertTrue(GameUtils.getCardsTargeting(scn.gameState(), falcon).isEmpty());
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/CardInfoTargetedBy_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/CardInfoTargetedBy_Tests.java
@@ -101,7 +101,7 @@ public class CardInfoTargetedBy_Tests {
     }
 
     @Test
-    public void DestroyedHomestead_7_226_CardInfoListsLukeAsTarget() {
+    public void DestroyedHomesteadCardInfoListsLukeAsTarget() {
         var scn = GetHomesteadScenario();
         deployHomesteadTargetingLuke(scn);
 
@@ -114,7 +114,7 @@ public class CardInfoTargetedBy_Tests {
     }
 
     @Test
-    public void LukeSkywalker_CardInfoListsDestroyedHomesteadAsTargetedBy_7_226() {
+    public void LukeSkywalkerCardInfoListsDestroyedHomesteadAsTargetedBy() {
         var scn = GetHomesteadScenario();
         deployHomesteadTargetingLuke(scn);
 
@@ -128,7 +128,7 @@ public class CardInfoTargetedBy_Tests {
     }
 
     @Test
-    public void LateralDamage_1_222_CardInfoListsFalconAsTarget() {
+    public void LateralDamageCardInfoListsFalconAsTarget() {
         var scn = GetLateralDamageScenario();
         deployLateralDamageTargetingFalcon(scn);
 
@@ -141,7 +141,7 @@ public class CardInfoTargetedBy_Tests {
     }
 
     @Test
-    public void MillenniumFalcon_CardInfoListsLateralDamageAsTargetedBy_1_222() {
+    public void MillenniumFalconCardInfoListsLateralDamageAsTargetedBy() {
         var scn = GetLateralDamageScenario();
         deployLateralDamageTargetingFalcon(scn);
 
@@ -155,7 +155,7 @@ public class CardInfoTargetedBy_Tests {
     }
 
     @Test
-    public void LukeSkywalker_CardInfoHasNoTargetedByWhenNoUtinni() {
+    public void LukeSkywalkerCardInfoHasNoTargetedByWhenNoUtinni() {
         var scn = GetHomesteadScenario();
         var luke = scn.GetLSCard("luke");
 
@@ -167,7 +167,7 @@ public class CardInfoTargetedBy_Tests {
     }
 
     @Test
-    public void MillenniumFalcon_CardInfoHasNoTargetedByWhenNoUtinni() {
+    public void MillenniumFalconCardInfoHasNoTargetedByWhenNoUtinni() {
         var scn = GetLateralDamageScenario();
         var falcon = scn.GetLSCard("falcon");
         var yavin = scn.GetLSCard("yavin");

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set3/dark/Card_3_099_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set3/dark/Card_3_099_Tests.java
@@ -1,0 +1,96 @@
+package com.gempukku.swccgo.cards.set3.dark;
+
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.logic.GameUtils;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class Card_3_099_Tests {
+
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("han", "1_011"); // Premiere Han Solo (smuggler)
+                    put("farm", "1_132"); // Tatooine: Lars' Moisture Farm (exterior planet site)
+                }},
+                new HashMap<>() {{
+                    put("death-mark", "3_099"); // Death Mark
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    // Put Han at the Farm, then deploy Death Mark there targeting him.
+    private void deployDeathMarkTargetingHan(VirtualTableScenario scn) {
+        var han = scn.GetLSCard("han");
+        var farm = scn.GetLSCard("farm");
+        var deathMark = scn.GetDSCard("death-mark");
+
+        scn.StartGame();
+        scn.MoveLocationToTable(farm);
+        scn.MoveCardsToLocation(farm, han);
+        scn.MoveCardsToDSHand(deathMark);
+        scn.SkipToPhase(Phase.DEPLOY);
+
+        scn.DSDeployCard(deathMark);
+        scn.DSChooseCard(farm);
+        scn.DSChooseCard(han);
+        scn.PassAllResponses();
+    }
+
+    @Test
+    public void DeathMark_3_099_CardInfoListsHanAsTarget() {
+        var scn = GetScenario();
+        var han = scn.GetLSCard("han");
+        var deathMark = scn.GetDSCard("death-mark");
+
+        deployDeathMarkTargetingHan(scn);
+
+        assertTrue(deathMark.getTargetedCards(scn.gameState()).containsValue(han));
+        assertEquals("Han Solo", deathMark.getTargetedCards(scn.gameState()).values().iterator().next().getTitle());
+    }
+
+    @Test
+    public void HanSolo_CardInfoListsDeathMarkAsTargetedBy_3_099() {
+        var scn = GetScenario();
+        var han = scn.GetLSCard("han");
+        var deathMark = scn.GetDSCard("death-mark");
+
+        deployDeathMarkTargetingHan(scn);
+
+        List<PhysicalCard> targetedBy = GameUtils.getCardsTargeting(scn.gameState(), han);
+        assertEquals(1, targetedBy.size());
+        assertTrue(targetedBy.contains(deathMark));
+        assertEquals("Death Mark", targetedBy.get(0).getTitle());
+    }
+
+    @Test
+    public void HanSolo_CardInfoHasNoTargetedByWhenNoUtinni() {
+        var scn = GetScenario();
+        var han = scn.GetLSCard("han");
+        var farm = scn.GetLSCard("farm");
+
+        scn.StartGame();
+        scn.MoveLocationToTable(farm);
+        scn.MoveCardsToLocation(farm, han);
+        scn.SkipToPhase(Phase.DEPLOY);
+
+        assertTrue(GameUtils.getCardsTargeting(scn.gameState(), han).isEmpty());
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set3/dark/Card_3_099_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set3/dark/Card_3_099_Tests.java
@@ -64,7 +64,7 @@ public class Card_3_099_Tests {
 
         assertTrue(deathMark.getZone().isInPlay());
         assertTrue(deathMark.getTargetedCards(scn.gameState()).containsValue(han));
-        assertEquals("Han Solo", deathMark.getTargetedCards(scn.gameState()).values().iterator().next().getTitle());
+        assertTrue(deathMark.getTargetedCards(scn.gameState()).values().stream().anyMatch(c -> "Han Solo".equals(c.getTitle())));
     }
 
     @Test

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set3/dark/Card_3_099_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set3/dark/Card_3_099_Tests.java
@@ -36,7 +36,7 @@ public class Card_3_099_Tests {
         );
     }
 
-    // Put Han at the Farm, then deploy Death Mark there targeting him.
+    // Death Mark cancels if Han is already at its site, so Han stays at the Light starting location.
     private void deployDeathMarkTargetingHan(VirtualTableScenario scn) {
         var han = scn.GetLSCard("han");
         var farm = scn.GetLSCard("farm");
@@ -44,7 +44,7 @@ public class Card_3_099_Tests {
 
         scn.StartGame();
         scn.MoveLocationToTable(farm);
-        scn.MoveCardsToLocation(farm, han);
+        scn.MoveCardsToLocation(scn.GetLSStartingLocation(), han);
         scn.MoveCardsToDSHand(deathMark);
         scn.SkipToPhase(Phase.DEPLOY);
 
@@ -57,11 +57,12 @@ public class Card_3_099_Tests {
     @Test
     public void DeathMark_3_099_CardInfoListsHanAsTarget() {
         var scn = GetScenario();
+        deployDeathMarkTargetingHan(scn);
+
         var han = scn.GetLSCard("han");
         var deathMark = scn.GetDSCard("death-mark");
 
-        deployDeathMarkTargetingHan(scn);
-
+        assertTrue(deathMark.getZone().isInPlay());
         assertTrue(deathMark.getTargetedCards(scn.gameState()).containsValue(han));
         assertEquals("Han Solo", deathMark.getTargetedCards(scn.gameState()).values().iterator().next().getTitle());
     }
@@ -69,10 +70,10 @@ public class Card_3_099_Tests {
     @Test
     public void HanSolo_CardInfoListsDeathMarkAsTargetedBy_3_099() {
         var scn = GetScenario();
+        deployDeathMarkTargetingHan(scn);
+
         var han = scn.GetLSCard("han");
         var deathMark = scn.GetDSCard("death-mark");
-
-        deployDeathMarkTargetingHan(scn);
 
         List<PhysicalCard> targetedBy = GameUtils.getCardsTargeting(scn.gameState(), han);
         assertEquals(1, targetedBy.size());
@@ -84,11 +85,9 @@ public class Card_3_099_Tests {
     public void HanSolo_CardInfoHasNoTargetedByWhenNoUtinni() {
         var scn = GetScenario();
         var han = scn.GetLSCard("han");
-        var farm = scn.GetLSCard("farm");
 
         scn.StartGame();
-        scn.MoveLocationToTable(farm);
-        scn.MoveCardsToLocation(farm, han);
+        scn.MoveCardsToLocation(scn.GetLSStartingLocation(), han);
         scn.SkipToPhase(Phase.DEPLOY);
 
         assertTrue(GameUtils.getCardsTargeting(scn.gameState(), han).isEmpty());


### PR DESCRIPTION
Show Card Information targeting in both directions for every card that sets an explicit target.

## What changed
Card Information previously listed `Targets:` on the Effect only. The targeted card showed nothing.

`GameUtils.getCardsTargeting` reverses the engine's existing `getTargetedCards` map across all cards on table. The targeted card now lists `Targeted by:`. This is display-only and not special-cased to any single Utinni Effect, so characters, starships, sites, and other explicit targets all benefit.

Death Mark, Destroyed Homestead, and Lateral Damage are the test examples, not the scope.

## Tests
`Card_3_099_Tests` + `CardInfoTargetedBy_Tests` — **9 run / 0 fail**.

- Death Mark lists Han; Han lists Death Mark; Han alone has no `Targeted by:`
- Destroyed Homestead lists Luke; Luke lists Destroyed Homestead (character)
- Lateral Damage lists Millennium Falcon; Falcon lists Lateral Damage (starship)
- Luke / Falcon contrast cases with no Utinni

## Known gaps
None for this display change.