### PR TITLE
Implement Laser Gate (2_113)

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/dark/Card2_113.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/dark/Card2_113.java
@@ -21,6 +21,8 @@ import com.gempukku.swccgo.game.SwccgGame;
 import com.gempukku.swccgo.game.state.GameState;
 import com.gempukku.swccgo.logic.effects.TargetCardOnTableEffect;
 import com.gempukku.swccgo.logic.modifiers.DefinedByGameTextDefenseValueModifier;
+import com.gempukku.swccgo.logic.conditions.TrueCondition;
+import com.gempukku.swccgo.logic.modifiers.MayBeTargetedByWeaponsAsIfPresentModifier;
 import com.gempukku.swccgo.logic.modifiers.MayBeTargetedByWeaponsModifier;
 import com.gempukku.swccgo.logic.modifiers.MayNotMoveFromLocationToLocationModifier;
 import com.gempukku.swccgo.logic.modifiers.Modifier;
@@ -126,9 +128,9 @@ public class Card2_113 extends AbstractDevice {
         modifiers.add(new MayNotMoveFromLocationToLocationModifier(self, blockedFromPassing, siteA, siteB));
         modifiers.add(new MayNotMoveFromLocationToLocationModifier(self, blockedFromPassing, siteB, siteA));
         modifiers.add(new DefinedByGameTextDefenseValueModifier(self, 3));
-        // Character weapons may target this device (as if a character). Full "from either site" /
-        // during-battle non-participant targeting needs shared between-sites engine support.
+        // Character weapons may target this device (as if a character) from either bounding site.
         modifiers.add(new MayBeTargetedByWeaponsModifier(self, Filters.character_weapon));
+        modifiers.add(new MayBeTargetedByWeaponsAsIfPresentModifier(self, self, new TrueCondition()));
         return modifiers;
     }
 }

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/dark/Card2_113.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/dark/Card2_113.java
@@ -43,7 +43,7 @@ public class Card2_113 extends AbstractDevice {
         setLore("Security corridors are guarded by a grid of laser emplacements which can be activated upon demand to seal off sensitive areas from intrusion.");
         setGameText("Deploy between any two interior mobile sites. To pass, a character must have (power + ability) > 4 or use a Lift Tube (all other vehicles are blocked). Laser Gate defense value = 3; may be targeted (as if a character) by a character weapon from either site.");
         addIcons(Icon.A_NEW_HOPE);
-        addKeywords(Keyword.DEPLOYS_ON_LOCATION);
+        addKeywords(Keyword.DEPLOYS_ON_SITE);
     }
 
     @Override

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/dark/Card2_113.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/dark/Card2_113.java
@@ -1,0 +1,126 @@
+package com.gempukku.swccgo.cards.set2.dark;
+
+import com.gempukku.swccgo.cards.AbstractDevice;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Keyword;
+import com.gempukku.swccgo.common.PlayCardOptionId;
+import com.gempukku.swccgo.common.PlayCardZoneOption;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.TargetId;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.filters.Filter;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.DeployAsCaptiveOption;
+import com.gempukku.swccgo.game.DeploymentRestrictionsOption;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.PlayCardOption;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.game.state.GameState;
+import com.gempukku.swccgo.logic.effects.TargetCardOnTableEffect;
+import com.gempukku.swccgo.logic.modifiers.DefinedByGameTextDefenseValueModifier;
+import com.gempukku.swccgo.logic.modifiers.MayBeTargetedByWeaponsModifier;
+import com.gempukku.swccgo.logic.modifiers.MayNotMoveFromLocationToLocationModifier;
+import com.gempukku.swccgo.logic.modifiers.Modifier;
+import com.gempukku.swccgo.logic.modifiers.querying.ModifiersQuerying;
+import com.gempukku.swccgo.logic.timing.Action;
+import com.gempukku.swccgo.logic.timing.TargetingEffect;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Set: A New Hope
+ * Type: Device
+ * Title: Laser Gate
+ */
+public class Card2_113 extends AbstractDevice {
+    public Card2_113() {
+        super(Side.DARK, 4, PlayCardZoneOption.ATTACHED, Title.Laser_Gate, Uniqueness.RESTRICTED_2, ExpansionSet.A_NEW_HOPE, Rarity.U2);
+        setLore("Security corridors are guarded by a grid of laser emplacements which can be activated upon demand to seal off sensitive areas from intrusion.");
+        setGameText("Deploy between any two interior mobile sites. To pass, a character must have (power + ability) > 4 or use a Lift Tube (all other vehicles are blocked). Laser Gate defense value = 3; may be targeted (as if a character) by a character weapon from either site.");
+        addIcons(Icon.A_NEW_HOPE);
+        addKeywords(Keyword.DEPLOYS_ON_LOCATION);
+    }
+
+    @Override
+    protected Filter getValidDeployTargetFilterForCardType(String playerId, final SwccgGame game, final PhysicalCard self, boolean isSimDeployAttached, boolean ignorePresenceOrForceIcons, DeploymentRestrictionsOption deploymentRestrictionsOption, DeployAsCaptiveOption deployAsCaptiveOption) {
+        return Filters.location;
+    }
+
+    @Override
+    protected Filter getGameTextValidDeployTargetFilter(final SwccgGame game, final PhysicalCard self, PlayCardOptionId playCardOptionId, boolean asReact) {
+        // Attach to an interior mobile site that has an adjacent interior mobile site.
+        return Filters.and(Filters.interior_mobile_site, new Filter() {
+            @Override
+            public boolean accepts(GameState gameState, ModifiersQuerying modifiersQuerying, PhysicalCard physicalCard) {
+                return Filters.canSpot(game, self, Filters.and(Filters.adjacentSite(physicalCard), Filters.interior_mobile_site));
+            }
+        });
+    }
+
+    @Override
+    protected Filter getGameTextValidToUseDeviceFilter(final SwccgGame game, final PhysicalCard self) {
+        return Filters.interior_mobile_site;
+    }
+
+    @Override
+    protected Filter getGameTextValidTargetFilterToRemainAttachedTo(final SwccgGame game, final PhysicalCard self) {
+        return Filters.interior_mobile_site;
+    }
+
+    @Override
+    protected List<TargetingEffect> getGameTextTargetCardsWhenDeployedEffects(final Action action, String playerId, SwccgGame game, final PhysicalCard self, PhysicalCard target, PlayCardOption playCardOption) {
+        final Filter targetFilter = Filters.and(Filters.interior_mobile_site, Filters.adjacentSite(target), Filters.not(target));
+        TargetingEffect targetingEffect = new TargetCardOnTableEffect(action, playerId, "Choose adjacent interior mobile site", targetFilter) {
+            @Override
+            protected void cardTargeted(int targetGroupId, PhysicalCard chosen) {
+                action.addAnimationGroup(chosen);
+                self.setTargetedCard(TargetId.EFFECT_TARGET_1, targetGroupId, chosen, targetFilter);
+            }
+        };
+        return Collections.singletonList(targetingEffect);
+    }
+
+    /**
+     * Characters with (power + ability) > 4, Lift Tubes, and cards aboard Lift Tubes may pass.
+     */
+    private static Filter cardsThatMayPass() {
+        final Filter powerPlusAbilityGreaterThan4 = new Filter() {
+            @Override
+            public boolean accepts(GameState gameState, ModifiersQuerying modifiersQuerying, PhysicalCard physicalCard) {
+                if (!Filters.character.accepts(gameState, modifiersQuerying, physicalCard)) {
+                    return false;
+                }
+                float power = modifiersQuerying.getPower(gameState, physicalCard);
+                float ability = modifiersQuerying.getAbility(gameState, physicalCard);
+                return (power + ability) > 4;
+            }
+        };
+        return Filters.or(
+                powerPlusAbilityGreaterThan4,
+                Filters.Lift_Tube,
+                Filters.aboard(Filters.Lift_Tube)
+        );
+    }
+
+    @Override
+    protected List<Modifier> getGameTextWhileActiveInPlayModifiers(SwccgGame game, final PhysicalCard self) {
+        Filter siteA = Filters.hasAttached(self);
+        Filter siteB = Filters.targetedByCardOnTableAsTargetId(self, TargetId.EFFECT_TARGET_1);
+        Filter blockedFromPassing = Filters.not(cardsThatMayPass());
+
+        List<Modifier> modifiers = new LinkedList<Modifier>();
+        // Block movement both directions between the two bounding sites for cards that cannot pass.
+        modifiers.add(new MayNotMoveFromLocationToLocationModifier(self, blockedFromPassing, siteA, siteB));
+        modifiers.add(new MayNotMoveFromLocationToLocationModifier(self, blockedFromPassing, siteB, siteA));
+        modifiers.add(new DefinedByGameTextDefenseValueModifier(self, 3));
+        // Character weapons may target this device (as if a character). Full "from either site" /
+        // during-battle non-participant targeting needs shared between-sites engine support.
+        modifiers.add(new MayBeTargetedByWeaponsModifier(self, Filters.character_weapon));
+        return modifiers;
+    }
+}

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/dark/Card2_113.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/dark/Card2_113.java
@@ -51,30 +51,38 @@ public class Card2_113 extends AbstractDevice {
         return Filters.location;
     }
 
+    /** Interior mobile sites that are not Dagobah/Ahch-To (shared Deploy Between Sites rule). */
+    private static Filter eligibleInteriorMobileSite() {
+        return Filters.and(
+                Filters.interior_mobile_site,
+                Filters.not(Filters.or(Filters.Dagobah_location, Filters.AhchTo_location)));
+    }
+
     @Override
     protected Filter getGameTextValidDeployTargetFilter(final SwccgGame game, final PhysicalCard self, PlayCardOptionId playCardOptionId, boolean asReact) {
-        // Attach to an interior mobile site that has an adjacent interior mobile site.
-        return Filters.and(Filters.interior_mobile_site, new Filter() {
+        // Attach to an eligible interior mobile site that has an adjacent eligible interior mobile site.
+        final Filter eligible = eligibleInteriorMobileSite();
+        return Filters.and(eligible, new Filter() {
             @Override
             public boolean accepts(GameState gameState, ModifiersQuerying modifiersQuerying, PhysicalCard physicalCard) {
-                return Filters.canSpot(game, self, Filters.and(Filters.adjacentSite(physicalCard), Filters.interior_mobile_site));
+                return Filters.canSpot(game, self, Filters.and(Filters.adjacentSite(physicalCard), eligible));
             }
         });
     }
 
     @Override
     protected Filter getGameTextValidToUseDeviceFilter(final SwccgGame game, final PhysicalCard self) {
-        return Filters.interior_mobile_site;
+        return eligibleInteriorMobileSite();
     }
 
     @Override
     protected Filter getGameTextValidTargetFilterToRemainAttachedTo(final SwccgGame game, final PhysicalCard self) {
-        return Filters.interior_mobile_site;
+        return eligibleInteriorMobileSite();
     }
 
     @Override
     protected List<TargetingEffect> getGameTextTargetCardsWhenDeployedEffects(final Action action, String playerId, SwccgGame game, final PhysicalCard self, PhysicalCard target, PlayCardOption playCardOption) {
-        final Filter targetFilter = Filters.and(Filters.interior_mobile_site, Filters.adjacentSite(target), Filters.not(target));
+        final Filter targetFilter = Filters.and(eligibleInteriorMobileSite(), Filters.adjacentSite(target), Filters.not(target));
         TargetingEffect targetingEffect = new TargetCardOnTableEffect(action, playerId, "Choose adjacent interior mobile site", targetFilter) {
             @Override
             protected void cardTargeted(int targetGroupId, PhysicalCard chosen) {

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
@@ -84226,6 +84226,36 @@
     ]
   },
   {
+    "cardId": "2_113",
+    "title": "Laser Gate",
+    "slug": "laser-gate",
+    "slugWithSetName": "laser-gate-a-new-hope",
+    "side": "DARK",
+    "uniqueness": "RESTRICTED_2",
+    "expansionSet": "A_NEW_HOPE",
+    "rarity": "U2",
+    "cardCategory": "DEVICE",
+    "cardTypes": [
+      "DEVICE"
+    ],
+    "lore": "Security corridors are guarded by a grid of laser emplacements which can be activated upon demand to seal off sensitive areas from intrusion.",
+    "gameText": "Deploy between any two interior mobile sites. To pass, a character must have (power + ability) > 4 or use a Lift Tube (all other vehicles are blocked). Laser Gate defense value = 3; may be targeted (as if a character) by a character weapon from either site.",
+    "destiny": 4,
+    "icons": [
+      {
+        "icon": "A_NEW_HOPE",
+        "count": 1
+      },
+      {
+        "icon": "DEVICE",
+        "count": 1
+      }
+    ],
+    "keywords": [
+      "DEPLOYS_ON_LOCATION"
+    ]
+  },
+  {
     "cardId": "2_114",
     "title": "Magnetic Suction Tube",
     "slug": "magnetic-suction-tube",

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
@@ -84252,7 +84252,7 @@
       }
     ],
     "keywords": [
-      "DEPLOYS_ON_LOCATION"
+      "DEPLOYS_ON_SITE"
     ]
   },
   {

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_dark.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_dark.json
@@ -40671,6 +40671,36 @@
     ]
   },
   {
+    "cardId": "2_113",
+    "title": "Laser Gate",
+    "slug": "laser-gate",
+    "slugWithSetName": "laser-gate-a-new-hope",
+    "side": "DARK",
+    "uniqueness": "RESTRICTED_2",
+    "expansionSet": "A_NEW_HOPE",
+    "rarity": "U2",
+    "cardCategory": "DEVICE",
+    "cardTypes": [
+      "DEVICE"
+    ],
+    "lore": "Security corridors are guarded by a grid of laser emplacements which can be activated upon demand to seal off sensitive areas from intrusion.",
+    "gameText": "Deploy between any two interior mobile sites. To pass, a character must have (power + ability) > 4 or use a Lift Tube (all other vehicles are blocked). Laser Gate defense value = 3; may be targeted (as if a character) by a character weapon from either site.",
+    "destiny": 4,
+    "icons": [
+      {
+        "icon": "A_NEW_HOPE",
+        "count": 1
+      },
+      {
+        "icon": "DEVICE",
+        "count": 1
+      }
+    ],
+    "keywords": [
+      "DEPLOYS_ON_LOCATION"
+    ]
+  },
+  {
     "cardId": "2_114",
     "title": "Magnetic Suction Tube",
     "slug": "magnetic-suction-tube",

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_dark.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_dark.json
@@ -40697,7 +40697,7 @@
       }
     ],
     "keywords": [
-      "DEPLOYS_ON_LOCATION"
+      "DEPLOYS_ON_SITE"
     ]
   },
   {

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
@@ -12664,6 +12664,30 @@ public class Filters {
     }
 
     /**
+     * Filter that accepts cards deployed "between" two sites (attached to one site and targeting the other via
+     * TargetId.EFFECT_TARGET_1) where either bounding site is accepted by the site filter.
+     * Used so between-sites devices (e.g. Laser Gate) can be weapon-targeted from either bounding site.
+     *
+     * @param siteFilter filter for one of the bounding sites
+     * @return Filter
+     */
+    public static Filter deployedBetweenSitesIncluding(final Filterable siteFilter) {
+        final Filter filterToCheck = Filters.and(siteFilter);
+        return new Filter() {
+            @Override
+            public boolean accepts(GameState gameState, ModifiersQuerying modifiersQuerying, PhysicalCard physicalCard) {
+                PhysicalCard attachedTo = physicalCard.getAttachedTo();
+                PhysicalCard otherSite = physicalCard.getTargetedCard(gameState, TargetId.EFFECT_TARGET_1);
+                if (attachedTo == null || otherSite == null) {
+                    return false;
+                }
+                return filterToCheck.accepts(gameState, modifiersQuerying, attachedTo)
+                        || filterToCheck.accepts(gameState, modifiersQuerying, otherSite);
+            }
+        };
+    }
+
+    /**
      * Filter that accepts cards being played that are targeting the specified card.
      */
     public static Filter cardBeingPlayedTargeting(PhysicalCard source, PhysicalCard card) {

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/actions/FireWeaponActionBuilder.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/actions/FireWeaponActionBuilder.java
@@ -289,7 +289,9 @@ public class FireWeaponActionBuilder {
             Filter inAttackFilter = gameState.isDuringAttack() ? Filters.and(Filters.creature, Filters.participatingInAttack) : Filters.any;
 
             // If during battle, only cards participating in battle can be targeted
-            Filter inBattleFilter = gameState.isDuringBattle() ? Filters.participatingInBattle : Filters.any;
+            Filter inBattleFilter = gameState.isDuringBattle()
+                    ? Filters.or(Filters.participatingInBattle, Filters.canBeTargetedByWeaponAsIfPresent)
+                    : Filters.any;
 
             for (int i = 0; i < _targetFilterList.size(); ++i) {
                 boolean isValid = false;
@@ -618,6 +620,21 @@ public class FireWeaponActionBuilder {
         return this;
     }
 
+
+    /**
+     * Proximity for weapons that fire at the same site: present cards, stacked "as if present" cards,
+     * and between-sites cards (e.g. Laser Gate) that may be targeted as if present from either bounding site.
+     */
+    private Filter getSameSiteWeaponProximityFilter() {
+        Filter presentAt = Filters.presentAt(Filters.wherePresent(_weaponOrCardWithPermanentWeapon));
+        Filter betweenSitesAsIfPresent = Filters.and(
+                Filters.canBeTargetedByWeaponAsIfPresent,
+                Filters.deployedBetweenSitesIncluding(Filters.wherePresent(_weaponOrCardWithPermanentWeapon)));
+        return Filters.or(presentAt,
+                Filters.and(Filters.stackedOn(_weaponOrCardWithPermanentWeapon, presentAt), Filters.canBeTargetedByWeaponAsIfPresent),
+                betweenSitesAsIfPresent);
+    }
+
     /**
      * Sets the targeting info when the weapon does not specify a cost.
      * @param targetFilter the target filter
@@ -645,9 +662,7 @@ public class FireWeaponActionBuilder {
      * @return the builder
      */
     public FireWeaponActionBuilder targetForFree(Filter targetFilter, Set<TargetingReason> targetingReasons) {
-        Filter presentAt = Filters.presentAt(Filters.wherePresent(_weaponOrCardWithPermanentWeapon));
-        _proximityFilterList.add(Filters.or(presentAt,
-                Filters.and(Filters.stackedOn(_weaponOrCardWithPermanentWeapon, presentAt), Filters.canBeTargetedByWeaponAsIfPresent)));
+        _proximityFilterList.add(getSameSiteWeaponProximityFilter());
         _targetFilterList.add(Filters.and(Filters.or(Filters.opponents(_weaponOrCardWithPermanentWeapon), Filters.creature), targetFilter));
         _targetsForFree.add(true);
         _targetingUseForceCostMin.add(0);
@@ -689,9 +704,7 @@ public class FireWeaponActionBuilder {
      */
     public FireWeaponActionBuilder targetUsingForce(int numTargets, Filter targetFilter, int useForceCost, Set<TargetingReason> targetingReasons) {
         _numTargets = numTargets;
-        Filter presentAt = Filters.presentAt(Filters.wherePresent(_weaponOrCardWithPermanentWeapon));
-        _proximityFilterList.add(Filters.or(presentAt,
-                Filters.and(Filters.stackedOn(_weaponOrCardWithPermanentWeapon, presentAt), Filters.canBeTargetedByWeaponAsIfPresent)));
+        _proximityFilterList.add(getSameSiteWeaponProximityFilter());
         _targetFilterList.add(Filters.and(Filters.or(Filters.opponents(_weaponOrCardWithPermanentWeapon), Filters.creature), targetFilter));
         _targetsForFree.add(false);
         _targetingUseForceCostMin.add(useForceCost);
@@ -709,9 +722,7 @@ public class FireWeaponActionBuilder {
      * @return the builder
      */
     public FireWeaponActionBuilder targetUsingForceRange(Filter targetFilter, int useForceCostMin, int useForceCostMax, TargetingReason targetingReason) {
-        Filter presentAt = Filters.presentAt(Filters.wherePresent(_weaponOrCardWithPermanentWeapon));
-        _proximityFilterList.add(Filters.or(presentAt,
-                Filters.and(Filters.stackedOn(_weaponOrCardWithPermanentWeapon, presentAt), Filters.canBeTargetedByWeaponAsIfPresent)));
+        _proximityFilterList.add(getSameSiteWeaponProximityFilter());
         _targetFilterList.add(Filters.and(Filters.or(Filters.opponents(_weaponOrCardWithPermanentWeapon), Filters.creature), targetFilter));
         _targetsForFree.add(false);
         _targetingUseForceCostMin.add(useForceCostMin);

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/dark/Card_2_113_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/dark/Card_2_113_Tests.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests for Laser Gate (2_113).
  * Doc checklist: deploy between interior mobile sites; movement pass rules;
- * defense value 3; character-weapon targeting wiring.
+ * defense value 3; either-site character-weapon targeting; Lift Tube pass.
  */
 public class Card_2_113_Tests {
 
@@ -194,6 +194,33 @@ public class Card_2_113_Tests {
     }
 
     @Test
+    public void LaserGate_2_113_LiftTubeMayPassToFarSite() {
+        var scn = GetScenario();
+        var gate = scn.GetDSCard("laserGate");
+        var corridor = scn.GetDSCard("corridor");
+        var warRoom = scn.GetDSCard("warRoom");
+        var dsLift = scn.GetDSCard("dsLift");
+        var stormie = scn.GetDSCard("stormie");
+
+        scn.StartGame();
+        putLocation(scn, corridor);
+        putLocation(scn, warRoom);
+        deployGateBetween(scn, gate, corridor, warRoom);
+        // Weak Stormtrooper alone is blocked; aboard Lift Tube may pass.
+        scn.MoveCardsToLocation(corridor, dsLift, stormie);
+        scn.BoardAsPassenger(dsLift, stormie);
+
+        scn.SkipToPhase(Phase.MOVE);
+
+        assertTrue("Lift Tube (with passenger) may move past Laser Gate", scn.DSMoveAvailable(dsLift));
+        scn.DSMoveCard(dsLift, warRoom);
+        scn.PassAllResponses();
+        assertTrue("Lift Tube must arrive at far bounding site", scn.CardsAtLocation(warRoom, dsLift));
+        assertTrue("Passenger remains aboard Lift Tube at far site",
+                scn.IsAboardAsPassenger(dsLift, stormie));
+    }
+
+    @Test
     public void LaserGate_2_113_DefenseValueIs3() {
         var scn = GetScenario();
         var gate = scn.GetDSCard("laserGate");
@@ -209,27 +236,84 @@ public class Card_2_113_Tests {
     }
 
     @Test
-    public void LaserGate_2_113_WeaponTargetingModifiersWired() {
+    public void LaserGate_2_113_CharacterWeaponMayTargetFromAttachedBoundingSite() {
         var scn = GetScenario();
         var gate = scn.GetDSCard("laserGate");
-        var corridor = scn.GetDSCard("corridor");
-        var warRoom = scn.GetDSCard("warRoom");
-        var dsBlaster = scn.GetDSCard("dsBlaster");
+        var corridor = scn.GetDSCard("corridor"); // site A
+        var warRoom = scn.GetDSCard("warRoom");   // site B
+        var luke = scn.GetLSCard("luke");
+        var blaster = scn.GetLSCard("blaster");
         var vader = scn.GetDSCard("vader");
 
         scn.StartGame();
         putLocation(scn, corridor);
         putLocation(scn, warRoom);
         deployGateBetween(scn, gate, corridor, warRoom);
-        scn.MoveCardsToLocation(corridor, vader);
-        scn.AttachCardsTo(vader, dsBlaster);
 
-        assertEquals(3, scn.GetDefense(gate));
-        assertTrue("Character weapon should be granted to target Laser Gate",
-                scn.game().getModifiersQuerying().grantedMayBeTargetedBy(scn.gameState(), gate, dsBlaster));
+        scn.MoveCardsToLocation(corridor, luke, vader);
+        scn.AttachCardsTo(luke, blaster);
+        scn.SkipToLSTurn(Phase.BATTLE);
+        assertTrue(scn.LSCanInitiateBattle(corridor));
+        scn.LSInitiateBattle(corridor);
+        scn.PassBattleStartResponses();
+        assertTrue(scn.AwaitingLSWeaponsSegmentActions());
+
+        assertTrue("Character weapon grant for Laser Gate",
+                scn.game().getModifiersQuerying().grantedMayBeTargetedBy(scn.gameState(), gate, blaster));
+        assertTrue("As-if-present grant for either-site targeting",
+                scn.game().getModifiersQuerying().canBeTargetedByWeaponsAsIfPresent(scn.gameState(), gate));
+
+        scn.LSUseCardAction(blaster);
+        assertTrue("Battle at attached site A: Laser Gate must be a legal weapon target",
+                scn.LSHasCardChoiceAvailable(gate));
+        scn.LSChooseCard(gate);
+        scn.PassWeaponFireWithDestinyDraw();
+        scn.PassAllResponses();
+    }
+
+    @Test
+    public void LaserGate_2_113_CharacterWeaponMayTargetFromFarBoundingSite() {
+        var scn = GetScenario();
+        var gate = scn.GetDSCard("laserGate");
+        var corridor = scn.GetDSCard("corridor"); // site A (attach)
+        var warRoom = scn.GetDSCard("warRoom");   // site B (EFFECT_TARGET_1)
+        var conference = scn.GetDSCard("conference"); // site C
+        var luke = scn.GetLSCard("luke");
+        var blaster = scn.GetLSCard("blaster");
+        var stormie = scn.GetDSCard("stormie");
+
+        scn.StartGame();
+        putLocation(scn, corridor);
+        putLocation(scn, warRoom);
+        putLocation(scn, conference);
+        deployGateBetween(scn, gate, corridor, warRoom);
+
+        // Battle at far bounding site B — gate is attached to A, not present at B
+        scn.MoveCardsToLocation(warRoom, luke, stormie);
+        scn.AttachCardsTo(luke, blaster);
+        scn.SkipToLSTurn(Phase.BATTLE);
+        assertTrue(scn.LSCanInitiateBattle(warRoom));
+        scn.LSInitiateBattle(warRoom);
+        scn.PassBattleStartResponses();
+        assertTrue(scn.AwaitingLSWeaponsSegmentActions());
+
+        assertTrue("Character weapon grant for Laser Gate",
+                scn.game().getModifiersQuerying().grantedMayBeTargetedBy(scn.gameState(), gate, blaster));
+        assertTrue("As-if-present grant for either-site targeting",
+                scn.game().getModifiersQuerying().canBeTargetedByWeaponsAsIfPresent(scn.gameState(), gate));
+        assertTrue("Between-sites filter includes far bounding site",
+                Filters.deployedBetweenSitesIncluding(Filters.sameCardId(warRoom)).accepts(scn.game(), gate));
+
+        scn.LSUseCardAction(blaster);
+        assertTrue("Battle at far site B: Laser Gate must be a legal weapon target",
+                scn.LSHasCardChoiceAvailable(gate));
+        scn.LSChooseCard(gate);
+        scn.PassWeaponFireWithDestinyDraw();
+        scn.PassAllResponses();
+
+        assertNotNull(conference);
         assertEquals(corridor, gate.getAttachedTo());
         assertEquals(warRoom, gate.getTargetedCard(scn.gameState(), TargetId.EFFECT_TARGET_1));
-        assertNotNull(dsBlaster);
     }
 
     @Test

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/dark/Card_2_113_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/dark/Card_2_113_Tests.java
@@ -202,10 +202,9 @@ public class Card_2_113_Tests {
         scn.PassAllResponses();
         assertTrue(scn.CardsAtLocation(warRoom, vader));
 
-        // Verify Laser Gate does not prohibit Lift Tube via landspeed movement query.
-        boolean liftBlocked = scn.game().getModifiersQuerying()
-                .mayNotMoveFromLocationToLocationUsingLandspeed(scn.gameState(), dsLift, corridor, warRoom, false);
-        assertFalse("Lift Tube must not be blocked by Laser Gate", liftBlocked);
+        // Lift Tube is exempt from the gate; assert move remains available.
+        // Full destination commit can NPE in VTS vehicle move decisions — known gap.
+        assertTrue("Lift Tube may move past Laser Gate", scn.DSMoveAvailable(dsLift));
     }
 
     @Test

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/dark/Card_2_113_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/dark/Card_2_113_Tests.java
@@ -1,0 +1,250 @@
+package com.gempukku.swccgo.cards.set2.dark;
+
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.TargetId;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.game.PhysicalCardImpl;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for Laser Gate (2_113).
+ * Doc checklist: deploy between interior mobile sites; movement pass rules;
+ * defense value 3; character-weapon targeting wiring.
+ */
+public class Card_2_113_Tests {
+
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("luke", "1_19"); // Luke Skywalker power 3 ability 4 -> 7 > 4
+                    put("trooper", "1_28"); // Rebel Trooper power 1 ability 1 -> 2
+                    put("blaster", "1_152"); // LS Blaster (character weapon)
+                    put("lift", "1_148"); // Lift Tube (Light)
+                }},
+                new HashMap<>() {{
+                    put("laserGate", "2_113");
+                    put("corridor", "1_284"); // Death Star: Detention Block Corridor
+                    put("warRoom", "1_287"); // Death Star: War Room
+                    put("conference", "2_144"); // Death Star: Conference Room
+                    put("vader", "1_168"); // power 6 ability 6
+                    put("stormie", "1_194"); // Stormtrooper power 1 ability 1
+                    put("dsLift", "1_308"); // Lift Tube (Dark)
+                    put("speeder", "8_169"); // Speeder Bike (non-Lift Tube vehicle)
+                    put("dsBlaster", "1_317"); // Imperial Blaster (character weapon)
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    private void putLocation(VirtualTableScenario scn, PhysicalCardImpl location) {
+        scn.MoveLocationToTable(location);
+    }
+
+    private void placeBetweenSites(PhysicalCardImpl gate, PhysicalCardImpl otherSite) {
+        gate.setTargetedCard(TargetId.EFFECT_TARGET_1, null, otherSite, Filters.sameCardId(otherSite));
+    }
+
+    private void deployGateBetween(VirtualTableScenario scn, PhysicalCardImpl gate,
+                                   PhysicalCardImpl siteA, PhysicalCardImpl siteB) {
+        scn.AttachCardsTo(siteA, gate);
+        placeBetweenSites(gate, siteB);
+    }
+
+    @Test
+    public void LaserGate_2_113_StatsAndKeywordsAreCorrect() {
+        /**
+         * Title: Laser Gate
+         * Uniqueness: Restricted (••)
+         * Side: Dark
+         * Type: Device
+         * Destiny: 4
+         * Icons: A New Hope, Device
+         * Set: A New Hope
+         * Rarity: U2
+         */
+        var scn = GetScenario();
+        var card = scn.GetDSCard("laserGate").getBlueprint();
+
+        assertEquals(Title.Laser_Gate, card.getTitle());
+        assertFalse(card.hasVirtualSuffix());
+        assertEquals(Uniqueness.RESTRICTED_2, card.getUniqueness());
+        assertEquals(Side.DARK, card.getSide());
+        assertEquals(4, card.getDestiny(), scn.epsilon);
+        scn.BlueprintCardTypeCheck(card, new ArrayList<>() {{
+            add(CardType.DEVICE);
+        }});
+        assertEquals(ExpansionSet.A_NEW_HOPE, card.getExpansionSet());
+        assertEquals(Rarity.U2, card.getRarity());
+        assertTrue(card.hasIcon(Icon.A_NEW_HOPE));
+        assertTrue(card.hasIcon(Icon.DEVICE));
+        assertTrue(card.getGameText().contains("interior mobile sites"));
+        assertTrue(card.getGameText().contains("defense value = 3"));
+    }
+
+    @Test
+    public void LaserGate_2_113_DeploysBetweenTwoInteriorMobileSites() {
+        var scn = GetScenario();
+        var gate = scn.GetDSCard("laserGate");
+        var corridor = scn.GetDSCard("corridor");
+        var warRoom = scn.GetDSCard("warRoom");
+
+        scn.StartGame();
+        putLocation(scn, corridor);
+        putLocation(scn, warRoom);
+
+        scn.MoveCardsToHand(gate);
+        scn.SkipToPhase(Phase.DEPLOY);
+
+        assertTrue(scn.DSCardPlayAvailable(gate));
+        scn.DSPlayCard(gate);
+        scn.DSChooseCard(corridor);
+        scn.DSChooseCard(warRoom);
+        scn.PassAllResponses();
+
+        assertEquals(corridor, gate.getAttachedTo());
+        assertEquals(warRoom, gate.getTargetedCard(scn.gameState(), TargetId.EFFECT_TARGET_1));
+    }
+
+    @Test
+    public void LaserGate_2_113_CannotDeployWithoutAdjacentInteriorMobilePair() {
+        var scn = GetScenario();
+        var gate = scn.GetDSCard("laserGate");
+        var corridor = scn.GetDSCard("corridor");
+
+        scn.StartGame();
+        putLocation(scn, corridor);
+
+        scn.MoveCardsToHand(gate);
+        scn.SkipToPhase(Phase.DEPLOY);
+
+        assertFalse("Laser Gate should not be playable with a single interior mobile site",
+                scn.DSCardPlayAvailable(gate));
+    }
+
+    @Test
+    public void LaserGate_2_113_BlocksWeakCharactersAndNonLiftTubeVehicles() {
+        var scn = GetScenario();
+        var gate = scn.GetDSCard("laserGate");
+        var corridor = scn.GetDSCard("corridor");
+        var warRoom = scn.GetDSCard("warRoom");
+        var stormie = scn.GetDSCard("stormie");
+        var speeder = scn.GetDSCard("speeder");
+
+        scn.StartGame();
+        putLocation(scn, corridor);
+        putLocation(scn, warRoom);
+        deployGateBetween(scn, gate, corridor, warRoom);
+        scn.MoveCardsToLocation(corridor, stormie, speeder);
+
+        scn.SkipToPhase(Phase.MOVE);
+
+        assertFalse("Weak character (power+ability <= 4) blocked by Laser Gate",
+                scn.DSMoveAvailable(stormie));
+        assertTrue(scn.CardsAtLocation(corridor, stormie));
+
+        if (scn.DSMoveAvailable(speeder)) {
+            try {
+                scn.DSMoveCard(speeder, warRoom);
+                scn.PassAllResponses();
+                assertFalse("Non-Lift-Tube vehicle should not end at far side of Laser Gate",
+                        scn.CardsAtLocation(warRoom, speeder));
+            } catch (RuntimeException expected) {
+                // Destination through gate not offered — acceptable.
+            }
+        }
+        assertTrue(scn.CardsAtLocation(corridor, speeder) || !scn.CardsAtLocation(warRoom, speeder));
+    }
+
+    @Test
+    public void LaserGate_2_113_AllowsStrongCharactersAndLiftTube() {
+        var scn = GetScenario();
+        var gate = scn.GetDSCard("laserGate");
+        var corridor = scn.GetDSCard("corridor");
+        var warRoom = scn.GetDSCard("warRoom");
+        var vader = scn.GetDSCard("vader");
+        var dsLift = scn.GetDSCard("dsLift");
+
+        scn.StartGame();
+        putLocation(scn, corridor);
+        putLocation(scn, warRoom);
+        deployGateBetween(scn, gate, corridor, warRoom);
+        scn.MoveCardsToLocation(corridor, vader, dsLift);
+
+        scn.SkipToPhase(Phase.MOVE);
+
+        assertTrue("Vader (power+ability > 4) may move past Laser Gate", scn.DSMoveAvailable(vader));
+        scn.DSMoveCard(vader, warRoom);
+        scn.PassAllResponses();
+        assertTrue(scn.CardsAtLocation(warRoom, vader));
+
+        assertTrue("Lift Tube may move past Laser Gate", scn.DSMoveAvailable(dsLift));
+        scn.DSMoveCard(dsLift, warRoom);
+        scn.PassAllResponses();
+        assertTrue(scn.CardsAtLocation(warRoom, dsLift));
+    }
+
+    @Test
+    public void LaserGate_2_113_DefenseValueIs3() {
+        var scn = GetScenario();
+        var gate = scn.GetDSCard("laserGate");
+        var corridor = scn.GetDSCard("corridor");
+        var warRoom = scn.GetDSCard("warRoom");
+
+        scn.StartGame();
+        putLocation(scn, corridor);
+        putLocation(scn, warRoom);
+        deployGateBetween(scn, gate, corridor, warRoom);
+
+        assertEquals(3, scn.GetDefense(gate));
+    }
+
+    @Test
+    public void LaserGate_2_113_WeaponTargetingModifiersWired() {
+        var scn = GetScenario();
+        var gate = scn.GetDSCard("laserGate");
+        var corridor = scn.GetDSCard("corridor");
+        var warRoom = scn.GetDSCard("warRoom");
+        var dsBlaster = scn.GetDSCard("dsBlaster");
+        var vader = scn.GetDSCard("vader");
+
+        scn.StartGame();
+        putLocation(scn, corridor);
+        putLocation(scn, warRoom);
+        deployGateBetween(scn, gate, corridor, warRoom);
+        scn.MoveCardsToLocation(corridor, vader);
+        scn.AttachCardsTo(vader, dsBlaster);
+
+        assertEquals(3, scn.GetDefense(gate));
+        assertTrue("Character weapon should be granted to target Laser Gate",
+                scn.game().getModifiersQuerying().grantedMayBeTargetedBy(scn.gameState(), gate, dsBlaster));
+        assertEquals(corridor, gate.getAttachedTo());
+        assertEquals(warRoom, gate.getTargetedCard(scn.gameState(), TargetId.EFFECT_TARGET_1));
+        // Gap: full fire-from-either-site during battle (non-participant) needs shared between-sites engine work.
+        assertNotNull(dsBlaster);
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/dark/Card_2_113_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/dark/Card_2_113_Tests.java
@@ -202,10 +202,10 @@ public class Card_2_113_Tests {
         scn.PassAllResponses();
         assertTrue(scn.CardsAtLocation(warRoom, vader));
 
-        assertTrue("Lift Tube may move past Laser Gate", scn.DSMoveAvailable(dsLift));
-        scn.DSMoveCard(dsLift, warRoom);
-        scn.PassAllResponses();
-        assertTrue(scn.CardsAtLocation(warRoom, dsLift));
+        // Verify Laser Gate does not prohibit Lift Tube via landspeed movement query.
+        boolean liftBlocked = scn.game().getModifiersQuerying()
+                .mayNotMoveFromLocationToLocationUsingLandspeed(scn.gameState(), dsLift, corridor, warRoom, false);
+        assertFalse("Lift Tube must not be blocked by Laser Gate", liftBlocked);
     }
 
     @Test

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/dark/Card_2_113_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/dark/Card_2_113_Tests.java
@@ -33,21 +33,22 @@ public class Card_2_113_Tests {
     protected VirtualTableScenario GetScenario() {
         return new VirtualTableScenario(
                 new HashMap<>() {{
-                    put("luke", "1_19"); // Luke Skywalker power 3 ability 4 -> 7 > 4
-                    put("trooper", "1_28"); // Rebel Trooper power 1 ability 1 -> 2
-                    put("blaster", "1_152"); // LS Blaster (character weapon)
-                    put("lift", "1_148"); // Lift Tube (Light)
+                    put("luke", "1_19");
+                    put("trooper", "1_28");
+                    put("blaster", "1_152");
+                    put("lift", "1_148");
                 }},
                 new HashMap<>() {{
                     put("laserGate", "2_113");
-                    put("corridor", "1_284"); // Death Star: Detention Block Corridor
-                    put("warRoom", "1_287"); // Death Star: War Room
-                    put("conference", "2_144"); // Death Star: Conference Room
-                    put("vader", "1_168"); // power 6 ability 6
-                    put("stormie", "1_194"); // Stormtrooper power 1 ability 1
-                    put("dsLift", "1_308"); // Lift Tube (Dark)
-                    put("speeder", "8_169"); // Speeder Bike (non-Lift Tube vehicle)
-                    put("dsBlaster", "1_317"); // Imperial Blaster (character weapon)
+                    put("corridor", "1_284");
+                    put("warRoom", "1_287");
+                    put("conference", "2_144");
+                    put("vader", "1_168");
+                    put("stormie", "1_194");
+                    put("dsLift", "1_308");
+                    put("speeder", "8_169");
+                    put("dsBlaster", "1_317");
+                    put("bewil", "5_092");
                 }},
                 10,
                 10,
@@ -77,16 +78,6 @@ public class Card_2_113_Tests {
 
     @Test
     public void LaserGate_2_113_StatsAndKeywordsAreCorrect() {
-        /**
-         * Title: Laser Gate
-         * Uniqueness: Restricted (••)
-         * Side: Dark
-         * Type: Device
-         * Destiny: 4
-         * Icons: A New Hope, Device
-         * Set: A New Hope
-         * Rarity: U2
-         */
         var scn = GetScenario();
         var card = scn.GetDSCard("laserGate").getBlueprint();
 
@@ -181,19 +172,18 @@ public class Card_2_113_Tests {
     }
 
     @Test
-    public void LaserGate_2_113_AllowsStrongCharactersAndLiftTube() {
+    public void LaserGate_2_113_AllowsStrongCharacters() {
         var scn = GetScenario();
         var gate = scn.GetDSCard("laserGate");
         var corridor = scn.GetDSCard("corridor");
         var warRoom = scn.GetDSCard("warRoom");
         var vader = scn.GetDSCard("vader");
-        var dsLift = scn.GetDSCard("dsLift");
 
         scn.StartGame();
         putLocation(scn, corridor);
         putLocation(scn, warRoom);
         deployGateBetween(scn, gate, corridor, warRoom);
-        scn.MoveCardsToLocation(corridor, vader, dsLift);
+        scn.MoveCardsToLocation(corridor, vader);
 
         scn.SkipToPhase(Phase.MOVE);
 
@@ -201,10 +191,6 @@ public class Card_2_113_Tests {
         scn.DSMoveCard(vader, warRoom);
         scn.PassAllResponses();
         assertTrue(scn.CardsAtLocation(warRoom, vader));
-
-        // Lift Tube is exempt from the gate; assert move remains available.
-        // Full destination commit can NPE in VTS vehicle move decisions — known gap.
-        assertTrue("Lift Tube may move past Laser Gate", scn.DSMoveAvailable(dsLift));
     }
 
     @Test
@@ -243,7 +229,14 @@ public class Card_2_113_Tests {
                 scn.game().getModifiersQuerying().grantedMayBeTargetedBy(scn.gameState(), gate, dsBlaster));
         assertEquals(corridor, gate.getAttachedTo());
         assertEquals(warRoom, gate.getTargetedCard(scn.gameState(), TargetId.EFFECT_TARGET_1));
-        // Gap: full fire-from-either-site during battle (non-participant) needs shared between-sites engine work.
         assertNotNull(dsBlaster);
+    }
+
+    @Test
+    public void LaserGate_2_113_CaptainBewilFilterIncludesLaserGate() {
+        var scn = GetScenario();
+        var gate = scn.GetDSCard("laserGate");
+        assertTrue(Filters.Laser_Gate.accepts(scn.game(), gate));
+        assertTrue(Filters.or(Filters.Laser_Gate, Filters.Heart_Of_The_Chasm, Filters.Rite_Of_Passage).accepts(scn.game(), gate));
     }
 }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/dark/Card_2_113_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/dark/Card_2_113_Tests.java
@@ -3,6 +3,7 @@ package com.gempukku.swccgo.cards.set2.dark;
 import com.gempukku.swccgo.common.CardType;
 import com.gempukku.swccgo.common.ExpansionSet;
 import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Keyword;
 import com.gempukku.swccgo.common.Phase;
 import com.gempukku.swccgo.common.Rarity;
 import com.gempukku.swccgo.common.Side;
@@ -91,8 +92,13 @@ public class Card_2_113_Tests {
         }});
         assertEquals(ExpansionSet.A_NEW_HOPE, card.getExpansionSet());
         assertEquals(Rarity.U2, card.getRarity());
-        assertTrue(card.hasIcon(Icon.A_NEW_HOPE));
-        assertTrue(card.hasIcon(Icon.DEVICE));
+        scn.BlueprintIconCheck(card, new ArrayList<>() {{
+            add(Icon.A_NEW_HOPE);
+            add(Icon.DEVICE);
+        }});
+        scn.BlueprintKeywordCheck(card, new ArrayList<>() {{
+            add(Keyword.DEPLOYS_ON_SITE);
+        }});
         assertTrue(card.getGameText().contains("interior mobile sites"));
         assertTrue(card.getGameText().contains("defense value = 3"));
     }
@@ -158,17 +164,10 @@ public class Card_2_113_Tests {
                 scn.DSMoveAvailable(stormie));
         assertTrue(scn.CardsAtLocation(corridor, stormie));
 
-        if (scn.DSMoveAvailable(speeder)) {
-            try {
-                scn.DSMoveCard(speeder, warRoom);
-                scn.PassAllResponses();
-                assertFalse("Non-Lift-Tube vehicle should not end at far side of Laser Gate",
-                        scn.CardsAtLocation(warRoom, speeder));
-            } catch (RuntimeException expected) {
-                // Destination through gate not offered — acceptable.
-            }
-        }
-        assertTrue(scn.CardsAtLocation(corridor, speeder) || !scn.CardsAtLocation(warRoom, speeder));
+        assertFalse("Non-Lift-Tube vehicle cannot move past Laser Gate",
+                scn.DSMoveAvailable(speeder));
+        assertTrue(scn.CardsAtLocation(corridor, speeder));
+        assertFalse(scn.CardsAtLocation(warRoom, speeder));
     }
 
     @Test
@@ -317,7 +316,7 @@ public class Card_2_113_Tests {
     }
 
     @Test
-    public void LaserGate_2_113_CaptainBewilFilterIncludesLaserGate() {
+    public void LaserGate_2_113_MatchesLaserGateFilter() {
         var scn = GetScenario();
         var gate = scn.GetDSCard("laserGate");
         assertTrue(Filters.Laser_Gate.accepts(scn.game(), gate));


### PR DESCRIPTION
## Summary
Implements **Laser Gate** (A New Hope Dark Device, GEMP id 2_113).

Closes #84.

## Card
- **Id:** 2_113
- **Title:** Laser Gate
- **Type:** Dark Device - Destiny 4 - Uniqueness Restricted (2) - A New Hope U2
- **Game text:** Deploy between any two interior mobile sites. To pass, a character must have (power + ability) > 4 or use a Lift Tube (all other vehicles are blocked). Laser Gate defense value = 3; may be targeted (as if a character) by a character weapon from either site.

## Design choices
- Extends AbstractDevice with DEPLOYS_ON_SITE; deploy attach filter = interior mobile site (not Dagobah/Ahch-To) with an adjacent eligible interior mobile site.
- Secondary deploy target via getGameTextTargetCardsWhenDeployedEffects + TargetId.EFFECT_TARGET_1.
- Movement: bidirectional MayNotMoveFromLocationToLocationModifier between attached site and EFFECT_TARGET_1, excluding (power+ability)>4, Lift Tubes, and cards aboard Lift Tubes.
- Defense: DefinedByGameTextDefenseValueModifier(self, 3).
- Weapon targeting:
  - MayBeTargetedByWeaponsModifier(self, Filters.character_weapon)
  - MayBeTargetedByWeaponsAsIfPresentModifier so the gate can be fired at during battle without being a participant
  - Filters.deployedBetweenSitesIncluding(...) + FireWeaponActionBuilder same-site proximity so weapons at either bounding site can legally target it
- Access Denied is not encoded.

## Tests
Card_2_113_Tests:
- stats / keywords (BlueprintIconCheck / BlueprintKeywordCheck)
- deploy between interior mobile pair
- cannot deploy without adjacent pair
- blocks weak characters / non-Lift-Tube vehicles
- allows (power+ability)>4 characters past the gate
- Lift Tube (with passenger) may pass to the far bounding site
- defense value 3
- character weapon may Fire-target Laser Gate during battle at the attached bounding site
- character weapon may Fire-target Laser Gate during battle at the far bounding site
- Laser Gate filter match