### PR TITLE
Implement TIE Sentry Ships (5_158)

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set201/dark/Card201_036.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set201/dark/Card201_036.java
@@ -8,6 +8,7 @@ import com.gempukku.swccgo.common.GameTextActionId;
 import com.gempukku.swccgo.common.Icon;
 import com.gempukku.swccgo.common.Rarity;
 import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Title;
 import com.gempukku.swccgo.common.Uniqueness;
 import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.game.PhysicalCard;
@@ -34,7 +35,7 @@ import java.util.List;
  */
 public class Card201_036 extends AbstractUsedOrLostInterrupt {
     public Card201_036() {
-        super(Side.DARK, 5, "TIE Sentry Ships", Uniqueness.UNIQUE, ExpansionSet.SET_1, Rarity.V);
+        super(Side.DARK, 5, Title.TIE_Sentry_Ships, Uniqueness.UNIQUE, ExpansionSet.SET_1, Rarity.V);
         setVirtualSuffix(true);
         setLore("Several TIEs were assigned to patrol Cloud City prior to the Imperial occupation of Bespin. Their instructions were to herd any vessels attempting to escape toward the Executor.");
         setGameText("USED: If you just drew a starship for destiny, take that starship into hand to cancel and redraw that destiny. LOST: Use 3 Force to retrieve a starship into hand.");

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/dark/Card5_158.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/dark/Card5_158.java
@@ -14,13 +14,13 @@ import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.game.SwccgGame;
 import com.gempukku.swccgo.logic.TriggerConditions;
 import com.gempukku.swccgo.logic.actions.PlayInterruptAction;
-import com.gempukku.swccgo.logic.decisions.MultipleChoiceAwaitingDecision;
-import com.gempukku.swccgo.logic.effects.PlayoutDecisionEffect;
 import com.gempukku.swccgo.logic.effects.RespondablePlayCardEffect;
+import com.gempukku.swccgo.logic.effects.choose.ChooseCardsFromHandEffect;
 import com.gempukku.swccgo.logic.effects.choose.DeployCardToLocationFromHandEffect;
 import com.gempukku.swccgo.logic.timing.Action;
 import com.gempukku.swccgo.logic.timing.EffectResult;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -74,40 +74,50 @@ public class Card5_158 extends AbstractLostInterrupt {
             return;
         }
 
-        action.appendEffect(
-                new DeployCardToLocationFromHandEffect(action, playerId, deployFilter, locationFilter, false, true) {
-                    @Override
-                    public String getChoiceText() {
-                        if (required) {
+        if (required) {
+            action.appendEffect(
+                    new DeployCardToLocationFromHandEffect(action, playerId, deployFilter, locationFilter, false, true) {
+                        @Override
+                        public String getChoiceText() {
                             return "Choose a TIE or pilot to deploy as a 'react'";
                         }
-                        return "Choose another TIE or pilot to deploy as a 'react'";
+
+                        @Override
+                        protected void cardDeployed(PhysicalCard card) {
+                            appendOptionalAdditionalReactDeploys(action, playerId, game, deployFilter, locationFilter);
+                        }
+                    }
+            );
+            return;
+        }
+
+        action.appendEffect(
+                new ChooseCardsFromHandEffect(action, playerId, playerId, 0, 1, deployFilter, true, false) {
+                    @Override
+                    public String getChoiceText(int numCardsToChoose) {
+                        return "Choose another TIE or pilot to deploy as a 'react', or click 'Done' to stop";
                     }
 
                     @Override
-                    protected void cardDeployed(PhysicalCard card) {
-                        appendOptionalAdditionalReactDeploys(action, playerId, game, deployFilter, locationFilter);
+                    protected void cardsSelected(SwccgGame game, Collection<PhysicalCard> selectedCards) {
+                        if (selectedCards.isEmpty()) {
+                            return;
+                        }
+                        PhysicalCard selectedCard = selectedCards.iterator().next();
+                        action.appendEffect(
+                                new DeployCardToLocationFromHandEffect(action, selectedCard, locationFilter, false, true) {
+                                    @Override
+                                    protected void cardDeployed(PhysicalCard card) {
+                                        appendOptionalAdditionalReactDeploys(action, playerId, game, deployFilter, locationFilter);
+                                    }
+                                }
+                        );
                     }
                 }
         );
     }
 
     private void appendOptionalAdditionalReactDeploys(final PlayInterruptAction action, final String playerId, final SwccgGame game, final Filter deployFilter, final Filter locationFilter) {
-        if (!GameConditions.hasInHand(game, playerId, deployFilter)) {
-            return;
-        }
-
-        action.appendEffect(
-                new PlayoutDecisionEffect(action, playerId,
-                        new MultipleChoiceAwaitingDecision("Deploy another TIE or pilot as a 'react'?", new String[]{"Yes", "No"}) {
-                            @Override
-                            protected void validDecisionMade(int index, String result) {
-                                if (index == 0) {
-                                    appendDeployAsReactFromHand(action, playerId, game, deployFilter, locationFilter, false);
-                                }
-                            }
-                        }
-                )
-        );
+        appendDeployAsReactFromHand(action, playerId, game, deployFilter, locationFilter, false);
     }
 }

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/dark/Card5_158.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/dark/Card5_158.java
@@ -1,0 +1,113 @@
+package com.gempukku.swccgo.cards.set5.dark;
+
+import com.gempukku.swccgo.cards.AbstractLostInterrupt;
+import com.gempukku.swccgo.cards.GameConditions;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.filters.Filter;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.logic.TriggerConditions;
+import com.gempukku.swccgo.logic.actions.PlayInterruptAction;
+import com.gempukku.swccgo.logic.decisions.MultipleChoiceAwaitingDecision;
+import com.gempukku.swccgo.logic.effects.PlayoutDecisionEffect;
+import com.gempukku.swccgo.logic.effects.RespondablePlayCardEffect;
+import com.gempukku.swccgo.logic.effects.choose.DeployCardToLocationFromHandEffect;
+import com.gempukku.swccgo.logic.timing.Action;
+import com.gempukku.swccgo.logic.timing.EffectResult;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Set: Cloud City
+ * Type: Interrupt
+ * Subtype: Lost
+ * Title: TIE Sentry Ships
+ */
+public class Card5_158 extends AbstractLostInterrupt {
+    public Card5_158() {
+        super(Side.DARK, 5, Title.TIE_Sentry_Ships, Uniqueness.UNIQUE, ExpansionSet.CLOUD_CITY, Rarity.C);
+        setLore("Several TIEs were assigned to patrol Cloud City prior to the Imperial occupation of Bespin. Their instructions were to herd any vessels attempting to escape toward the Executor.");
+        setGameText("If opponent just initiated a Force drain at a system, cloud sector or asteroid sector, you may 'react' by deploying TIEs and pilots to that location (at normal use of the Force).");
+        addIcons(Icon.CLOUD_CITY);
+    }
+
+    @Override
+    protected List<PlayInterruptAction> getGameTextOptionalAfterActions(final String playerId, SwccgGame game, EffectResult effectResult, final PhysicalCard self) {
+        final String opponent = game.getOpponent(playerId);
+        final Filter locationFilter = Filters.or(Filters.system, Filters.cloud_sector, Filters.asteroid_sector);
+        final Filter deployFilter = Filters.or(Filters.TIE, Filters.pilot);
+
+        // Check condition(s)
+        if (TriggerConditions.forceDrainInitiatedBy(game, effectResult, opponent, locationFilter)
+                && GameConditions.hasInHand(game, playerId, deployFilter)) {
+
+            final PhysicalCard forceDrainLocation = game.getGameState().getForceDrainLocation();
+            if (forceDrainLocation == null) {
+                return null;
+            }
+
+            final PlayInterruptAction action = new PlayInterruptAction(game, self);
+            action.setText("Deploy TIEs and pilots as a 'react'");
+            // Allow response(s)
+            action.allowResponses("Deploy TIEs and pilots as a 'react' to " + forceDrainLocation.getTitle(),
+                    new RespondablePlayCardEffect(action) {
+                        @Override
+                        protected void performActionResults(Action targetingAction) {
+                            appendDeployAsReactFromHand(action, playerId, game, deployFilter, Filters.sameCardId(forceDrainLocation), true);
+                        }
+                    }
+            );
+            return Collections.singletonList(action);
+        }
+        return null;
+    }
+
+    private void appendDeployAsReactFromHand(final PlayInterruptAction action, final String playerId, final SwccgGame game, final Filter deployFilter, final Filter locationFilter, final boolean required) {
+        if (!GameConditions.hasInHand(game, playerId, deployFilter)) {
+            return;
+        }
+
+        action.appendEffect(
+                new DeployCardToLocationFromHandEffect(action, playerId, deployFilter, locationFilter, false, true) {
+                    @Override
+                    public String getChoiceText() {
+                        if (required) {
+                            return "Choose a TIE or pilot to deploy as a 'react'";
+                        }
+                        return "Choose another TIE or pilot to deploy as a 'react'";
+                    }
+
+                    @Override
+                    protected void cardDeployed(PhysicalCard card) {
+                        appendOptionalAdditionalReactDeploys(action, playerId, game, deployFilter, locationFilter);
+                    }
+                }
+        );
+    }
+
+    private void appendOptionalAdditionalReactDeploys(final PlayInterruptAction action, final String playerId, final SwccgGame game, final Filter deployFilter, final Filter locationFilter) {
+        if (!GameConditions.hasInHand(game, playerId, deployFilter)) {
+            return;
+        }
+
+        action.appendEffect(
+                new PlayoutDecisionEffect(action, playerId,
+                        new MultipleChoiceAwaitingDecision("Deploy another TIE or pilot as a 'react'?", new String[]{"Yes", "No"}) {
+                            @Override
+                            protected void validDecisionMade(int index, String result) {
+                                if (index == 0) {
+                                    appendDeployAsReactFromHand(action, playerId, game, deployFilter, locationFilter, false);
+                                }
+                            }
+                        }
+                )
+        );
+    }
+}

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/dark/Card5_158.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/dark/Card5_158.java
@@ -11,6 +11,7 @@ import com.gempukku.swccgo.common.Uniqueness;
 import com.gempukku.swccgo.filters.Filter;
 import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.ReactActionOption;
 import com.gempukku.swccgo.game.SwccgGame;
 import com.gempukku.swccgo.logic.TriggerConditions;
 import com.gempukku.swccgo.logic.actions.PlayInterruptAction;
@@ -70,12 +71,18 @@ public class Card5_158 extends AbstractLostInterrupt {
         return null;
     }
 
-    private void appendDeployAsReactFromHand(final PlayInterruptAction action, final String playerId, final SwccgGame game, final Filter deployFilter, final Filter locationFilter, final boolean required) {
-        if (!GameConditions.hasInHand(game, playerId, deployFilter)) {
-            return;
-        }
+    private Filter fullyDeployableAsReactFilter(PhysicalCard self, Filter deployFilter, Filter locationFilter) {
+        Filter targetFilter = Filters.locationAndCardsAtLocation(locationFilter);
+        ReactActionOption reactOption = new ReactActionOption(self, false, 0, false, "Deploy as a 'react'", deployFilter, targetFilter, null, false);
+        reactOption.setForFreeCardFilter(Filters.none);
+        return Filters.and(deployFilter, Filters.deployableToTarget(self, targetFilter, false, false, 0, null, null, null, null, reactOption));
+    }
 
+    private void appendDeployAsReactFromHand(final PlayInterruptAction action, final String playerId, final SwccgGame game, final Filter deployFilter, final Filter locationFilter, final boolean required) {
         if (required) {
+            if (!GameConditions.hasInHand(game, playerId, deployFilter)) {
+                return;
+            }
             action.appendEffect(
                     new DeployCardToLocationFromHandEffect(action, playerId, deployFilter, locationFilter, false, true) {
                         @Override
@@ -95,8 +102,13 @@ public class Card5_158 extends AbstractLostInterrupt {
             return;
         }
 
+        Filter extraFilter = fullyDeployableAsReactFilter(action.getActionSource(), deployFilter, locationFilter);
+        if (!GameConditions.hasInHand(game, playerId, extraFilter)) {
+            return;
+        }
+
         action.appendEffect(
-                new ChooseCardsFromHandEffect(action, playerId, playerId, 0, 1, deployFilter, true, false) {
+                new ChooseCardsFromHandEffect(action, playerId, playerId, 0, 1, extraFilter, true, false) {
                     @Override
                     public String getChoiceText(int numCardsToChoose) {
                         return "Choose another TIE or pilot to deploy as a 'react', or click 'Done' to stop";

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/dark/Card5_158.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/dark/Card5_158.java
@@ -19,6 +19,7 @@ import com.gempukku.swccgo.logic.effects.choose.ChooseCardsFromHandEffect;
 import com.gempukku.swccgo.logic.effects.choose.DeployCardToLocationFromHandEffect;
 import com.gempukku.swccgo.logic.timing.Action;
 import com.gempukku.swccgo.logic.timing.EffectResult;
+import com.gempukku.swccgo.logic.timing.PassthruEffect;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -81,9 +82,12 @@ public class Card5_158 extends AbstractLostInterrupt {
                         public String getChoiceText() {
                             return "Choose a TIE or pilot to deploy as a 'react'";
                         }
-
+                    }
+            );
+            action.appendEffect(
+                    new PassthruEffect(action) {
                         @Override
-                        protected void cardDeployed(PhysicalCard card) {
+                        protected void doPlayEffect(SwccgGame game) {
                             appendOptionalAdditionalReactDeploys(action, playerId, game, deployFilter, locationFilter);
                         }
                     }
@@ -105,9 +109,12 @@ public class Card5_158 extends AbstractLostInterrupt {
                         }
                         PhysicalCard selectedCard = selectedCards.iterator().next();
                         action.appendEffect(
-                                new DeployCardToLocationFromHandEffect(action, selectedCard, locationFilter, false, true) {
+                                new DeployCardToLocationFromHandEffect(action, selectedCard, locationFilter, false, true)
+                        );
+                        action.appendEffect(
+                                new PassthruEffect(action) {
                                     @Override
-                                    protected void cardDeployed(PhysicalCard card) {
+                                    protected void doPlayEffect(SwccgGame game) {
                                         appendOptionalAdditionalReactDeploys(action, playerId, game, deployFilter, locationFilter);
                                     }
                                 }

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
@@ -102347,6 +102347,34 @@
     ]
   },
   {
+    "cardId": "5_158",
+    "title": "TIE Sentry Ships",
+    "slug": "tie-sentry-ships",
+    "slugWithSetName": "tie-sentry-ships-cloud-city",
+    "side": "DARK",
+    "uniqueness": "UNIQUE",
+    "expansionSet": "CLOUD_CITY",
+    "rarity": "C",
+    "cardCategory": "INTERRUPT",
+    "cardTypes": [
+      "INTERRUPT"
+    ],
+    "cardSubtype": "LOST",
+    "lore": "Several TIEs were assigned to patrol Cloud City prior to the Imperial occupation of Bespin. Their instructions were to herd any vessels attempting to escape toward the Executor.",
+    "gameText": "If opponent just initiated a Force drain at a system, cloud sector or asteroid sector, you may 'react' by deploying TIEs and pilots to that location (at normal use of the Force).",
+    "destiny": 5,
+    "icons": [
+      {
+        "icon": "CLOUD_CITY",
+        "count": 1
+      },
+      {
+        "icon": "INTERRUPT",
+        "count": 1
+      }
+    ]
+  },
+  {
     "cardId": "5_159",
     "title": "Trooper Assault",
     "slug": "trooper-assault",

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_dark.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_dark.json
@@ -50403,6 +50403,34 @@
     ]
   },
   {
+    "cardId": "5_158",
+    "title": "TIE Sentry Ships",
+    "slug": "tie-sentry-ships",
+    "slugWithSetName": "tie-sentry-ships-cloud-city",
+    "side": "DARK",
+    "uniqueness": "UNIQUE",
+    "expansionSet": "CLOUD_CITY",
+    "rarity": "C",
+    "cardCategory": "INTERRUPT",
+    "cardTypes": [
+      "INTERRUPT"
+    ],
+    "cardSubtype": "LOST",
+    "lore": "Several TIEs were assigned to patrol Cloud City prior to the Imperial occupation of Bespin. Their instructions were to herd any vessels attempting to escape toward the Executor.",
+    "gameText": "If opponent just initiated a Force drain at a system, cloud sector or asteroid sector, you may 'react' by deploying TIEs and pilots to that location (at normal use of the Force).",
+    "destiny": 5,
+    "icons": [
+      {
+        "icon": "CLOUD_CITY",
+        "count": 1
+      },
+      {
+        "icon": "INTERRUPT",
+        "count": 1
+      }
+    ]
+  },
+  {
     "cardId": "5_159",
     "title": "Trooper Assault",
     "slug": "trooper-assault",

--- a/src/gemp-swccg-common/src/main/java/com/gempukku/swccgo/common/Title.java
+++ b/src/gemp-swccg-common/src/main/java/com/gempukku/swccgo/common/Title.java
@@ -1212,6 +1212,7 @@ public interface Title {
     String Tibanna_Gas_Miner = "Tibanna Gas Miner";
     String Tibrin = "Tibrin";
     String TIE_Assault_Squadron = "TIE Assault Squadron";
+    String TIE_Sentry_Ships = "TIE Sentry Ships";
     String TK421 = "TK-421";
     String TK422 = "TK-422";
     String Too_Cold_For_Speeders = "Too Cold For Speeders";

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
@@ -19488,6 +19488,7 @@ public class Filters {
     public static final Filter TIE_ln = Filters.modelType(ModelType.TIE_LN);
     public static final Filter TIE_rc = Filters.modelType(ModelType.TIE_RC);
     public static final Filter TIE_sa = Filters.modelType(ModelType.TIE_SA);
+    public static final Filter TIE_Sentry_Ships = Filters.title(Title.TIE_Sentry_Ships);
     public static final Filter TIE_sr = Filters.modelType(ModelType.TIE_SR);
     public static final Filter TIE_vn = Filters.modelType(ModelType.TIE_VN);
     public static final Filter Tigran = Filters.persona(Persona.TIGRAN);

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_158_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_158_Tests.java
@@ -1,0 +1,224 @@
+package com.gempukku.swccgo.cards.set5.dark;
+
+import com.gempukku.swccgo.common.CardSubtype;
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static com.gempukku.swccgo.framework.Assertions.assertAtLocation;
+import static com.gempukku.swccgo.framework.Assertions.assertInZone;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Card_5_158_Tests {
+
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("xwing", "1_146");
+                    put("bespin", "5_76");
+                    put("clouds", "5_85");
+                }},
+                new HashMap<>() {{
+                    put("sentry", "5_158");
+                    put("tie", "1_304");
+                    put("hoth", "3_143");
+                    put("big-one", "4_156");
+                }},
+                20,
+                20,
+                StartingSetup.DefaultLSSpaceSystem,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void StatsAndKeywordsAreCorrect_5_158_TIESentryShips() {
+        /**
+         * Title: TIE Sentry Ships
+         * Uniqueness: Unique
+         * Side: Dark
+         * Type: Interrupt
+         * Subtype: Lost
+         * Destiny: 5
+         * Icons: Cloud City
+         * Game Text: If opponent just initiated a Force drain at a system, cloud sector or asteroid sector,
+         *      you may 'react' by deploying TIEs and pilots to that location (at normal use of the Force).
+         * Lore: Several TIEs were assigned to patrol Cloud City prior to the Imperial occupation of Bespin.
+         *      Their instructions were to herd any vessels attempting to escape toward the Executor.
+         * Set: Cloud City
+         * Rarity: C
+         */
+
+        var scn = GetScenario();
+
+        var card = scn.GetDSCard("sentry").getBlueprint();
+
+        assertEquals("TIE Sentry Ships", card.getTitle());
+        assertFalse(card.hasVirtualSuffix());
+        assertEquals(Uniqueness.UNIQUE, card.getUniqueness());
+        assertEquals(Side.DARK, card.getSide());
+        assertEquals(5, card.getDestiny(), scn.epsilon);
+        scn.BlueprintCardTypeCheck(card, new ArrayList<>() {{
+            add(CardType.INTERRUPT);
+        }});
+        assertEquals(CardSubtype.LOST, card.getCardSubtype());
+        scn.BlueprintIconCheck(card, new ArrayList<>() {{
+            add(Icon.CLOUD_CITY);
+            add(Icon.INTERRUPT);
+        }});
+        assertEquals(ExpansionSet.CLOUD_CITY, card.getExpansionSet());
+        assertEquals(Rarity.C, card.getRarity());
+    }
+
+    @Test
+    public void DeploysTIEAsReactToSystemForceDrain_5_158_TIESentryShips() {
+        var scn = GetScenario();
+
+        var sentry = scn.GetDSCard("sentry");
+        var tie = scn.GetDSCard("tie");
+        var xwing = scn.GetLSCard("xwing");
+        var system = scn.GetLSStartingLocation();
+
+        scn.StartGame();
+
+        scn.MoveCardsToLocation(system, xwing);
+        scn.MoveCardsToDSHand(sentry, tie);
+
+        scn.SkipToLSTurn(Phase.CONTROL);
+        int forceBefore = scn.GetDSForcePileCount();
+        assertTrue(scn.LSForceDrainAvailable(system));
+        scn.LSForceDrainAt(system);
+        assertTrue(scn.DSCardPlayAvailable(sentry));
+        scn.DSPlayCard(sentry);
+        scn.PassAllResponses();
+        if (scn.DSAnyDecisionsAvailable() && scn.DSHasCardChoiceAvailable(tie)) {
+            scn.DSChooseCard(tie);
+        }
+        scn.PassAllResponses();
+
+        assertAtLocation(system, tie);
+        assertInZone(Zone.LOST_PILE, sentry);
+        assertEquals(forceBefore - 1, scn.GetDSForcePileCount());
+    }
+
+    @Test
+    public void PlayableAsReactToCloudSectorForceDrain_5_158_TIESentryShips() {
+        var scn = GetScenario();
+
+        var sentry = scn.GetDSCard("sentry");
+        var tie = scn.GetDSCard("tie");
+        var xwing = scn.GetLSCard("xwing");
+        var bespin = scn.GetLSCard("bespin");
+        var clouds = scn.GetLSCard("clouds");
+
+        scn.StartGame();
+
+        scn.MoveLocationToTable(bespin);
+        scn.MoveLocationToTable(clouds);
+        scn.MoveCardsToLocation(clouds, xwing);
+        scn.MoveCardsToDSHand(sentry, tie);
+
+        scn.SkipToLSTurn(Phase.CONTROL);
+        assertTrue(scn.LSForceDrainAvailable(clouds));
+        scn.LSForceDrainAt(clouds);
+        assertTrue(scn.DSCardPlayAvailable(sentry));
+        scn.DSPlayCard(sentry);
+        scn.PassAllResponses();
+        if (scn.DSAnyDecisionsAvailable() && scn.DSHasCardChoiceAvailable(tie)) {
+            scn.DSChooseCard(tie);
+        }
+        scn.PassAllResponses();
+
+        assertAtLocation(clouds, tie);
+        assertInZone(Zone.LOST_PILE, sentry);
+    }
+
+    @Test
+    public void PlayableAsReactToAsteroidSectorForceDrain_5_158_TIESentryShips() {
+        var scn = GetScenario();
+
+        var sentry = scn.GetDSCard("sentry");
+        var tie = scn.GetDSCard("tie");
+        var xwing = scn.GetLSCard("xwing");
+        var hoth = scn.GetDSCard("hoth");
+        var bigOne = scn.GetDSCard("big-one");
+
+        scn.StartGame();
+
+        scn.MoveLocationToTable(hoth);
+        scn.MoveLocationToTable(bigOne);
+        scn.MoveCardsToLocation(bigOne, xwing);
+        scn.MoveCardsToDSHand(sentry, tie);
+
+        scn.SkipToLSTurn(Phase.CONTROL);
+        assertTrue(scn.LSForceDrainAvailable(bigOne));
+        scn.LSForceDrainAt(bigOne);
+        assertTrue(scn.DSCardPlayAvailable(sentry));
+        scn.DSPlayCard(sentry);
+        scn.PassAllResponses();
+        if (scn.DSAnyDecisionsAvailable() && scn.DSHasCardChoiceAvailable(tie)) {
+            scn.DSChooseCard(tie);
+        }
+        scn.PassAllResponses();
+
+        assertAtLocation(bigOne, tie);
+        assertInZone(Zone.LOST_PILE, sentry);
+    }
+
+    @Test
+    public void NotPlayableAsReactToBattleAtSystem_5_158_TIESentryShips() {
+        var scn = GetScenario();
+
+        var sentry = scn.GetDSCard("sentry");
+        var tie = scn.GetDSCard("tie");
+        var xwing = scn.GetLSCard("xwing");
+        var system = scn.GetLSStartingLocation();
+
+        scn.StartGame();
+
+        scn.MoveCardsToLocation(system, xwing, tie);
+        scn.MoveCardsToDSHand(sentry);
+
+        scn.SkipToLSTurn(Phase.BATTLE);
+        scn.LSInitiateBattle(system);
+        assertFalse(scn.DSAnyDecisionsAvailable() && scn.DSCardPlayAvailable(sentry));
+    }
+
+    @Test
+    public void NotPlayableAsReactToForceDrainAtSite_5_158_TIESentryShips() {
+        var scn = GetScenario();
+
+        var sentry = scn.GetDSCard("sentry");
+        var tie = scn.GetDSCard("tie");
+        var site = scn.GetDSStartingLocation();
+        var lsPresence = scn.GetLSFiller(1);
+
+        scn.StartGame();
+
+        scn.MoveCardsToLocation(site, lsPresence);
+        scn.MoveCardsToDSHand(sentry, tie);
+
+        scn.SkipToLSTurn(Phase.CONTROL);
+        assertTrue(scn.LSForceDrainAvailable(site));
+        scn.LSForceDrainAt(site);
+        assertFalse(scn.DSAnyDecisionsAvailable() && scn.DSCardPlayAvailable(sentry));
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_158_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_158_Tests.java
@@ -34,6 +34,7 @@ public class Card_5_158_Tests {
                 new HashMap<>() {{
                     put("sentry", "5_158");
                     put("tie", "1_304");
+                    put("tie2", "1_304");
                     put("hoth", "3_143");
                     put("big-one", "4_156");
                 }},
@@ -117,6 +118,43 @@ public class Card_5_158_Tests {
         assertAtLocation(system, tie);
         assertInZone(Zone.LOST_PILE, sentry);
         assertEquals(forceBefore - 1, scn.GetDSForcePileCount());
+    }
+
+    @Test
+    public void AdditionalReactChoiceCanBeStoppedWithDone_5_158_TIESentryShips() {
+        var scn = GetScenario();
+
+        var sentry = scn.GetDSCard("sentry");
+        var tie = scn.GetDSCard("tie");
+        var tie2 = scn.GetDSCard("tie2");
+        var xwing = scn.GetLSCard("xwing");
+        var system = scn.GetLSStartingLocation();
+
+        scn.StartGame();
+
+        scn.MoveCardsToLocation(system, xwing);
+        scn.MoveCardsToDSHand(sentry, tie, tie2);
+
+        scn.SkipToLSTurn(Phase.CONTROL);
+        assertTrue(scn.LSForceDrainAvailable(system));
+        scn.LSForceDrainAt(system);
+        assertTrue(scn.DSCardPlayAvailable(sentry));
+        scn.DSPlayCard(sentry);
+        scn.PassAllResponses();
+        if (scn.DSAnyDecisionsAvailable() && scn.DSHasCardChoiceAvailable(tie)) {
+            scn.DSChooseCard(tie);
+        }
+        scn.PassAllResponses();
+
+        assertTrue(scn.DSAnyDecisionsAvailable());
+        assertTrue(scn.DSGetDecision().getText().toLowerCase().contains("done"));
+        assertTrue(scn.DSHasCardChoiceAvailable(tie2));
+        scn.DSPass();
+        scn.PassAllResponses();
+
+        assertAtLocation(system, tie);
+        assertInZone(Zone.HAND, tie2);
+        assertInZone(Zone.LOST_PILE, sentry);
     }
 
     @Test

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_158_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_158_Tests.java
@@ -35,6 +35,9 @@ public class Card_5_158_Tests {
                     put("sentry", "5_158");
                     put("tie", "1_304");
                     put("tie2", "1_304");
+                    put("black2", "1_299");
+                    put("ds612", "1_173");
+                    put("ds613", "1_174");
                     put("hoth", "3_143");
                     put("big-one", "4_156");
                 }},
@@ -146,6 +149,153 @@ public class Card_5_158_Tests {
         }
         scn.PassAllResponses();
 
+        assertTrue(scn.DSAnyDecisionsAvailable());
+        assertTrue(scn.DSGetDecision().getText().toLowerCase().contains("done"));
+        assertTrue(scn.DSHasCardChoiceAvailable(tie2));
+        scn.DSPass();
+        scn.PassAllResponses();
+
+        assertAtLocation(system, tie);
+        assertInZone(Zone.HAND, tie2);
+        assertInZone(Zone.LOST_PILE, sentry);
+    }
+
+    @Test
+    public void ExtraReactDoesNotOfferCardsThatCostMoreThanRemainingForce_5_158_TIESentryShips() {
+        var scn = GetScenario();
+
+        var sentry = scn.GetDSCard("sentry");
+        var tie = scn.GetDSCard("tie");
+        var ds612 = scn.GetDSCard("ds612");
+        var ds613 = scn.GetDSCard("ds613");
+        var xwing = scn.GetLSCard("xwing");
+        var system = scn.GetLSStartingLocation();
+
+        scn.StartGame();
+
+        scn.MoveCardsToLocation(system, xwing);
+        scn.MoveCardsToDSHand(sentry, tie, ds612, ds613);
+
+        scn.SkipToLSTurn(Phase.CONTROL);
+        int currentForce = scn.GetDSForcePileCount();
+        if (currentForce > 2) {
+            scn.DSUseForceCheat(currentForce - 2);
+        } else if (currentForce < 2) {
+            scn.DSActivateForceCheat(2 - currentForce);
+        }
+
+        assertTrue(scn.LSForceDrainAvailable(system));
+        scn.LSForceDrainAt(system);
+        assertTrue(scn.DSCardPlayAvailable(sentry));
+        scn.DSPlayCard(sentry);
+        scn.PassAllResponses();
+        if (scn.DSAnyDecisionsAvailable() && scn.DSHasCardChoiceAvailable(tie)) {
+            scn.DSChooseCard(tie);
+        }
+        scn.PassAllResponses();
+
+        assertEquals(1, scn.GetDSForcePileCount());
+        assertFalse("2-deploy pilot should not light up with 1 Force",
+                scn.DSAnyDecisionsAvailable() && scn.DSHasCardChoiceAvailable(ds612));
+        assertFalse("2-deploy pilot should not light up with 1 Force",
+                scn.DSAnyDecisionsAvailable() && scn.DSHasCardChoiceAvailable(ds613));
+        if (scn.DSAnyDecisionsAvailable()
+                && scn.DSGetDecision().getText().toLowerCase().contains("done")) {
+            scn.DSPass();
+            scn.PassAllResponses();
+        }
+
+        assertAtLocation(system, tie);
+        assertInZone(Zone.HAND, ds612);
+        assertInZone(Zone.HAND, ds613);
+        assertInZone(Zone.LOST_PILE, sentry);
+    }
+
+    @Test
+    public void ExtraReactDoesNotOfferBlack2WhenRemainingForceCannotPayForRequiredPilot_5_158_TIESentryShips() {
+        var scn = GetScenario();
+
+        var sentry = scn.GetDSCard("sentry");
+        var tie = scn.GetDSCard("tie");
+        var black2 = scn.GetDSCard("black2");
+        var ds612 = scn.GetDSCard("ds612");
+        var xwing = scn.GetLSCard("xwing");
+        var system = scn.GetLSStartingLocation();
+
+        scn.StartGame();
+
+        scn.MoveCardsToLocation(system, xwing);
+        scn.MoveCardsToDSHand(sentry, tie, black2, ds612);
+
+        scn.SkipToLSTurn(Phase.CONTROL);
+        int currentForce = scn.GetDSForcePileCount();
+        if (currentForce > 2) {
+            scn.DSUseForceCheat(currentForce - 2);
+        } else if (currentForce < 2) {
+            scn.DSActivateForceCheat(2 - currentForce);
+        }
+
+        assertTrue(scn.LSForceDrainAvailable(system));
+        scn.LSForceDrainAt(system);
+        assertTrue(scn.DSCardPlayAvailable(sentry));
+        scn.DSPlayCard(sentry);
+        scn.PassAllResponses();
+        if (scn.DSAnyDecisionsAvailable() && scn.DSHasCardChoiceAvailable(tie)) {
+            scn.DSChooseCard(tie);
+        }
+        scn.PassAllResponses();
+
+        assertEquals(1, scn.GetDSForcePileCount());
+        assertFalse("Black 2 should not light up without enough Force for a required pilot",
+                scn.DSAnyDecisionsAvailable() && scn.DSHasCardChoiceAvailable(black2));
+        assertFalse("2-deploy pilot should not light up with 1 Force",
+                scn.DSAnyDecisionsAvailable() && scn.DSHasCardChoiceAvailable(ds612));
+        if (scn.DSAnyDecisionsAvailable()
+                && scn.DSGetDecision().getText().toLowerCase().contains("done")) {
+            scn.DSPass();
+            scn.PassAllResponses();
+        }
+
+        assertAtLocation(system, tie);
+        assertInZone(Zone.HAND, black2);
+        assertInZone(Zone.HAND, ds612);
+        assertInZone(Zone.LOST_PILE, sentry);
+    }
+
+    @Test
+    public void ExtraReactStillOffersOneCostTIEWhenExactlyOneForceRemains_5_158_TIESentryShips() {
+        var scn = GetScenario();
+
+        var sentry = scn.GetDSCard("sentry");
+        var tie = scn.GetDSCard("tie");
+        var tie2 = scn.GetDSCard("tie2");
+        var xwing = scn.GetLSCard("xwing");
+        var system = scn.GetLSStartingLocation();
+
+        scn.StartGame();
+
+        scn.MoveCardsToLocation(system, xwing);
+        scn.MoveCardsToDSHand(sentry, tie, tie2);
+
+        scn.SkipToLSTurn(Phase.CONTROL);
+        int currentForce = scn.GetDSForcePileCount();
+        if (currentForce > 2) {
+            scn.DSUseForceCheat(currentForce - 2);
+        } else if (currentForce < 2) {
+            scn.DSActivateForceCheat(2 - currentForce);
+        }
+
+        assertTrue(scn.LSForceDrainAvailable(system));
+        scn.LSForceDrainAt(system);
+        assertTrue(scn.DSCardPlayAvailable(sentry));
+        scn.DSPlayCard(sentry);
+        scn.PassAllResponses();
+        if (scn.DSAnyDecisionsAvailable() && scn.DSHasCardChoiceAvailable(tie)) {
+            scn.DSChooseCard(tie);
+        }
+        scn.PassAllResponses();
+
+        assertEquals(1, scn.GetDSForcePileCount());
         assertTrue(scn.DSAnyDecisionsAvailable());
         assertTrue(scn.DSGetDecision().getText().toLowerCase().contains("done"));
         assertTrue(scn.DSHasCardChoiceAvailable(tie2));

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_158_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_158_Tests.java
@@ -4,6 +4,7 @@ import com.gempukku.swccgo.common.CardSubtype;
 import com.gempukku.swccgo.common.CardType;
 import com.gempukku.swccgo.common.ExpansionSet;
 import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Keyword;
 import com.gempukku.swccgo.common.Phase;
 import com.gempukku.swccgo.common.Rarity;
 import com.gempukku.swccgo.common.Side;
@@ -17,6 +18,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 
 import static com.gempukku.swccgo.framework.Assertions.assertAtLocation;
+import static com.gempukku.swccgo.framework.Assertions.assertInHand;
 import static com.gempukku.swccgo.framework.Assertions.assertInZone;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -54,7 +56,7 @@ public class Card_5_158_Tests {
     }
 
     @Test
-    public void StatsAndKeywordsAreCorrect_5_158_TIESentryShips() {
+    public void TIESentryShipsStatsAndKeywordsAreCorrect() {
         /**
          * Title: TIE Sentry Ships
          * Uniqueness: Unique
@@ -62,7 +64,7 @@ public class Card_5_158_Tests {
          * Type: Interrupt
          * Subtype: Lost
          * Destiny: 5
-         * Icons: Cloud City
+         * Icons: Cloud City, Interrupt
          * Game Text: If opponent just initiated a Force drain at a system, cloud sector or asteroid sector,
          *      you may 'react' by deploying TIEs and pilots to that location (at normal use of the Force).
          * Lore: Several TIEs were assigned to patrol Cloud City prior to the Imperial occupation of Bespin.
@@ -88,12 +90,13 @@ public class Card_5_158_Tests {
             add(Icon.CLOUD_CITY);
             add(Icon.INTERRUPT);
         }});
+        scn.BlueprintKeywordCheck(card, new ArrayList<Keyword>());
         assertEquals(ExpansionSet.CLOUD_CITY, card.getExpansionSet());
         assertEquals(Rarity.C, card.getRarity());
     }
 
     @Test
-    public void DeploysTIEAsReactToSystemForceDrain_5_158_TIESentryShips() {
+    public void TIESentryShipsDeploysAsReactToSystemForceDrain() {
         var scn = GetScenario();
 
         var sentry = scn.GetDSCard("sentry");
@@ -124,7 +127,7 @@ public class Card_5_158_Tests {
     }
 
     @Test
-    public void AdditionalReactChoiceCanBeStoppedWithDone_5_158_TIESentryShips() {
+    public void TIESentryShipsAdditionalReactCanBeStoppedWithDone() {
         var scn = GetScenario();
 
         var sentry = scn.GetDSCard("sentry");
@@ -156,12 +159,12 @@ public class Card_5_158_Tests {
         scn.PassAllResponses();
 
         assertAtLocation(system, tie);
-        assertInZone(Zone.HAND, tie2);
+        assertInHand(tie2);
         assertInZone(Zone.LOST_PILE, sentry);
     }
 
     @Test
-    public void ExtraReactDoesNotOfferCardsThatCostMoreThanRemainingForce_5_158_TIESentryShips() {
+    public void TIESentryShipsDoesNotOfferExtraReactsThatCostMoreThanRemainingForce() {
         var scn = GetScenario();
 
         var sentry = scn.GetDSCard("sentry");
@@ -195,10 +198,8 @@ public class Card_5_158_Tests {
         scn.PassAllResponses();
 
         assertEquals(1, scn.GetDSForcePileCount());
-        assertFalse("2-deploy pilot should not light up with 1 Force",
-                scn.DSAnyDecisionsAvailable() && scn.DSHasCardChoiceAvailable(ds612));
-        assertFalse("2-deploy pilot should not light up with 1 Force",
-                scn.DSAnyDecisionsAvailable() && scn.DSHasCardChoiceAvailable(ds613));
+        assertFalse(scn.DSAnyDecisionsAvailable() && scn.DSHasCardChoiceAvailable(ds612));
+        assertFalse(scn.DSAnyDecisionsAvailable() && scn.DSHasCardChoiceAvailable(ds613));
         if (scn.DSAnyDecisionsAvailable()
                 && scn.DSGetDecision().getText().toLowerCase().contains("done")) {
             scn.DSPass();
@@ -206,13 +207,13 @@ public class Card_5_158_Tests {
         }
 
         assertAtLocation(system, tie);
-        assertInZone(Zone.HAND, ds612);
-        assertInZone(Zone.HAND, ds613);
+        assertInHand(ds612);
+        assertInHand(ds613);
         assertInZone(Zone.LOST_PILE, sentry);
     }
 
     @Test
-    public void ExtraReactDoesNotOfferBlack2WhenRemainingForceCannotPayForRequiredPilot_5_158_TIESentryShips() {
+    public void TIESentryShipsDoesNotOfferUnpilotedStarfighterWhenRemainingForceCannotPayRequiredPilot() {
         var scn = GetScenario();
 
         var sentry = scn.GetDSCard("sentry");
@@ -246,10 +247,8 @@ public class Card_5_158_Tests {
         scn.PassAllResponses();
 
         assertEquals(1, scn.GetDSForcePileCount());
-        assertFalse("Black 2 should not light up without enough Force for a required pilot",
-                scn.DSAnyDecisionsAvailable() && scn.DSHasCardChoiceAvailable(black2));
-        assertFalse("2-deploy pilot should not light up with 1 Force",
-                scn.DSAnyDecisionsAvailable() && scn.DSHasCardChoiceAvailable(ds612));
+        assertFalse(scn.DSAnyDecisionsAvailable() && scn.DSHasCardChoiceAvailable(black2));
+        assertFalse(scn.DSAnyDecisionsAvailable() && scn.DSHasCardChoiceAvailable(ds612));
         if (scn.DSAnyDecisionsAvailable()
                 && scn.DSGetDecision().getText().toLowerCase().contains("done")) {
             scn.DSPass();
@@ -257,13 +256,13 @@ public class Card_5_158_Tests {
         }
 
         assertAtLocation(system, tie);
-        assertInZone(Zone.HAND, black2);
-        assertInZone(Zone.HAND, ds612);
+        assertInHand(black2);
+        assertInHand(ds612);
         assertInZone(Zone.LOST_PILE, sentry);
     }
 
     @Test
-    public void ExtraReactStillOffersOneCostTIEWhenExactlyOneForceRemains_5_158_TIESentryShips() {
+    public void TIESentryShipsStillOffersAffordableExtraReactWhenExactlyOneForceRemains() {
         var scn = GetScenario();
 
         var sentry = scn.GetDSCard("sentry");
@@ -303,12 +302,12 @@ public class Card_5_158_Tests {
         scn.PassAllResponses();
 
         assertAtLocation(system, tie);
-        assertInZone(Zone.HAND, tie2);
+        assertInHand(tie2);
         assertInZone(Zone.LOST_PILE, sentry);
     }
 
     @Test
-    public void PlayableAsReactToCloudSectorForceDrain_5_158_TIESentryShips() {
+    public void TIESentryShipsPlayableAsReactToCloudSectorForceDrain() {
         var scn = GetScenario();
 
         var sentry = scn.GetDSCard("sentry");
@@ -340,7 +339,7 @@ public class Card_5_158_Tests {
     }
 
     @Test
-    public void PlayableAsReactToAsteroidSectorForceDrain_5_158_TIESentryShips() {
+    public void TIESentryShipsPlayableAsReactToAsteroidSectorForceDrain() {
         var scn = GetScenario();
 
         var sentry = scn.GetDSCard("sentry");
@@ -372,7 +371,7 @@ public class Card_5_158_Tests {
     }
 
     @Test
-    public void NotPlayableAsReactToBattleAtSystem_5_158_TIESentryShips() {
+    public void TIESentryShipsNotPlayableAsReactToBattleAtSystem() {
         var scn = GetScenario();
 
         var sentry = scn.GetDSCard("sentry");
@@ -391,7 +390,7 @@ public class Card_5_158_Tests {
     }
 
     @Test
-    public void NotPlayableAsReactToForceDrainAtSite_5_158_TIESentryShips() {
+    public void TIESentryShipsNotPlayableAsReactToForceDrainAtSite() {
         var scn = GetScenario();
 
         var sentry = scn.GetDSCard("sentry");


### PR DESCRIPTION
Implements the unimplemented Cloud City Dark Lost Interrupt **TIE Sentry Ships** (`5_158`).

Closes #129.

Local unit tests green at `ab8721c344f88d5af10f338ad4b54fd5d205d7b6`: **6 run / 0 fail**. Incremental Maven on `gemp-swccg-server`.

## Card text (errata)
**TIE Sentry Ships** (Unique, Dark, Interrupt - Lost, Cloud City, C)

Destiny 5.

Lore: Several TIEs were assigned to patrol Cloud City prior to the Imperial occupation of Bespin. Their instructions were to herd any vessels attempting to escape toward the Executor.

Game text: If opponent just initiated a Force drain at a system, cloud sector or asteroid sector, you may 'react' by deploying TIEs and pilots to that location (at normal use of the Force).

## Implementation notes
- New class `Card5_158` extends `AbstractLostInterrupt` (`set5/dark`). Neighbors `Card5_157` (This Is Still Wrong) / `Card5_159` (Trooper Assault). Does not implement missing 5_137 Double-Crossing No-Good Swindler.
- `Title.TIE_Sentry_Ships` and `Filters.TIE_Sentry_Ships` added. Virtual `Card201_036` now uses the Title constant.
- `CardImages.js` already maps `5_158` to `CloudCity-Dark/large/tiesentryships.gif`; not changed.
- Blueprint JSON added for `5_158` in `card_blueprint_database.json` and `_dark.json`.
- Optional after-action when opponent initiates a Force drain at a system, cloud sector, or asteroid sector. Deploys one or more TIEs and pilots from hand as a 'react' at printed Force cost (Rescue In The Clouds / CZ-3 / Comlink style chained extra deploys). Not legal as a react to battle or to a Force drain at a site.

Google Doc tab: https://docs.google.com/document/d/1OXth1UXD0dogzaYxGXAthcl24q7meZyeWfjGCjYUmFI/edit?tab=t.ep1qrp9fd1k6
Scomp: https://scomp.starwarsccg.org/?s=TIE%20Sentry%20Ships

## Tests
`src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_158_Tests.java` - names include `5_158` and TIESentryShips. Decipher-set only.

- `StatsAndKeywordsAreCorrect_5_158_TIESentryShips`
- `DeploysTIEAsReactToSystemForceDrain_5_158_TIESentryShips`
- `PlayableAsReactToCloudSectorForceDrain_5_158_TIESentryShips`
- `PlayableAsReactToAsteroidSectorForceDrain_5_158_TIESentryShips`
- `NotPlayableAsReactToBattleAtSystem_5_158_TIESentryShips`
- `NotPlayableAsReactToForceDrainAtSite_5_158_TIESentryShips`

## Test plan
- [x] `mvn -pl gemp-swccg-server -am -Dtest=Card_5_158_Tests -Dsurefire.failIfNoSpecifiedTests=false test` in Docker (**6 run, 0 fail**)
- [ ] Playtest TIE Sentry Ships on localhost:17001 (asdf/asdf). Hard-refresh if an old game is open.
