### PR TITLE
Implement Rescue In The Clouds (5_67)

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set209/light/Card209_022.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set209/light/Card209_022.java
@@ -35,7 +35,7 @@ import java.util.List;
  */
 public class Card209_022 extends AbstractUsedOrLostInterrupt {
     public Card209_022() {
-        super(Side.LIGHT, 5, "Rescue In The Clouds", Uniqueness.UNIQUE, ExpansionSet.SET_9, Rarity.V);
+        super(Side.LIGHT, 5, Title.Rescue_In_The_Clouds, Uniqueness.UNIQUE, ExpansionSet.SET_9, Rarity.V);
         setVirtualSuffix(true);
         setLore("'I know where Luke is.'");
         setGameText("USED: At a system or Bespin location, choose: Cancel a just drawn destiny targeting the ability or defense value of your non-Undercover character of ability < 5. OR During battle, draw one battle destiny if unable to otherwise. LOST: Cancel Close Call.");

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/light/Card5_067.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/light/Card5_067.java
@@ -1,0 +1,153 @@
+package com.gempukku.swccgo.cards.set5.light;
+
+import com.gempukku.swccgo.cards.AbstractUsedOrLostInterrupt;
+import com.gempukku.swccgo.cards.GameConditions;
+import com.gempukku.swccgo.common.CardSubtype;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.filters.Filter;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.TriggerConditions;
+import com.gempukku.swccgo.logic.actions.PlayInterruptAction;
+import com.gempukku.swccgo.logic.decisions.MultipleChoiceAwaitingDecision;
+import com.gempukku.swccgo.logic.effects.PlayoutDecisionEffect;
+import com.gempukku.swccgo.logic.effects.PutStackedCardInUsedPileEffect;
+import com.gempukku.swccgo.logic.effects.RespondablePlayCardEffect;
+import com.gempukku.swccgo.logic.effects.choose.ChooseStackedCardEffect;
+import com.gempukku.swccgo.logic.effects.choose.DeployCardToLocationFromHandEffect;
+import com.gempukku.swccgo.logic.timing.Action;
+import com.gempukku.swccgo.logic.timing.EffectResult;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Set: Cloud City
+ * Type: Interrupt
+ * Subtype: Used Or Lost
+ * Title: Rescue In The Clouds
+ */
+public class Card5_067 extends AbstractUsedOrLostInterrupt {
+    public Card5_067() {
+        super(Side.LIGHT, 5, Title.Rescue_In_The_Clouds, Uniqueness.UNIQUE, ExpansionSet.CLOUD_CITY, Rarity.C);
+        setLore("'I know where Luke is.'");
+        setGameText("USED: If you have a character on Weather Vane, place that character on your Used Pile. LOST: Deploy one or more vehicles, starfighters and pilots (at normal use of the Force) as a 'react' to a cloud sector.");
+        addIcons(Icon.CLOUD_CITY);
+    }
+
+    @Override
+    protected List<PlayInterruptAction> getGameTextTopLevelActions(final String playerId, SwccgGame game, final PhysicalCard self) {
+        List<PlayInterruptAction> actions = new LinkedList<PlayInterruptAction>();
+
+        Filter yourCharacterOnWeatherVane = Filters.and(Filters.your(self), Filters.character, Filters.stackedOn(self, Filters.Weather_Vane));
+
+        // Check condition(s)
+        if (GameConditions.canSpot(game, self, Filters.and(Filters.Weather_Vane, Filters.hasStacked(yourCharacterOnWeatherVane)))) {
+            final PhysicalCard weatherVane = Filters.findFirstActive(game, self, Filters.Weather_Vane);
+            if (weatherVane != null) {
+                final PlayInterruptAction action = new PlayInterruptAction(game, self, CardSubtype.USED);
+                action.setText("Place character from Weather Vane in Used Pile");
+                // Choose target(s)
+                action.appendTargeting(
+                        new ChooseStackedCardEffect(action, playerId, weatherVane, yourCharacterOnWeatherVane) {
+                            @Override
+                            protected void cardSelected(final PhysicalCard selectedCard) {
+                                action.addAnimationGroup(selectedCard);
+                                // Allow response(s)
+                                action.allowResponses("Place " + GameUtils.getCardLink(selectedCard) + " from Weather Vane in Used Pile",
+                                        new RespondablePlayCardEffect(action) {
+                                            @Override
+                                            protected void performActionResults(Action targetingAction) {
+                                                // Perform result(s)
+                                                action.appendEffect(
+                                                        new PutStackedCardInUsedPileEffect(action, playerId, selectedCard, false));
+                                            }
+                                        }
+                                );
+                            }
+                        }
+                );
+                actions.add(action);
+            }
+        }
+
+        return actions;
+    }
+
+    @Override
+    protected List<PlayInterruptAction> getGameTextOptionalAfterActions(final String playerId, SwccgGame game, EffectResult effectResult, final PhysicalCard self) {
+        final String opponent = game.getOpponent(playerId);
+        final Filter deployFilter = Filters.or(Filters.vehicle, Filters.starfighter, Filters.pilot);
+
+        // Check condition(s)
+        if ((TriggerConditions.battleInitiatedAt(game, effectResult, opponent, Filters.cloud_sector)
+                || TriggerConditions.forceDrainInitiatedBy(game, effectResult, opponent, Filters.cloud_sector))
+                && GameConditions.canSpotLocation(game, Filters.cloud_sector)
+                && GameConditions.hasInHand(game, playerId, deployFilter)) {
+
+            final PlayInterruptAction action = new PlayInterruptAction(game, self, CardSubtype.LOST);
+            action.setText("Deploy as a 'react' to a cloud sector");
+            // Allow response(s)
+            action.allowResponses("Deploy vehicles, starfighters, and pilots as a 'react' to a cloud sector",
+                    new RespondablePlayCardEffect(action) {
+                        @Override
+                        protected void performActionResults(Action targetingAction) {
+                            appendDeployAsReactFromHand(action, playerId, game, self, deployFilter, true);
+                        }
+                    }
+            );
+            return Collections.singletonList(action);
+        }
+        return null;
+    }
+
+    private void appendDeployAsReactFromHand(final PlayInterruptAction action, final String playerId, final SwccgGame game, final PhysicalCard self, final Filter deployFilter, final boolean required) {
+        if (!GameConditions.hasInHand(game, playerId, deployFilter)) {
+            return;
+        }
+
+        action.appendEffect(
+                new DeployCardToLocationFromHandEffect(action, playerId, deployFilter, Filters.cloud_sector, false, true) {
+                    @Override
+                    public String getChoiceText() {
+                        if (required) {
+                            return "Choose vehicle, starfighter, or pilot to deploy as a 'react'";
+                        }
+                        return "Choose another vehicle, starfighter, or pilot to deploy as a 'react'";
+                    }
+
+                    @Override
+                    protected void cardDeployed(PhysicalCard card) {
+                        appendOptionalAdditionalReactDeploys(action, playerId, game, self, deployFilter);
+                    }
+                }
+        );
+    }
+
+    private void appendOptionalAdditionalReactDeploys(final PlayInterruptAction action, final String playerId, final SwccgGame game, final PhysicalCard self, final Filter deployFilter) {
+        if (!GameConditions.hasInHand(game, playerId, deployFilter)) {
+            return;
+        }
+
+        action.appendEffect(
+                new PlayoutDecisionEffect(action, playerId,
+                        new MultipleChoiceAwaitingDecision("Deploy another vehicle, starfighter, or pilot as a 'react'?", new String[]{"Yes", "No"}) {
+                            @Override
+                            protected void validDecisionMade(int index, String result) {
+                                if (index == 0) {
+                                    appendDeployAsReactFromHand(action, playerId, game, self, deployFilter, false);
+                                }
+                            }
+                        }
+                )
+        );
+    }
+}

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/light/Card5_067.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/light/Card5_067.java
@@ -12,6 +12,7 @@ import com.gempukku.swccgo.common.Uniqueness;
 import com.gempukku.swccgo.filters.Filter;
 import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.ReactActionOption;
 import com.gempukku.swccgo.game.SwccgGame;
 import com.gempukku.swccgo.game.state.GameState;
 import com.gempukku.swccgo.logic.modifiers.querying.ModifiersQuerying;
@@ -125,6 +126,13 @@ public class Card5_067 extends AbstractUsedOrLostInterrupt {
         return null;
     }
 
+    private Filter fullyDeployableAsReactFilter(PhysicalCard self, Filter deployFilter, Filter locationFilter) {
+        Filter targetFilter = Filters.locationAndCardsAtLocation(locationFilter);
+        ReactActionOption reactOption = new ReactActionOption(self, false, 0, false, "Deploy as a 'react'", deployFilter, targetFilter, null, false);
+        reactOption.setForFreeCardFilter(Filters.none);
+        return Filters.and(deployFilter, Filters.deployableToTarget(self, targetFilter, false, false, 0, null, null, null, null, reactOption));
+    }
+
     private void appendDeployAsReactFromHand(final PlayInterruptAction action, final String playerId, final SwccgGame game, final PhysicalCard self, final Filter deployFilter, final Filter locationFilter, final boolean required) {
         if (required) {
             if (!GameConditions.hasInHand(game, playerId, deployFilter)) {
@@ -149,12 +157,13 @@ public class Card5_067 extends AbstractUsedOrLostInterrupt {
             return;
         }
 
-        if (!GameConditions.hasInHand(game, playerId, deployFilter)) {
+        Filter extraFilter = fullyDeployableAsReactFilter(self, deployFilter, locationFilter);
+        if (!GameConditions.hasInHand(game, playerId, extraFilter)) {
             return;
         }
 
         action.appendEffect(
-                new ChooseCardsFromHandEffect(action, playerId, playerId, 0, 1, deployFilter, true, false) {
+                new ChooseCardsFromHandEffect(action, playerId, playerId, 0, 1, extraFilter, true, false) {
                     @Override
                     public String getChoiceText(int numCardsToChoose) {
                         return "Choose another vehicle, starfighter, or pilot to deploy as a 'react', or click 'Done' to stop";

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/light/Card5_067.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/light/Card5_067.java
@@ -18,15 +18,15 @@ import com.gempukku.swccgo.logic.modifiers.querying.ModifiersQuerying;
 import com.gempukku.swccgo.logic.GameUtils;
 import com.gempukku.swccgo.logic.TriggerConditions;
 import com.gempukku.swccgo.logic.actions.PlayInterruptAction;
-import com.gempukku.swccgo.logic.decisions.MultipleChoiceAwaitingDecision;
-import com.gempukku.swccgo.logic.effects.PlayoutDecisionEffect;
 import com.gempukku.swccgo.logic.effects.PutStackedCardInUsedPileEffect;
 import com.gempukku.swccgo.logic.effects.RespondablePlayCardEffect;
+import com.gempukku.swccgo.logic.effects.choose.ChooseCardsFromHandEffect;
 import com.gempukku.swccgo.logic.effects.choose.ChooseStackedCardEffect;
 import com.gempukku.swccgo.logic.effects.choose.DeployCardToLocationFromHandEffect;
 import com.gempukku.swccgo.logic.timing.Action;
 import com.gempukku.swccgo.logic.timing.EffectResult;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -124,40 +124,50 @@ public class Card5_067 extends AbstractUsedOrLostInterrupt {
             return;
         }
 
-        action.appendEffect(
-                new DeployCardToLocationFromHandEffect(action, playerId, deployFilter, Filters.cloud_sector, false, true) {
-                    @Override
-                    public String getChoiceText() {
-                        if (required) {
+        if (required) {
+            action.appendEffect(
+                    new DeployCardToLocationFromHandEffect(action, playerId, deployFilter, Filters.cloud_sector, false, true) {
+                        @Override
+                        public String getChoiceText() {
                             return "Choose vehicle, starfighter, or pilot to deploy as a 'react'";
                         }
-                        return "Choose another vehicle, starfighter, or pilot to deploy as a 'react'";
+
+                        @Override
+                        protected void cardDeployed(PhysicalCard card) {
+                            appendOptionalAdditionalReactDeploys(action, playerId, game, self, deployFilter);
+                        }
+                    }
+            );
+            return;
+        }
+
+        action.appendEffect(
+                new ChooseCardsFromHandEffect(action, playerId, playerId, 0, 1, deployFilter, true, false) {
+                    @Override
+                    public String getChoiceText(int numCardsToChoose) {
+                        return "Choose another vehicle, starfighter, or pilot to deploy as a 'react', or click 'Done' to stop";
                     }
 
                     @Override
-                    protected void cardDeployed(PhysicalCard card) {
-                        appendOptionalAdditionalReactDeploys(action, playerId, game, self, deployFilter);
+                    protected void cardsSelected(SwccgGame game, Collection<PhysicalCard> selectedCards) {
+                        if (selectedCards.isEmpty()) {
+                            return;
+                        }
+                        PhysicalCard selectedCard = selectedCards.iterator().next();
+                        action.appendEffect(
+                                new DeployCardToLocationFromHandEffect(action, selectedCard, Filters.cloud_sector, false, true) {
+                                    @Override
+                                    protected void cardDeployed(PhysicalCard card) {
+                                        appendOptionalAdditionalReactDeploys(action, playerId, game, self, deployFilter);
+                                    }
+                                }
+                        );
                     }
                 }
         );
     }
 
     private void appendOptionalAdditionalReactDeploys(final PlayInterruptAction action, final String playerId, final SwccgGame game, final PhysicalCard self, final Filter deployFilter) {
-        if (!GameConditions.hasInHand(game, playerId, deployFilter)) {
-            return;
-        }
-
-        action.appendEffect(
-                new PlayoutDecisionEffect(action, playerId,
-                        new MultipleChoiceAwaitingDecision("Deploy another vehicle, starfighter, or pilot as a 'react'?", new String[]{"Yes", "No"}) {
-                            @Override
-                            protected void validDecisionMade(int index, String result) {
-                                if (index == 0) {
-                                    appendDeployAsReactFromHand(action, playerId, game, self, deployFilter, false);
-                                }
-                            }
-                        }
-                )
-        );
+        appendDeployAsReactFromHand(action, playerId, game, self, deployFilter, false);
     }
 }

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/light/Card5_067.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/light/Card5_067.java
@@ -13,6 +13,8 @@ import com.gempukku.swccgo.filters.Filter;
 import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.game.state.GameState;
+import com.gempukku.swccgo.logic.modifiers.querying.ModifiersQuerying;
 import com.gempukku.swccgo.logic.GameUtils;
 import com.gempukku.swccgo.logic.TriggerConditions;
 import com.gempukku.swccgo.logic.actions.PlayInterruptAction;
@@ -85,7 +87,15 @@ public class Card5_067 extends AbstractUsedOrLostInterrupt {
     @Override
     protected List<PlayInterruptAction> getGameTextOptionalAfterActions(final String playerId, SwccgGame game, EffectResult effectResult, final PhysicalCard self) {
         final String opponent = game.getOpponent(playerId);
-        final Filter deployFilter = Filters.or(Filters.vehicle, Filters.starfighter, Filters.pilot);
+        // Starships that "deploy like a starfighter" follow starfighter deployment rules (ARB Starships).
+        final Filter deployFilter = Filters.or(Filters.vehicle, Filters.starfighter, Filters.pilot, new Filter() {
+            @Override
+            public boolean accepts(GameState gameState, ModifiersQuerying modifiersQuerying, PhysicalCard physicalCard) {
+                return physicalCard.getBlueprint().isDeploysLikeStarfighter()
+                        || modifiersQuerying.isDeploysLikeStarfighter(gameState, physicalCard)
+                        || modifiersQuerying.isDeploysLikeStarfighterAtCloudSectors(gameState, physicalCard);
+            }
+        });
 
         // Check condition(s)
         if ((TriggerConditions.battleInitiatedAt(game, effectResult, opponent, Filters.cloud_sector)

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/light/Card5_067.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/light/Card5_067.java
@@ -25,6 +25,7 @@ import com.gempukku.swccgo.logic.effects.choose.ChooseStackedCardEffect;
 import com.gempukku.swccgo.logic.effects.choose.DeployCardToLocationFromHandEffect;
 import com.gempukku.swccgo.logic.timing.Action;
 import com.gempukku.swccgo.logic.timing.EffectResult;
+import com.gempukku.swccgo.logic.timing.PassthruEffect;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -100,8 +101,13 @@ public class Card5_067 extends AbstractUsedOrLostInterrupt {
         // Check condition(s)
         if ((TriggerConditions.battleInitiatedAt(game, effectResult, opponent, Filters.cloud_sector)
                 || TriggerConditions.forceDrainInitiatedBy(game, effectResult, opponent, Filters.cloud_sector))
-                && GameConditions.canSpotLocation(game, Filters.cloud_sector)
                 && GameConditions.hasInHand(game, playerId, deployFilter)) {
+
+            final PhysicalCard reactLocation = game.getGameState().getBattleOrForceDrainLocation();
+            if (reactLocation == null || !Filters.cloud_sector.accepts(game, reactLocation)) {
+                return null;
+            }
+            final Filter locationFilter = Filters.sameCardId(reactLocation);
 
             final PlayInterruptAction action = new PlayInterruptAction(game, self, CardSubtype.LOST);
             action.setText("Deploy as a 'react' to a cloud sector");
@@ -110,7 +116,7 @@ public class Card5_067 extends AbstractUsedOrLostInterrupt {
                     new RespondablePlayCardEffect(action) {
                         @Override
                         protected void performActionResults(Action targetingAction) {
-                            appendDeployAsReactFromHand(action, playerId, game, self, deployFilter, true);
+                            appendDeployAsReactFromHand(action, playerId, game, self, deployFilter, locationFilter, true);
                         }
                     }
             );
@@ -119,25 +125,31 @@ public class Card5_067 extends AbstractUsedOrLostInterrupt {
         return null;
     }
 
-    private void appendDeployAsReactFromHand(final PlayInterruptAction action, final String playerId, final SwccgGame game, final PhysicalCard self, final Filter deployFilter, final boolean required) {
-        if (!GameConditions.hasInHand(game, playerId, deployFilter)) {
-            return;
-        }
-
+    private void appendDeployAsReactFromHand(final PlayInterruptAction action, final String playerId, final SwccgGame game, final PhysicalCard self, final Filter deployFilter, final Filter locationFilter, final boolean required) {
         if (required) {
+            if (!GameConditions.hasInHand(game, playerId, deployFilter)) {
+                return;
+            }
             action.appendEffect(
-                    new DeployCardToLocationFromHandEffect(action, playerId, deployFilter, Filters.cloud_sector, false, true) {
+                    new DeployCardToLocationFromHandEffect(action, playerId, deployFilter, locationFilter, false, true) {
                         @Override
                         public String getChoiceText() {
                             return "Choose vehicle, starfighter, or pilot to deploy as a 'react'";
                         }
-
+                    }
+            );
+            action.appendEffect(
+                    new PassthruEffect(action) {
                         @Override
-                        protected void cardDeployed(PhysicalCard card) {
-                            appendOptionalAdditionalReactDeploys(action, playerId, game, self, deployFilter);
+                        protected void doPlayEffect(SwccgGame game) {
+                            appendOptionalAdditionalReactDeploys(action, playerId, game, self, deployFilter, locationFilter);
                         }
                     }
             );
+            return;
+        }
+
+        if (!GameConditions.hasInHand(game, playerId, deployFilter)) {
             return;
         }
 
@@ -155,10 +167,18 @@ public class Card5_067 extends AbstractUsedOrLostInterrupt {
                         }
                         PhysicalCard selectedCard = selectedCards.iterator().next();
                         action.appendEffect(
-                                new DeployCardToLocationFromHandEffect(action, selectedCard, Filters.cloud_sector, false, true) {
+                                new DeployCardToLocationFromHandEffect(action, playerId, Filters.sameCardId(selectedCard), locationFilter, false, true) {
                                     @Override
-                                    protected void cardDeployed(PhysicalCard card) {
-                                        appendOptionalAdditionalReactDeploys(action, playerId, game, self, deployFilter);
+                                    public String getChoiceText() {
+                                        return "Choose vehicle, starfighter, or pilot to deploy as a 'react'";
+                                    }
+                                }
+                        );
+                        action.appendEffect(
+                                new PassthruEffect(action) {
+                                    @Override
+                                    protected void doPlayEffect(SwccgGame game) {
+                                        appendOptionalAdditionalReactDeploys(action, playerId, game, self, deployFilter, locationFilter);
                                     }
                                 }
                         );
@@ -167,7 +187,7 @@ public class Card5_067 extends AbstractUsedOrLostInterrupt {
         );
     }
 
-    private void appendOptionalAdditionalReactDeploys(final PlayInterruptAction action, final String playerId, final SwccgGame game, final PhysicalCard self, final Filter deployFilter) {
-        appendDeployAsReactFromHand(action, playerId, game, self, deployFilter, false);
+    private void appendOptionalAdditionalReactDeploys(final PlayInterruptAction action, final String playerId, final SwccgGame game, final PhysicalCard self, final Filter deployFilter, final Filter locationFilter) {
+        appendDeployAsReactFromHand(action, playerId, game, self, deployFilter, locationFilter, false);
     }
 }

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
@@ -104765,6 +104765,34 @@
     ]
   },
   {
+    "cardId": "5_67",
+    "title": "Rescue In The Clouds",
+    "slug": "rescue-in-the-clouds",
+    "slugWithSetName": "rescue-in-the-clouds-cloud-city",
+    "side": "LIGHT",
+    "uniqueness": "UNIQUE",
+    "expansionSet": "CLOUD_CITY",
+    "rarity": "C",
+    "cardCategory": "INTERRUPT",
+    "cardTypes": [
+      "INTERRUPT"
+    ],
+    "cardSubtype": "USED_OR_LOST",
+    "lore": "'I know where Luke is.'",
+    "gameText": "USED: If you have a character on Weather Vane, place that character on your Used Pile. LOST: Deploy one or more vehicles, starfighters and pilots (at normal use of the Force) as a 'react' to a cloud sector.",
+    "destiny": 5,
+    "icons": [
+      {
+        "icon": "CLOUD_CITY",
+        "count": 1
+      },
+      {
+        "icon": "INTERRUPT",
+        "count": 1
+      }
+    ]
+  },
+  {
     "cardId": "5_68",
     "title": "Shocking Information",
     "slug": "shocking-information",

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_light.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_light.json
@@ -53479,6 +53479,34 @@
     ]
   },
   {
+    "cardId": "5_67",
+    "title": "Rescue In The Clouds",
+    "slug": "rescue-in-the-clouds",
+    "slugWithSetName": "rescue-in-the-clouds-cloud-city",
+    "side": "LIGHT",
+    "uniqueness": "UNIQUE",
+    "expansionSet": "CLOUD_CITY",
+    "rarity": "C",
+    "cardCategory": "INTERRUPT",
+    "cardTypes": [
+      "INTERRUPT"
+    ],
+    "cardSubtype": "USED_OR_LOST",
+    "lore": "'I know where Luke is.'",
+    "gameText": "USED: If you have a character on Weather Vane, place that character on your Used Pile. LOST: Deploy one or more vehicles, starfighters and pilots (at normal use of the Force) as a 'react' to a cloud sector.",
+    "destiny": 5,
+    "icons": [
+      {
+        "icon": "CLOUD_CITY",
+        "count": 1
+      },
+      {
+        "icon": "INTERRUPT",
+        "count": 1
+      }
+    ]
+  },
+  {
     "cardId": "5_68",
     "title": "Shocking Information",
     "slug": "shocking-information",

--- a/src/gemp-swccg-common/src/main/java/com/gempukku/swccgo/common/Title.java
+++ b/src/gemp-swccg-common/src/main/java/com/gempukku/swccgo/common/Title.java
@@ -968,6 +968,7 @@ public interface Title {
     String Rennek = "Rennek";
     String Report_To_Lord_Vader = "Report To Lord Vader";
     String Res_Luk_Raauf = "Res Luk Ra'auf";
+    String Rescue_In_The_Clouds = "Rescue In The Clouds";
     String Rescue_The_Princess = "Rescue The Princess";
     String Resistance = "Resistance";
     String Responsibility_Of_Command = "Responsibility Of Command";

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
@@ -19131,6 +19131,7 @@ public class Filters {
     public static final Filter Republic_character = Filters.and(Filters.icon(Icon.REPUBLIC), CardCategory.CHARACTER);
     public static final Filter Republic_starship = Filters.and(Filters.icon(Icon.REPUBLIC), CardCategory.STARSHIP);
     public static final Filter Res_Luk_Raauf = Filters.title(Title.Res_Luk_Raauf);
+    public static final Filter Rescue_In_The_Clouds = Filters.title(Title.Rescue_In_The_Clouds);
     public static final Filter Rescue_The_Princess = Filters.title(Title.Rescue_The_Princess);
     public static final Filter Resistance = Filters.title(Title.Resistance);
     public static final Filter resistance = Filters.icon(Icon.RESISTANCE);

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_067_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_067_Tests.java
@@ -1,0 +1,265 @@
+package com.gempukku.swccgo.cards.set5.light;
+
+import com.gempukku.swccgo.common.CardSubtype;
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static com.gempukku.swccgo.framework.Assertions.assertAtLocation;
+import static com.gempukku.swccgo.framework.Assertions.assertInZone;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Card_5_067_Tests {
+
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("rescue", "5_67");
+                    put("weather-vane", "5_30");
+                    put("luke", "1_19");
+                    put("xwing", "1_146");
+                    put("cloud-car", "5_88");
+                    put("bespin", "5_76");
+                    put("clouds", "5_85");
+                }},
+                new HashMap<>() {{
+                    put("tie", "1_304");
+                    put("hoth", "3_143");
+                    put("big-one", "4_156");
+                }},
+                20,
+                20,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void RescueInTheCloudsStatsAndKeywordsAreCorrect() {
+        /**
+         * Title: Rescue In The Clouds
+         * Uniqueness: Unique
+         * Side: Light
+         * Type: Interrupt
+         * Subtype: Used Or Lost
+         * Destiny: 5
+         * Icons: Cloud City
+         * Game Text: USED: If you have a character on Weather Vane, place that character on your Used Pile.
+         *      LOST: Deploy one or more vehicles, starfighters and pilots (at normal use of the Force)
+         *      as a 'react' to a cloud sector.
+         * Lore: 'I know where Luke is.'
+         * Set: Cloud City
+         * Rarity: C
+         */
+
+        var scn = GetScenario();
+
+        var card = scn.GetLSCard("rescue").getBlueprint();
+
+        assertEquals("Rescue In The Clouds", card.getTitle());
+        assertFalse(card.hasVirtualSuffix());
+        assertEquals(Uniqueness.UNIQUE, card.getUniqueness());
+        assertEquals(Side.LIGHT, card.getSide());
+        assertEquals(5, card.getDestiny(), scn.epsilon);
+        scn.BlueprintCardTypeCheck(card, new ArrayList<>() {{
+            add(CardType.INTERRUPT);
+        }});
+        assertEquals(CardSubtype.USED_OR_LOST, card.getCardSubtype());
+        scn.BlueprintIconCheck(card, new ArrayList<>() {{
+            add(Icon.CLOUD_CITY);
+            add(Icon.INTERRUPT);
+        }});
+        assertEquals(ExpansionSet.CLOUD_CITY, card.getExpansionSet());
+        assertEquals(Rarity.C, card.getRarity());
+    }
+
+    @Test
+    public void RescueInTheCloudsUsedPlacesCharacterFromWeatherVaneInUsedPile() {
+        var scn = GetScenario();
+
+        var rescue = scn.GetLSCard("rescue");
+        var weatherVane = scn.GetLSCard("weather-vane");
+        var luke = scn.GetLSCard("luke");
+
+        scn.StartGame();
+
+        scn.MoveCardsToLSSideOfTable(weatherVane);
+        scn.StackCardsOn(weatherVane, luke);
+        scn.MoveCardsToLSHand(rescue);
+
+        assertTrue(scn.IsStackedOn(weatherVane, luke));
+
+        scn.SkipToLSTurn(Phase.CONTROL);
+        assertTrue(scn.LSCardPlayAvailable(rescue));
+        scn.LSPlayCard(rescue);
+        if (scn.LSHasCardChoiceAvailable(luke)) {
+            scn.LSChooseCard(luke);
+        }
+        scn.PassAllResponses();
+
+        assertInZone(Zone.USED_PILE, luke);
+        assertFalse(scn.IsStackedOn(weatherVane, luke));
+        assertInZone(Zone.USED_PILE, rescue);
+    }
+
+    @Test
+    public void RescueInTheCloudsUsedNotPlayableIfOnlyOpponentsCharacterOnWeatherVane() {
+        var scn = GetScenario();
+
+        var rescue = scn.GetLSCard("rescue");
+        var weatherVane = scn.GetLSCard("weather-vane");
+        var stormtrooper = scn.GetDSFiller(1);
+
+        scn.StartGame();
+
+        scn.MoveCardsToLSSideOfTable(weatherVane);
+        scn.StackCardsOn(weatherVane, stormtrooper);
+        scn.MoveCardsToLSHand(rescue);
+
+        scn.SkipToLSTurn(Phase.CONTROL);
+        assertFalse(scn.LSCardPlayAvailable(rescue));
+    }
+
+    @Test
+    public void RescueInTheCloudsUsedNotPlayableWithoutCharacterOnWeatherVane() {
+        var scn = GetScenario();
+
+        var rescue = scn.GetLSCard("rescue");
+        var weatherVane = scn.GetLSCard("weather-vane");
+
+        scn.StartGame();
+
+        scn.MoveCardsToLSSideOfTable(weatherVane);
+        scn.MoveCardsToLSHand(rescue);
+
+        scn.SkipToLSTurn(Phase.CONTROL);
+        assertFalse(scn.LSCardPlayAvailable(rescue));
+    }
+
+    @Test
+    public void RescueInTheCloudsLostDeploysStarfighterAsReactToCloudSector() {
+        var scn = GetScenario();
+
+        var rescue = scn.GetLSCard("rescue");
+        var xwing = scn.GetLSCard("xwing");
+        var cloudCar = scn.GetLSCard("cloud-car");
+        var bespin = scn.GetLSCard("bespin");
+        var clouds = scn.GetLSCard("clouds");
+
+        var tie = scn.GetDSCard("tie");
+
+        scn.StartGame();
+
+        scn.MoveLocationToTable(bespin);
+        scn.MoveLocationToTable(clouds);
+        scn.MoveCardsToLocation(clouds, tie, cloudCar);
+        scn.MoveCardsToLSHand(rescue, xwing);
+
+        scn.SkipToDSTurn(Phase.BATTLE);
+        int forceBefore = scn.GetLSForcePileCount();
+        scn.DSInitiateBattle(clouds);
+        assertTrue(scn.LSCardPlayAvailable(rescue));
+        scn.LSPlayCard(rescue);
+        scn.PassAllResponses();
+        if (scn.LSAnyDecisionsAvailable() && scn.LSHasCardChoiceAvailable(xwing)) {
+            scn.LSChooseCard(xwing);
+        }
+        scn.PassAllResponses();
+
+        assertAtLocation(clouds, xwing);
+        assertInZone(Zone.LOST_PILE, rescue);
+        assertEquals(forceBefore - 2, scn.GetLSForcePileCount());
+    }
+
+    @Test
+    public void RescueInTheCloudsLostPlayableAsReactToCloudSectorForceDrain() {
+        var scn = GetScenario();
+
+        var rescue = scn.GetLSCard("rescue");
+        var xwing = scn.GetLSCard("xwing");
+        var bespin = scn.GetLSCard("bespin");
+        var clouds = scn.GetLSCard("clouds");
+        var tie = scn.GetDSCard("tie");
+
+        scn.StartGame();
+
+        scn.MoveLocationToTable(bespin);
+        scn.MoveLocationToTable(clouds);
+        scn.MoveCardsToLocation(clouds, tie);
+        scn.MoveCardsToLSHand(rescue, xwing);
+
+        scn.SkipToDSTurn(Phase.CONTROL);
+        assertTrue(scn.DSForceDrainAvailable(clouds));
+        scn.DSForceDrainAt(clouds);
+        assertTrue(scn.LSCardPlayAvailable(rescue));
+        scn.LSPlayCard(rescue);
+        scn.PassAllResponses();
+        if (scn.LSAnyDecisionsAvailable() && scn.LSHasCardChoiceAvailable(xwing)) {
+            scn.LSChooseCard(xwing);
+        }
+        scn.PassAllResponses();
+
+        assertAtLocation(clouds, xwing);
+        assertInZone(Zone.LOST_PILE, rescue);
+    }
+
+    @Test
+    public void RescueInTheCloudsLostNotPlayableAsReactToAsteroidSectorBattle() {
+        var scn = GetScenario();
+
+        var rescue = scn.GetLSCard("rescue");
+        var xwing = scn.GetLSCard("xwing");
+        var hoth = scn.GetDSCard("hoth");
+        var bigOne = scn.GetDSCard("big-one");
+        var tie = scn.GetDSCard("tie");
+
+        scn.StartGame();
+
+        scn.MoveLocationToTable(hoth);
+        scn.MoveLocationToTable(bigOne);
+        scn.MoveCardsToLocation(bigOne, tie, xwing);
+        scn.MoveCardsToLSHand(rescue);
+
+        scn.SkipToDSTurn(Phase.BATTLE);
+        scn.DSInitiateBattle(bigOne);
+        assertFalse(scn.LSAnyDecisionsAvailable() && scn.LSCardPlayAvailable(rescue));
+    }
+
+    @Test
+    public void RescueInTheCloudsLostNotPlayableWhenBattleIsNotAtCloudSector() {
+        var scn = GetScenario();
+
+        var rescue = scn.GetLSCard("rescue");
+        var xwing = scn.GetLSCard("xwing");
+        var site = scn.GetLSStartingLocation();
+        var lsPresence = scn.GetLSFiller(1);
+        var dsPresence = scn.GetDSFiller(1);
+
+        scn.StartGame();
+
+        scn.MoveCardsToLocation(site, lsPresence, dsPresence);
+        scn.MoveCardsToLSHand(rescue, xwing);
+
+        scn.SkipToDSTurn(Phase.BATTLE);
+        scn.DSInitiateBattle(site);
+        assertFalse(scn.LSAnyDecisionsAvailable() && scn.LSCardPlayAvailable(rescue));
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_067_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_067_Tests.java
@@ -274,6 +274,46 @@ public class Card_5_067_Tests {
     }
 
     @Test
+    public void LostAdditionalReactChoiceCanBeStoppedWithDone_5_67_RescueInTheClouds() {
+        var scn = GetScenario();
+
+        var rescue = scn.GetLSCard("rescue");
+        var xwing = scn.GetLSCard("xwing");
+        var freighter = scn.GetLSCard("freighter");
+        var cloudCar = scn.GetLSCard("cloud-car");
+        var bespin = scn.GetLSCard("bespin");
+        var clouds = scn.GetLSCard("clouds");
+        var tie = scn.GetDSCard("tie");
+
+        scn.StartGame();
+
+        scn.MoveLocationToTable(bespin);
+        scn.MoveLocationToTable(clouds);
+        scn.MoveCardsToLocation(clouds, tie, cloudCar);
+        scn.MoveCardsToLSHand(rescue, xwing, freighter);
+
+        scn.SkipToDSTurn(Phase.BATTLE);
+        scn.DSInitiateBattle(clouds);
+        assertTrue(scn.LSCardPlayAvailable(rescue));
+        scn.LSPlayCard(rescue);
+        scn.PassAllResponses();
+        if (scn.LSAnyDecisionsAvailable() && scn.LSHasCardChoiceAvailable(xwing)) {
+            scn.LSChooseCard(xwing);
+        }
+        scn.PassAllResponses();
+
+        assertTrue(scn.LSAnyDecisionsAvailable());
+        assertTrue(scn.LSGetDecision().getText().toLowerCase().contains("done"));
+        assertTrue(scn.LSHasCardChoiceAvailable(freighter));
+        scn.LSPass();
+        scn.PassAllResponses();
+
+        assertAtLocation(clouds, xwing);
+        assertInZone(Zone.HAND, freighter);
+        assertInZone(Zone.LOST_PILE, rescue);
+    }
+
+    @Test
     public void LostNotPlayableWhenOnlyCapitalThatDoesNotDeployLikeStarfighterIsInHand_5_67_RescueInTheClouds() {
         var scn = GetScenario();
 

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_067_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_067_Tests.java
@@ -40,6 +40,8 @@ public class Card_5_067_Tests {
                     put("xwing2", "1_146");
                     put("freighter", "7_144");
                     put("corvette", "1_140");
+                    put("patrol", "7_153");
+                    put("raider", "112_5");
                     put("bespin", "5_76");
                     put("clouds", "5_85");
                 }},
@@ -533,6 +535,55 @@ public class Card_5_067_Tests {
                         + " car2=" + cloudCar2.getZone(),
                 Zone.AT_LOCATION, cloudCar2.getZone());
         assertAtLocation(clouds, cloudCar2);
+        assertInZone(Zone.LOST_PILE, rescue);
+    }
+
+    @Test
+    public void LostExtraReactDoesNotOfferUnaffordablePatrolCraftOrPalaceRaider_5_67_RescueInTheClouds() {
+        var scn = GetScenario();
+
+        var rescue = scn.GetLSCard("rescue");
+        var xwing = scn.GetLSCard("xwing");
+        var patrol = scn.GetLSCard("patrol");
+        var raider = scn.GetLSCard("raider");
+        var cloudCar = scn.GetLSCard("cloud-car");
+        var bespin = scn.GetLSCard("bespin");
+        var clouds = scn.GetLSCard("clouds");
+        var tie = scn.GetDSCard("tie");
+
+        scn.StartGame();
+
+        scn.MoveLocationToTable(bespin);
+        scn.MoveLocationToTable(clouds);
+        scn.MoveCardsToLocation(clouds, tie, cloudCar);
+        scn.MoveCardsToLSHand(rescue, xwing, patrol, raider);
+
+        scn.SkipToDSTurn(Phase.BATTLE);
+        int currentForce = scn.GetLSForcePileCount();
+        if (currentForce > 3) {
+            scn.LSUseForceCheat(currentForce - 3);
+        } else if (currentForce < 3) {
+            scn.LSActivateForceCheat(3 - currentForce);
+        }
+
+        scn.DSInitiateBattle(clouds);
+        playRescueAndDeployFirstReact(scn, rescue, xwing);
+        scn.PassAllResponses();
+
+        assertEquals(1, scn.GetLSForcePileCount());
+        assertFalse("Patrol Craft should not light up without a full driver combo",
+                scn.LSAnyDecisionsAvailable() && scn.LSHasCardChoiceAvailable(patrol));
+        assertFalse("Palace Raider should not light up without enough Force",
+                scn.LSAnyDecisionsAvailable() && scn.LSHasCardChoiceAvailable(raider));
+        if (scn.LSAnyDecisionsAvailable()
+                && scn.LSGetDecision().getText().toLowerCase().contains("click 'done' to stop")) {
+            scn.LSPass();
+            scn.PassAllResponses();
+        }
+
+        assertAtLocation(clouds, xwing);
+        assertInZone(Zone.HAND, patrol);
+        assertInZone(Zone.HAND, raider);
         assertInZone(Zone.LOST_PILE, rescue);
     }
 

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_067_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_067_Tests.java
@@ -13,6 +13,7 @@ import com.gempukku.swccgo.common.Zone;
 import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.framework.StartingSetup;
 import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.game.PhysicalCardImpl;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -32,8 +33,11 @@ public class Card_5_067_Tests {
                     put("rescue", "5_67");
                     put("weather-vane", "5_30");
                     put("luke", "1_19");
+                    put("red1", "1_144");
                     put("xwing", "1_146");
                     put("cloud-car", "5_88");
+                    put("cloud-car2", "5_88");
+                    put("xwing2", "1_146");
                     put("freighter", "7_144");
                     put("corvette", "1_140");
                     put("bespin", "5_76");
@@ -303,13 +307,232 @@ public class Card_5_067_Tests {
         scn.PassAllResponses();
 
         assertTrue(scn.LSAnyDecisionsAvailable());
-        assertTrue(scn.LSGetDecision().getText().toLowerCase().contains("done"));
+        assertTrue("Expected extra react Done prompt, LS decision: " + scn.LSGetDecision().getText(),
+                scn.LSGetDecision().getText().toLowerCase().contains("click 'done' to stop"));
         assertTrue(scn.LSHasCardChoiceAvailable(freighter));
         scn.LSPass();
         scn.PassAllResponses();
 
         assertAtLocation(clouds, xwing);
         assertInZone(Zone.HAND, freighter);
+        assertInZone(Zone.LOST_PILE, rescue);
+    }
+
+    @Test
+    public void LostDeploysSecondStarfighterWhenContinuingAfterFirstReact_5_67_RescueInTheClouds() {
+        var scn = GetScenario();
+
+        var rescue = scn.GetLSCard("rescue");
+        var xwing = scn.GetLSCard("xwing");
+        var xwing2 = scn.GetLSCard("xwing2");
+        var cloudCar = scn.GetLSCard("cloud-car");
+        var bespin = scn.GetLSCard("bespin");
+        var clouds = scn.GetLSCard("clouds");
+        var tie = scn.GetDSCard("tie");
+
+        scn.StartGame();
+
+        scn.MoveLocationToTable(bespin);
+        scn.MoveLocationToTable(clouds);
+        scn.MoveCardsToLocation(clouds, tie, cloudCar);
+        scn.MoveCardsToLSHand(rescue, xwing, xwing2);
+
+        scn.SkipToDSTurn(Phase.BATTLE);
+        scn.DSInitiateBattle(clouds);
+        assertTrue(scn.LSCardPlayAvailable(rescue));
+        scn.LSPlayCard(rescue);
+        scn.PassAllResponses();
+        if (scn.LSAnyDecisionsAvailable() && scn.LSHasCardChoiceAvailable(xwing)) {
+            scn.LSChooseCard(xwing);
+        }
+        scn.PassAllResponses();
+
+        assertTrue("Expected extra react choice after first X-wing. LS decision: "
+                        + (scn.LSGetDecision() == null ? "none" : scn.LSGetDecision().getText()),
+                scn.LSAnyDecisionsAvailable());
+        assertTrue(scn.LSGetDecision().getText().toLowerCase().contains("click 'done' to stop"));
+        assertTrue(scn.LSHasCardChoiceAvailable(xwing2));
+        scn.LSChooseCard(xwing2);
+        scn.PassAllResponses();
+
+        if (scn.LSAnyDecisionsAvailable()
+                && scn.LSGetDecision().getText().toLowerCase().contains("click 'done' to stop")) {
+            scn.LSPass();
+            scn.PassAllResponses();
+        }
+
+        assertAtLocation(clouds, xwing);
+        assertAtLocation(clouds, xwing2);
+        assertInZone(Zone.LOST_PILE, rescue);
+    }
+
+    @Test
+    public void LostDeploysSecondCloudCarWhenContinuingAfterFirstReact_5_67_RescueInTheClouds() {
+        var scn = GetScenario();
+
+        var rescue = scn.GetLSCard("rescue");
+        var cloudCar = scn.GetLSCard("cloud-car");
+        var cloudCar2 = scn.GetLSCard("cloud-car2");
+        var presence = scn.GetLSCard("xwing");
+        var bespin = scn.GetLSCard("bespin");
+        var clouds = scn.GetLSCard("clouds");
+        var tie = scn.GetDSCard("tie");
+
+        scn.StartGame();
+
+        scn.MoveLocationToTable(bespin);
+        scn.MoveLocationToTable(clouds);
+        scn.MoveCardsToLocation(clouds, tie, presence);
+        scn.MoveCardsToLSHand(rescue, cloudCar, cloudCar2);
+
+        scn.SkipToDSTurn(Phase.BATTLE);
+        scn.DSInitiateBattle(clouds);
+        assertTrue(scn.LSCardPlayAvailable(rescue));
+        scn.LSPlayCard(rescue);
+        scn.PassAllResponses();
+        if (scn.LSAnyDecisionsAvailable() && scn.LSHasCardChoiceAvailable(cloudCar)) {
+            scn.LSChooseCard(cloudCar);
+        }
+        scn.PassAllResponses();
+
+        assertTrue("Expected extra react choice after first Cloud Car. LS decision: "
+                        + (scn.LSGetDecision() == null ? "none" : scn.LSGetDecision().getText()),
+                scn.LSAnyDecisionsAvailable());
+        assertTrue(scn.LSGetDecision().getText().toLowerCase().contains("click 'done' to stop"));
+        assertTrue(scn.LSHasCardChoiceAvailable(cloudCar2));
+        scn.LSChooseCard(cloudCar2);
+        scn.PassAllResponses();
+
+        if (scn.LSAnyDecisionsAvailable()
+                && scn.LSGetDecision().getText().toLowerCase().contains("click 'done' to stop")) {
+            scn.LSPass();
+            scn.PassAllResponses();
+        }
+
+        assertAtLocation(clouds, cloudCar);
+        assertAtLocation(clouds, cloudCar2);
+        assertInZone(Zone.LOST_PILE, rescue);
+    }
+
+    private void playRescueAndDeployFirstReact(VirtualTableScenario scn, PhysicalCardImpl rescue, PhysicalCardImpl firstCard) {
+        assertTrue(scn.LSCardPlayAvailable(rescue));
+        scn.LSPlayCard(rescue);
+        scn.PassAllResponses();
+        if (scn.LSAnyDecisionsAvailable() && scn.LSHasCardChoiceAvailable(firstCard)) {
+            scn.LSChooseCard(firstCard);
+        }
+        scn.PassAllResponses();
+    }
+
+    private void acceptSimultaneousPilotIfOffered(VirtualTableScenario scn, PhysicalCardImpl pilot) {
+        if (scn.LSAnyDecisionsAvailable() && scn.LSDecisionAvailable("simultaneously")) {
+            scn.LSChooseYes();
+        }
+        if (scn.LSAnyDecisionsAvailable() && scn.LSHasCardChoiceAvailable(pilot)
+                && !scn.LSGetDecision().getText().toLowerCase().contains("click 'done' to stop")) {
+            scn.LSChooseCard(pilot);
+        }
+        scn.PassAllResponses();
+    }
+
+    @Test
+    public void LostComboThenAdditionalReactCanBeStoppedWithDone_5_67_RescueInTheClouds() {
+        var scn = GetScenario();
+
+        var rescue = scn.GetLSCard("rescue");
+        var red1 = scn.GetLSCard("red1");
+        var luke = scn.GetLSCard("luke");
+        var cloudCar2 = scn.GetLSCard("cloud-car2");
+        var cloudCar = scn.GetLSCard("cloud-car");
+        var bespin = scn.GetLSCard("bespin");
+        var clouds = scn.GetLSCard("clouds");
+        var tie = scn.GetDSCard("tie");
+
+        scn.StartGame();
+        scn.LSActivateForceCheat(10);
+
+        scn.MoveLocationToTable(bespin);
+        scn.MoveLocationToTable(clouds);
+        scn.MoveCardsToLocation(clouds, tie, cloudCar);
+        scn.MoveCardsToLSHand(rescue, red1, luke, cloudCar2);
+
+        scn.SkipToDSTurn(Phase.BATTLE);
+        scn.DSInitiateBattle(clouds);
+        playRescueAndDeployFirstReact(scn, rescue, red1);
+        acceptSimultaneousPilotIfOffered(scn, luke);
+        scn.PassAllResponses();
+
+        assertTrue("Expected extra react choice after ship/pilot combo. LS decision: "
+                        + (scn.LSGetDecision() == null ? "none" : scn.LSGetDecision().getText()),
+                scn.LSAnyDecisionsAvailable());
+        assertTrue(scn.LSGetDecision().getText().toLowerCase().contains("click 'done' to stop"));
+        assertTrue(scn.LSHasCardChoiceAvailable(cloudCar2));
+        scn.LSPass();
+        scn.PassAllResponses();
+
+        assertAtLocation(clouds, red1);
+        assertTrue(scn.IsAboardAsPilot(red1, luke));
+        assertInZone(Zone.HAND, cloudCar2);
+        assertInZone(Zone.LOST_PILE, rescue);
+    }
+
+    @Test
+    public void LostComboThenDeploysAnotherVehicleAsReact_5_67_RescueInTheClouds() {
+        var scn = GetScenario();
+
+        var rescue = scn.GetLSCard("rescue");
+        var red1 = scn.GetLSCard("red1");
+        var luke = scn.GetLSCard("luke");
+        var cloudCar2 = scn.GetLSCard("cloud-car2");
+        var cloudCar = scn.GetLSCard("cloud-car");
+        var bespin = scn.GetLSCard("bespin");
+        var clouds = scn.GetLSCard("clouds");
+        var tie = scn.GetDSCard("tie");
+
+        scn.StartGame();
+        scn.LSActivateForceCheat(10);
+
+        scn.MoveLocationToTable(bespin);
+        scn.MoveLocationToTable(clouds);
+        scn.MoveCardsToLocation(clouds, tie, cloudCar);
+        scn.MoveCardsToLSHand(rescue, red1, luke, cloudCar2);
+
+        scn.SkipToDSTurn(Phase.BATTLE);
+        scn.DSInitiateBattle(clouds);
+        playRescueAndDeployFirstReact(scn, rescue, red1);
+        acceptSimultaneousPilotIfOffered(scn, luke);
+        scn.PassAllResponses();
+
+        assertTrue("Expected extra react choice after ship/pilot combo. LS decision: "
+                        + (scn.LSGetDecision() == null ? "none" : scn.LSGetDecision().getText()),
+                scn.LSAnyDecisionsAvailable());
+        assertTrue(scn.LSGetDecision().getText().toLowerCase().contains("click 'done' to stop"));
+        assertTrue(scn.LSHasCardChoiceAvailable(cloudCar2));
+        scn.LSChooseCard(cloudCar2);
+        if (scn.LSAnyDecisionsAvailable() && scn.LSHasCardChoiceAvailable(cloudCar2)
+                && !scn.LSGetDecision().getText().toLowerCase().contains("click 'done' to stop")) {
+            scn.LSChooseCard(cloudCar2);
+        }
+        if (scn.LSAnyDecisionsAvailable() && scn.LSHasCardChoiceAvailable(clouds)
+                && scn.LSDecisionAvailable("where to deploy")) {
+            scn.LSChooseCard(clouds);
+        }
+        scn.PassAllResponses();
+
+        if (scn.LSAnyDecisionsAvailable()
+                && scn.LSGetDecision().getText().toLowerCase().contains("click 'done' to stop")) {
+            scn.LSPass();
+            scn.PassAllResponses();
+        }
+
+        assertAtLocation(clouds, red1);
+        assertTrue(scn.IsAboardAsPilot(red1, luke));
+        assertEquals("Second react should deploy the Cloud Car. remaining decision="
+                        + (scn.LSGetDecision() == null ? "none" : scn.LSGetDecision().getText())
+                        + " force=" + scn.GetLSForcePileCount()
+                        + " car2=" + cloudCar2.getZone(),
+                Zone.AT_LOCATION, cloudCar2.getZone());
+        assertAtLocation(clouds, cloudCar2);
         assertInZone(Zone.LOST_PILE, rescue);
     }
 

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_067_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_067_Tests.java
@@ -53,7 +53,7 @@ public class Card_5_067_Tests {
     }
 
     @Test
-    public void RescueInTheCloudsStatsAndKeywordsAreCorrect() {
+    public void StatsAndKeywordsAreCorrect_5_67_RescueInTheClouds() {
         /**
          * Title: Rescue In The Clouds
          * Uniqueness: Unique
@@ -92,7 +92,7 @@ public class Card_5_067_Tests {
     }
 
     @Test
-    public void RescueInTheCloudsUsedPlacesCharacterFromWeatherVaneInUsedPile() {
+    public void UsedPlacesYourCharacterFromWeatherVaneInUsedPile_5_67_RescueInTheClouds() {
         var scn = GetScenario();
 
         var rescue = scn.GetLSCard("rescue");
@@ -121,7 +121,7 @@ public class Card_5_067_Tests {
     }
 
     @Test
-    public void RescueInTheCloudsUsedNotPlayableIfOnlyOpponentsCharacterOnWeatherVane() {
+    public void UsedNotPlayableIfOnlyOpponentsCharacterOnWeatherVane_5_67_RescueInTheClouds() {
         var scn = GetScenario();
 
         var rescue = scn.GetLSCard("rescue");
@@ -139,7 +139,7 @@ public class Card_5_067_Tests {
     }
 
     @Test
-    public void RescueInTheCloudsUsedNotPlayableWithoutCharacterOnWeatherVane() {
+    public void UsedNotPlayableWithoutCharacterOnWeatherVane_5_67_RescueInTheClouds() {
         var scn = GetScenario();
 
         var rescue = scn.GetLSCard("rescue");
@@ -155,7 +155,7 @@ public class Card_5_067_Tests {
     }
 
     @Test
-    public void RescueInTheCloudsLostDeploysStarfighterAsReactToCloudSector() {
+    public void LostDeploysStarfighterAsReactToCloudSectorBattle_5_67_RescueInTheClouds() {
         var scn = GetScenario();
 
         var rescue = scn.GetLSCard("rescue");
@@ -190,7 +190,7 @@ public class Card_5_067_Tests {
     }
 
     @Test
-    public void RescueInTheCloudsLostPlayableAsReactToCloudSectorForceDrain() {
+    public void LostPlayableAsReactToCloudSectorForceDrain_5_67_RescueInTheClouds() {
         var scn = GetScenario();
 
         var rescue = scn.GetLSCard("rescue");
@@ -222,7 +222,7 @@ public class Card_5_067_Tests {
     }
 
     @Test
-    public void RescueInTheCloudsLostNotPlayableAsReactToAsteroidSectorBattle() {
+    public void LostNotPlayableAsReactToAsteroidSectorBattle_5_67_RescueInTheClouds() {
         var scn = GetScenario();
 
         var rescue = scn.GetLSCard("rescue");
@@ -244,7 +244,7 @@ public class Card_5_067_Tests {
     }
 
     @Test
-    public void RescueInTheCloudsLostNotPlayableWhenBattleIsNotAtCloudSector() {
+    public void LostNotPlayableWhenBattleIsAtASite_5_67_RescueInTheClouds() {
         var scn = GetScenario();
 
         var rescue = scn.GetLSCard("rescue");

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_067_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_067_Tests.java
@@ -1,5 +1,6 @@
 package com.gempukku.swccgo.cards.set5.light;
 
+import com.gempukku.swccgo.cards.GameConditions;
 import com.gempukku.swccgo.common.CardSubtype;
 import com.gempukku.swccgo.common.CardType;
 import com.gempukku.swccgo.common.ExpansionSet;
@@ -9,6 +10,7 @@ import com.gempukku.swccgo.common.Rarity;
 import com.gempukku.swccgo.common.Side;
 import com.gempukku.swccgo.common.Uniqueness;
 import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.framework.StartingSetup;
 import com.gempukku.swccgo.framework.VirtualTableScenario;
 import org.junit.Test;
@@ -32,6 +34,8 @@ public class Card_5_067_Tests {
                     put("luke", "1_19");
                     put("xwing", "1_146");
                     put("cloud-car", "5_88");
+                    put("freighter", "7_144");
+                    put("corvette", "1_140");
                     put("bespin", "5_76");
                     put("clouds", "5_85");
                 }},
@@ -187,6 +191,109 @@ public class Card_5_067_Tests {
         assertAtLocation(clouds, xwing);
         assertInZone(Zone.LOST_PILE, rescue);
         assertEquals(forceBefore - 2, scn.GetLSForcePileCount());
+    }
+
+    @Test
+    public void LostDeploysMediumBulkFreighterAsReactToCloudSectorBattle_5_67_RescueInTheClouds() {
+        var scn = GetScenario();
+
+        var rescue = scn.GetLSCard("rescue");
+        var freighter = scn.GetLSCard("freighter");
+        var cloudCar = scn.GetLSCard("cloud-car");
+        var bespin = scn.GetLSCard("bespin");
+        var clouds = scn.GetLSCard("clouds");
+        var tie = scn.GetDSCard("tie");
+
+        scn.StartGame();
+
+        assertTrue(freighter.getBlueprint().isDeploysLikeStarfighter());
+        assertEquals(CardSubtype.CAPITAL, freighter.getBlueprint().getCardSubtype());
+
+        scn.MoveLocationToTable(bespin);
+        scn.MoveLocationToTable(clouds);
+        scn.MoveCardsToLocation(clouds, tie, cloudCar);
+        scn.MoveCardsToLSHand(rescue, freighter);
+
+        assertTrue(Filters.deploysLikeStarfighter.accepts(scn.game(), freighter));
+        assertTrue(GameConditions.hasInHand(scn.game(), VirtualTableScenario.LS, Filters.deploysLikeStarfighter));
+
+        scn.SkipToDSTurn(Phase.BATTLE);
+        int forceBefore = scn.GetLSForcePileCount();
+        scn.DSInitiateBattle(clouds);
+        assertTrue("Expected Rescue after-action. LS decision: " + (scn.LSGetDecision() == null ? "none" : scn.LSGetDecision().getText()),
+                scn.LSAnyDecisionsAvailable());
+        assertTrue(scn.LSCardPlayAvailable(rescue));
+        scn.LSPlayCard(rescue);
+        scn.PassAllResponses();
+        if (scn.LSAnyDecisionsAvailable() && scn.LSHasCardChoiceAvailable(freighter)) {
+            scn.LSChooseCard(freighter);
+        }
+        scn.PassAllResponses();
+
+        assertAtLocation(clouds, freighter);
+        assertInZone(Zone.LOST_PILE, rescue);
+        assertEquals(forceBefore - 3, scn.GetLSForcePileCount());
+    }
+
+    @Test
+    public void LostOffersXwingAndMediumBulkFreighterButNotCorvetteAsReact_5_67_RescueInTheClouds() {
+        var scn = GetScenario();
+
+        var rescue = scn.GetLSCard("rescue");
+        var xwing = scn.GetLSCard("xwing");
+        var freighter = scn.GetLSCard("freighter");
+        var corvette = scn.GetLSCard("corvette");
+        var cloudCar = scn.GetLSCard("cloud-car");
+        var bespin = scn.GetLSCard("bespin");
+        var clouds = scn.GetLSCard("clouds");
+        var tie = scn.GetDSCard("tie");
+
+        scn.StartGame();
+
+        scn.MoveLocationToTable(bespin);
+        scn.MoveLocationToTable(clouds);
+        scn.MoveCardsToLocation(clouds, tie, cloudCar);
+        scn.MoveCardsToLSHand(rescue, xwing, freighter, corvette);
+
+        scn.SkipToDSTurn(Phase.BATTLE);
+        scn.DSInitiateBattle(clouds);
+        assertTrue(scn.LSAnyDecisionsAvailable());
+        assertTrue(scn.LSCardPlayAvailable(rescue));
+        scn.LSPlayCard(rescue);
+        scn.PassAllResponses();
+        assertTrue(scn.LSAnyDecisionsAvailable());
+        assertTrue(scn.LSHasCardChoiceAvailable(xwing));
+        assertTrue(scn.LSHasCardChoiceAvailable(freighter));
+        assertFalse(scn.LSHasCardChoiceAvailable(corvette));
+        scn.LSChooseCard(freighter);
+        scn.PassAllResponses();
+
+        assertAtLocation(clouds, freighter);
+        assertInZone(Zone.HAND, xwing);
+        assertInZone(Zone.HAND, corvette);
+    }
+
+    @Test
+    public void LostNotPlayableWhenOnlyCapitalThatDoesNotDeployLikeStarfighterIsInHand_5_67_RescueInTheClouds() {
+        var scn = GetScenario();
+
+        var rescue = scn.GetLSCard("rescue");
+        var corvette = scn.GetLSCard("corvette");
+        var cloudCar = scn.GetLSCard("cloud-car");
+        var bespin = scn.GetLSCard("bespin");
+        var clouds = scn.GetLSCard("clouds");
+        var tie = scn.GetDSCard("tie");
+
+        scn.StartGame();
+
+        scn.MoveLocationToTable(bespin);
+        scn.MoveLocationToTable(clouds);
+        scn.MoveCardsToLocation(clouds, tie, cloudCar);
+        scn.MoveCardsToLSHand(rescue, corvette);
+
+        scn.SkipToDSTurn(Phase.BATTLE);
+        scn.DSInitiateBattle(clouds);
+        assertFalse(scn.LSAnyDecisionsAvailable() && scn.LSCardPlayAvailable(rescue));
     }
 
     @Test

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_067_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_067_Tests.java
@@ -1,16 +1,15 @@
 package com.gempukku.swccgo.cards.set5.light;
 
-import com.gempukku.swccgo.cards.GameConditions;
 import com.gempukku.swccgo.common.CardSubtype;
 import com.gempukku.swccgo.common.CardType;
 import com.gempukku.swccgo.common.ExpansionSet;
 import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Keyword;
 import com.gempukku.swccgo.common.Phase;
 import com.gempukku.swccgo.common.Rarity;
 import com.gempukku.swccgo.common.Side;
 import com.gempukku.swccgo.common.Uniqueness;
 import com.gempukku.swccgo.common.Zone;
-import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.framework.StartingSetup;
 import com.gempukku.swccgo.framework.VirtualTableScenario;
 import com.gempukku.swccgo.game.PhysicalCardImpl;
@@ -20,6 +19,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 
 import static com.gempukku.swccgo.framework.Assertions.assertAtLocation;
+import static com.gempukku.swccgo.framework.Assertions.assertInHand;
 import static com.gempukku.swccgo.framework.Assertions.assertInZone;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -63,7 +63,7 @@ public class Card_5_067_Tests {
     }
 
     @Test
-    public void StatsAndKeywordsAreCorrect_5_67_RescueInTheClouds() {
+    public void RescueInTheCloudsStatsAndKeywordsAreCorrect() {
         /**
          * Title: Rescue In The Clouds
          * Uniqueness: Unique
@@ -71,7 +71,7 @@ public class Card_5_067_Tests {
          * Type: Interrupt
          * Subtype: Used Or Lost
          * Destiny: 5
-         * Icons: Cloud City
+         * Icons: Cloud City, Interrupt
          * Game Text: USED: If you have a character on Weather Vane, place that character on your Used Pile.
          *      LOST: Deploy one or more vehicles, starfighters and pilots (at normal use of the Force)
          *      as a 'react' to a cloud sector.
@@ -97,12 +97,13 @@ public class Card_5_067_Tests {
             add(Icon.CLOUD_CITY);
             add(Icon.INTERRUPT);
         }});
+        scn.BlueprintKeywordCheck(card, new ArrayList<Keyword>());
         assertEquals(ExpansionSet.CLOUD_CITY, card.getExpansionSet());
         assertEquals(Rarity.C, card.getRarity());
     }
 
     @Test
-    public void UsedPlacesYourCharacterFromWeatherVaneInUsedPile_5_67_RescueInTheClouds() {
+    public void RescueInTheCloudsUsedPlacesYourCharacterFromWeatherVaneInUsedPile() {
         var scn = GetScenario();
 
         var rescue = scn.GetLSCard("rescue");
@@ -131,7 +132,7 @@ public class Card_5_067_Tests {
     }
 
     @Test
-    public void UsedNotPlayableIfOnlyOpponentsCharacterOnWeatherVane_5_67_RescueInTheClouds() {
+    public void RescueInTheCloudsUsedNotPlayableIfOnlyOpponentsCharacterOnWeatherVane() {
         var scn = GetScenario();
 
         var rescue = scn.GetLSCard("rescue");
@@ -149,7 +150,7 @@ public class Card_5_067_Tests {
     }
 
     @Test
-    public void UsedNotPlayableWithoutCharacterOnWeatherVane_5_67_RescueInTheClouds() {
+    public void RescueInTheCloudsUsedNotPlayableWithoutCharacterOnWeatherVane() {
         var scn = GetScenario();
 
         var rescue = scn.GetLSCard("rescue");
@@ -165,7 +166,7 @@ public class Card_5_067_Tests {
     }
 
     @Test
-    public void LostDeploysStarfighterAsReactToCloudSectorBattle_5_67_RescueInTheClouds() {
+    public void RescueInTheCloudsLostDeploysAsReactToCloudSectorBattle() {
         var scn = GetScenario();
 
         var rescue = scn.GetLSCard("rescue");
@@ -173,7 +174,6 @@ public class Card_5_067_Tests {
         var cloudCar = scn.GetLSCard("cloud-car");
         var bespin = scn.GetLSCard("bespin");
         var clouds = scn.GetLSCard("clouds");
-
         var tie = scn.GetDSCard("tie");
 
         scn.StartGame();
@@ -200,7 +200,7 @@ public class Card_5_067_Tests {
     }
 
     @Test
-    public void LostDeploysMediumBulkFreighterAsReactToCloudSectorBattle_5_67_RescueInTheClouds() {
+    public void RescueInTheCloudsLostDeploysCardsThatDeployLikeStarfighters() {
         var scn = GetScenario();
 
         var rescue = scn.GetLSCard("rescue");
@@ -220,14 +220,9 @@ public class Card_5_067_Tests {
         scn.MoveCardsToLocation(clouds, tie, cloudCar);
         scn.MoveCardsToLSHand(rescue, freighter);
 
-        assertTrue(Filters.deploysLikeStarfighter.accepts(scn.game(), freighter));
-        assertTrue(GameConditions.hasInHand(scn.game(), VirtualTableScenario.LS, Filters.deploysLikeStarfighter));
-
         scn.SkipToDSTurn(Phase.BATTLE);
         int forceBefore = scn.GetLSForcePileCount();
         scn.DSInitiateBattle(clouds);
-        assertTrue("Expected Rescue after-action. LS decision: " + (scn.LSGetDecision() == null ? "none" : scn.LSGetDecision().getText()),
-                scn.LSAnyDecisionsAvailable());
         assertTrue(scn.LSCardPlayAvailable(rescue));
         scn.LSPlayCard(rescue);
         scn.PassAllResponses();
@@ -242,7 +237,7 @@ public class Card_5_067_Tests {
     }
 
     @Test
-    public void LostOffersXwingAndMediumBulkFreighterButNotCorvetteAsReact_5_67_RescueInTheClouds() {
+    public void RescueInTheCloudsLostDoesNotOfferCapitalsThatDoNotDeployLikeStarfighters() {
         var scn = GetScenario();
 
         var rescue = scn.GetLSCard("rescue");
@@ -275,12 +270,12 @@ public class Card_5_067_Tests {
         scn.PassAllResponses();
 
         assertAtLocation(clouds, freighter);
-        assertInZone(Zone.HAND, xwing);
-        assertInZone(Zone.HAND, corvette);
+        assertInHand(xwing);
+        assertInHand(corvette);
     }
 
     @Test
-    public void LostAdditionalReactChoiceCanBeStoppedWithDone_5_67_RescueInTheClouds() {
+    public void RescueInTheCloudsLostAdditionalReactCanBeStoppedWithDone() {
         var scn = GetScenario();
 
         var rescue = scn.GetLSCard("rescue");
@@ -309,19 +304,18 @@ public class Card_5_067_Tests {
         scn.PassAllResponses();
 
         assertTrue(scn.LSAnyDecisionsAvailable());
-        assertTrue("Expected extra react Done prompt, LS decision: " + scn.LSGetDecision().getText(),
-                scn.LSGetDecision().getText().toLowerCase().contains("click 'done' to stop"));
+        assertTrue(scn.LSGetDecision().getText().toLowerCase().contains("click 'done' to stop"));
         assertTrue(scn.LSHasCardChoiceAvailable(freighter));
         scn.LSPass();
         scn.PassAllResponses();
 
         assertAtLocation(clouds, xwing);
-        assertInZone(Zone.HAND, freighter);
+        assertInHand(freighter);
         assertInZone(Zone.LOST_PILE, rescue);
     }
 
     @Test
-    public void LostDeploysSecondStarfighterWhenContinuingAfterFirstReact_5_67_RescueInTheClouds() {
+    public void RescueInTheCloudsLostDeploysAdditionalReact() {
         var scn = GetScenario();
 
         var rescue = scn.GetLSCard("rescue");
@@ -349,9 +343,7 @@ public class Card_5_067_Tests {
         }
         scn.PassAllResponses();
 
-        assertTrue("Expected extra react choice after first X-wing. LS decision: "
-                        + (scn.LSGetDecision() == null ? "none" : scn.LSGetDecision().getText()),
-                scn.LSAnyDecisionsAvailable());
+        assertTrue(scn.LSAnyDecisionsAvailable());
         assertTrue(scn.LSGetDecision().getText().toLowerCase().contains("click 'done' to stop"));
         assertTrue(scn.LSHasCardChoiceAvailable(xwing2));
         scn.LSChooseCard(xwing2);
@@ -369,7 +361,7 @@ public class Card_5_067_Tests {
     }
 
     @Test
-    public void LostDeploysSecondCloudCarWhenContinuingAfterFirstReact_5_67_RescueInTheClouds() {
+    public void RescueInTheCloudsLostDeploysAdditionalVehicleReact() {
         var scn = GetScenario();
 
         var rescue = scn.GetLSCard("rescue");
@@ -397,9 +389,7 @@ public class Card_5_067_Tests {
         }
         scn.PassAllResponses();
 
-        assertTrue("Expected extra react choice after first Cloud Car. LS decision: "
-                        + (scn.LSGetDecision() == null ? "none" : scn.LSGetDecision().getText()),
-                scn.LSAnyDecisionsAvailable());
+        assertTrue(scn.LSAnyDecisionsAvailable());
         assertTrue(scn.LSGetDecision().getText().toLowerCase().contains("click 'done' to stop"));
         assertTrue(scn.LSHasCardChoiceAvailable(cloudCar2));
         scn.LSChooseCard(cloudCar2);
@@ -438,7 +428,7 @@ public class Card_5_067_Tests {
     }
 
     @Test
-    public void LostComboThenAdditionalReactCanBeStoppedWithDone_5_67_RescueInTheClouds() {
+    public void RescueInTheCloudsLostAdditionalReactAfterSimultaneousDeployCanBeStoppedWithDone() {
         var scn = GetScenario();
 
         var rescue = scn.GetLSCard("rescue");
@@ -464,9 +454,7 @@ public class Card_5_067_Tests {
         acceptSimultaneousPilotIfOffered(scn, luke);
         scn.PassAllResponses();
 
-        assertTrue("Expected extra react choice after ship/pilot combo. LS decision: "
-                        + (scn.LSGetDecision() == null ? "none" : scn.LSGetDecision().getText()),
-                scn.LSAnyDecisionsAvailable());
+        assertTrue(scn.LSAnyDecisionsAvailable());
         assertTrue(scn.LSGetDecision().getText().toLowerCase().contains("click 'done' to stop"));
         assertTrue(scn.LSHasCardChoiceAvailable(cloudCar2));
         scn.LSPass();
@@ -474,12 +462,12 @@ public class Card_5_067_Tests {
 
         assertAtLocation(clouds, red1);
         assertTrue(scn.IsAboardAsPilot(red1, luke));
-        assertInZone(Zone.HAND, cloudCar2);
+        assertInHand(cloudCar2);
         assertInZone(Zone.LOST_PILE, rescue);
     }
 
     @Test
-    public void LostComboThenDeploysAnotherVehicleAsReact_5_67_RescueInTheClouds() {
+    public void RescueInTheCloudsLostDeploysAdditionalReactAfterSimultaneousDeploy() {
         var scn = GetScenario();
 
         var rescue = scn.GetLSCard("rescue");
@@ -505,9 +493,7 @@ public class Card_5_067_Tests {
         acceptSimultaneousPilotIfOffered(scn, luke);
         scn.PassAllResponses();
 
-        assertTrue("Expected extra react choice after ship/pilot combo. LS decision: "
-                        + (scn.LSGetDecision() == null ? "none" : scn.LSGetDecision().getText()),
-                scn.LSAnyDecisionsAvailable());
+        assertTrue(scn.LSAnyDecisionsAvailable());
         assertTrue(scn.LSGetDecision().getText().toLowerCase().contains("click 'done' to stop"));
         assertTrue(scn.LSHasCardChoiceAvailable(cloudCar2));
         scn.LSChooseCard(cloudCar2);
@@ -529,17 +515,12 @@ public class Card_5_067_Tests {
 
         assertAtLocation(clouds, red1);
         assertTrue(scn.IsAboardAsPilot(red1, luke));
-        assertEquals("Second react should deploy the Cloud Car. remaining decision="
-                        + (scn.LSGetDecision() == null ? "none" : scn.LSGetDecision().getText())
-                        + " force=" + scn.GetLSForcePileCount()
-                        + " car2=" + cloudCar2.getZone(),
-                Zone.AT_LOCATION, cloudCar2.getZone());
         assertAtLocation(clouds, cloudCar2);
         assertInZone(Zone.LOST_PILE, rescue);
     }
 
     @Test
-    public void LostExtraReactDoesNotOfferUnaffordablePatrolCraftOrPalaceRaider_5_67_RescueInTheClouds() {
+    public void RescueInTheCloudsLostDoesNotOfferExtraReactsThatCannotFullyDeploy() {
         var scn = GetScenario();
 
         var rescue = scn.GetLSCard("rescue");
@@ -571,10 +552,8 @@ public class Card_5_067_Tests {
         scn.PassAllResponses();
 
         assertEquals(1, scn.GetLSForcePileCount());
-        assertFalse("Patrol Craft should not light up without a full driver combo",
-                scn.LSAnyDecisionsAvailable() && scn.LSHasCardChoiceAvailable(patrol));
-        assertFalse("Palace Raider should not light up without enough Force",
-                scn.LSAnyDecisionsAvailable() && scn.LSHasCardChoiceAvailable(raider));
+        assertFalse(scn.LSAnyDecisionsAvailable() && scn.LSHasCardChoiceAvailable(patrol));
+        assertFalse(scn.LSAnyDecisionsAvailable() && scn.LSHasCardChoiceAvailable(raider));
         if (scn.LSAnyDecisionsAvailable()
                 && scn.LSGetDecision().getText().toLowerCase().contains("click 'done' to stop")) {
             scn.LSPass();
@@ -582,13 +561,13 @@ public class Card_5_067_Tests {
         }
 
         assertAtLocation(clouds, xwing);
-        assertInZone(Zone.HAND, patrol);
-        assertInZone(Zone.HAND, raider);
+        assertInHand(patrol);
+        assertInHand(raider);
         assertInZone(Zone.LOST_PILE, rescue);
     }
 
     @Test
-    public void LostNotPlayableWhenOnlyCapitalThatDoesNotDeployLikeStarfighterIsInHand_5_67_RescueInTheClouds() {
+    public void RescueInTheCloudsLostNotPlayableWhenOnlyIllegalCapitalIsInHand() {
         var scn = GetScenario();
 
         var rescue = scn.GetLSCard("rescue");
@@ -611,7 +590,7 @@ public class Card_5_067_Tests {
     }
 
     @Test
-    public void LostPlayableAsReactToCloudSectorForceDrain_5_67_RescueInTheClouds() {
+    public void RescueInTheCloudsLostPlayableAsReactToCloudSectorForceDrain() {
         var scn = GetScenario();
 
         var rescue = scn.GetLSCard("rescue");
@@ -643,7 +622,7 @@ public class Card_5_067_Tests {
     }
 
     @Test
-    public void LostNotPlayableAsReactToAsteroidSectorBattle_5_67_RescueInTheClouds() {
+    public void RescueInTheCloudsLostNotPlayableAsReactToAsteroidSectorBattle() {
         var scn = GetScenario();
 
         var rescue = scn.GetLSCard("rescue");
@@ -665,7 +644,7 @@ public class Card_5_067_Tests {
     }
 
     @Test
-    public void LostNotPlayableWhenBattleIsAtASite_5_67_RescueInTheClouds() {
+    public void RescueInTheCloudsLostNotPlayableWhenBattleIsAtASite() {
         var scn = GetScenario();
 
         var rescue = scn.GetLSCard("rescue");


### PR DESCRIPTION
Implements the unimplemented Cloud City Light Used or Lost Interrupt **Rescue In The Clouds** (`5_67`).

Closes #123.

Local unit tests green at `88eb65e3bf0fcf13c8f2682348061864aa180665`: **11 run / 0 fail**. Incremental Maven on `gemp-swccg-server`.

## Card text (errata)
**Rescue In The Clouds** (Unique, Light, Interrupt - Used or Lost, Cloud City, C)

Destiny 5.

Lore: 'I know where Luke is.'

Game text: USED: If you have a character on Weather Vane, place that character on your Used Pile. LOST: Deploy one or more vehicles, starfighters and pilots (at normal use of the Force) as a 'react' to a cloud sector.

## Implementation notes
- New class `Card5_067` extends `AbstractUsedOrLostInterrupt` (`set5/light`). Neighbors `Card5_066` / `Card5_068`. Does not implement missing 5_13 Cyborg Construct, 5_15 Access Denied, 5_23 Frozen Assets, 5_52 Impressive Most Impressive, or 5_53 Innocent Scoundrel.
- `Title.Rescue_In_The_Clouds` and `Filters.Rescue_In_The_Clouds` added. Virtual `Card209_022` now uses the Title constant.
- `CardImages.js` already maps `5_67` to `CloudCity-Light/large/rescueintheclouds.gif`; not changed.
- Blueprint JSON added for `5_67` in `card_blueprint_database.json` and `_light.json`.
- USED: your character stacked on Weather Vane goes to Used Pile. Opponent's character on Weather Vane is not legal.
- LOST: optional after-action when opponent initiates a battle or Force drain at a cloud sector. Deploys one or more vehicles, starfighters, pilots, and cards that **deploy like a starfighter** from hand as a 'react' at printed Force cost (CZ-3 / Comlink style). Per ARB Starships, "deploy like a starfighter" is never optional, so Medium Bulk Freighter is legal; Corellian Corvette is not. Not legal at sites or asteroid sectors.

Google Doc tab: https://docs.google.com/document/d/1OXth1UXD0dogzaYxGXAthcl24q7meZyeWfjGCjYUmFI/edit?tab=t.ep1qrp9fd1k6
Scomp: https://scomp.starwarsccg.org/?s=Rescue%20In%20The%20Clouds
ARB: https://res.starwarsccg.org/rules/SWCCG_2023_AdvancedRulebook.pdf (Starships - deploys like a starfighter)

## Tests
`src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_067_Tests.java` - names include `5_67` and RescueInTheClouds. Decipher-set only.

- `StatsAndKeywordsAreCorrect_5_67_RescueInTheClouds`
- `UsedPlacesYourCharacterFromWeatherVaneInUsedPile_5_67_RescueInTheClouds`
- `UsedNotPlayableWithoutCharacterOnWeatherVane_5_67_RescueInTheClouds`
- `UsedNotPlayableIfOnlyOpponentsCharacterOnWeatherVane_5_67_RescueInTheClouds`
- `LostDeploysStarfighterAsReactToCloudSectorBattle_5_67_RescueInTheClouds`
- `LostPlayableAsReactToCloudSectorForceDrain_5_67_RescueInTheClouds`
- `LostDeploysMediumBulkFreighterAsReactToCloudSectorBattle_5_67_RescueInTheClouds`
- `LostOffersXwingAndMediumBulkFreighterButNotCorvetteAsReact_5_67_RescueInTheClouds`
- `LostNotPlayableWhenOnlyCapitalThatDoesNotDeployLikeStarfighterIsInHand_5_67_RescueInTheClouds`
- `LostNotPlayableAsReactToAsteroidSectorBattle_5_67_RescueInTheClouds`
- `LostNotPlayableWhenBattleIsAtASite_5_67_RescueInTheClouds`

## Test plan
- [x] `mvn -pl gemp-swccg-server -am -Dtest=Card_5_067_Tests -Dsurefire.failIfNoSpecifiedTests=false test` in Docker (**11 run, 0 fail**)
- [x] Redeploy Rescue In The Clouds to localhost:17001 (asdf/asdf). Hard-refresh if an old game is open.
