### PR TITLE
Encode Restricted Access (5_122)

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set4/light/Card4_052.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set4/light/Card4_052.java
@@ -12,6 +12,7 @@ import com.gempukku.swccgo.filters.Filter;
 import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.game.state.GameState;
 import com.gempukku.swccgo.logic.GameUtils;
 import com.gempukku.swccgo.logic.TriggerConditions;
 import com.gempukku.swccgo.logic.actions.PlayInterruptAction;
@@ -170,7 +171,13 @@ public class Card4_052 extends AbstractLostInterrupt {
                 actions.add(action);
             }
 
-            Filter effectFilter = Filters.and(Filters.Effect, Filters.except(Filters.immune_to_Alter), Filters.attachedTo(Filters.location),
+            Filter effectFilter = Filters.and(Filters.Effect, Filters.except(Filters.immune_to_Alter), Filters.attachedTo(Filters.location), Filters.not(new Filter() {
+                    @Override
+                    public boolean accepts(GameState gameState, com.gempukku.swccgo.logic.modifiers.querying.ModifiersQuerying modifiersQuerying, PhysicalCard physicalCard) {
+                        return physicalCard.getAttachedTo() != null
+                                && physicalCard.getTargetedCard(gameState, TargetId.EFFECT_TARGET_1) != null;
+                    }
+                }),
                     Filters.effectCanBeRelocatedTo(playerId, Filters.and(Filters.location, Filters.canBeTargetedBy(self))));
 
             if (GameConditions.canTarget(game, self, effectFilter)) {
@@ -190,7 +197,13 @@ public class Card4_052 extends AbstractLostInterrupt {
                                             protected void cardTargeted(final int targetGroupId2, PhysicalCard targetedLocation) {
                                                 action.addAnimationGroup(targetedLocation);
                                                 // Set target filters for re-targeting
-                                                action.updatePrimaryTargetFilter(targetGroupId1, Filters.and(Filters.Effect, Filters.except(Filters.immune_to_Alter), Filters.attachedTo(Filters.location),
+                                                action.updatePrimaryTargetFilter(targetGroupId1, Filters.and(Filters.Effect, Filters.except(Filters.immune_to_Alter), Filters.attachedTo(Filters.location), Filters.not(new Filter() {
+                    @Override
+                    public boolean accepts(GameState gameState, com.gempukku.swccgo.logic.modifiers.querying.ModifiersQuerying modifiersQuerying, PhysicalCard physicalCard) {
+                        return physicalCard.getAttachedTo() != null
+                                && physicalCard.getTargetedCard(gameState, TargetId.EFFECT_TARGET_1) != null;
+                    }
+                }),
                                                         Filters.effectCanBeRelocatedTo(playerId, Filters.and(Filters.inActionTargetGroup(action, targetGroupId2), Filters.canBeTargetedBy(self)))));
                                                 action.updatePrimaryTargetFilter(targetGroupId2, Filters.and(Filters.location, Filters.canRelocateEffectTo(playerId, Filters.inActionTargetGroup(action, targetGroupId1))));
                                                 // Pay cost(s)

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/dark/Card5_122.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/dark/Card5_122.java
@@ -1,0 +1,169 @@
+package com.gempukku.swccgo.cards.set5.dark;
+
+import com.gempukku.swccgo.cards.AbstractNormalEffect;
+import com.gempukku.swccgo.cards.conditions.PlayCardOptionIdCondition;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Keyword;
+import com.gempukku.swccgo.common.PlayCardOptionId;
+import com.gempukku.swccgo.common.PlayCardZoneOption;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.TargetId;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.filters.Filter;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.DeployAsCaptiveOption;
+import com.gempukku.swccgo.game.DeploymentRestrictionsOption;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.PlayCardOption;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.game.state.GameState;
+import com.gempukku.swccgo.logic.actions.RequiredGameTextTriggerAction;
+import com.gempukku.swccgo.logic.conditions.Condition;
+import com.gempukku.swccgo.logic.effects.LoseInsertCardEffect;
+import com.gempukku.swccgo.logic.effects.ShuffleReserveDeckEffect;
+import com.gempukku.swccgo.logic.effects.TargetCardOnTableEffect;
+import com.gempukku.swccgo.logic.modifiers.ImmuneToTitleModifier;
+import com.gempukku.swccgo.logic.modifiers.Modifier;
+import com.gempukku.swccgo.logic.modifiers.MoveCostFromLocationToLocationModifier;
+import com.gempukku.swccgo.logic.modifiers.querying.ModifiersQuerying;
+import com.gempukku.swccgo.logic.timing.Action;
+import com.gempukku.swccgo.logic.timing.PassthruEffect;
+import com.gempukku.swccgo.logic.timing.TargetingEffect;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Set: Cloud City
+ * Type: Effect
+ * Title: Restricted Access
+ */
+public class Card5_122 extends AbstractNormalEffect {
+    public Card5_122() {
+        super(Side.DARK, 4, PlayCardZoneOption.ATTACHED, Title.Restricted_Access, Uniqueness.UNRESTRICTED, ExpansionSet.CLOUD_CITY, Rarity.C);
+        setLore("Cloud City's computer-controlled security system is designed to keep unauthorized personnel from entering restricted areas.");
+        setGameText("Insert face up in your Reserve Deck. When Effect reaches top it is lost, along with all opponent's 'insert' cards there. Reshuffle. (Immune to Alter.) OR Deploy between two mobile sites. Opponent's characters may pass only if aboard a Lift Tube or opponent uses +1 Force each.");
+        addIcons(Icon.CLOUD_CITY);
+        addKeywords(Keyword.DEPLOYS_ON_SITE);
+        // Bill ruling: insert mode Immune to Alter; between-sites Effect NOT Immune (see AlwaysOn).
+    }
+
+    @Override
+    protected List<PlayCardOption> getGameTextPlayCardOptions() {
+        List<PlayCardOption> playCardOptions = new ArrayList<PlayCardOption>();
+        playCardOptions.add(new PlayCardOption(PlayCardOptionId.PLAY_AS_INSERT_CARD, PlayCardZoneOption.YOUR_RESERVE_DECK, "Insert face up in your Reserve Deck"));
+        playCardOptions.add(new PlayCardOption(PlayCardOptionId.PLAY_CARD_OPTION_1, PlayCardZoneOption.ATTACHED, "Deploy between two mobile sites"));
+        return playCardOptions;
+    }
+
+    /** Mobile sites that are not Dagobah/Ahch-To (shared Deploy Between Sites rule). */
+    private static Filter eligibleMobileSite() {
+        return Filters.and(
+                Filters.mobile_site,
+                Filters.not(Filters.or(Filters.Dagobah_location, Filters.AhchTo_location)));
+    }
+
+    @Override
+    protected Filter getValidDeployTargetFilterForCardType(String playerId, final SwccgGame game, final PhysicalCard self, boolean isSimDeployAttached, boolean ignorePresenceOrForceIcons, DeploymentRestrictionsOption deploymentRestrictionsOption, DeployAsCaptiveOption deployAsCaptiveOption) {
+        return Filters.location;
+    }
+
+    @Override
+    protected Filter getGameTextValidDeployTargetFilter(final SwccgGame game, final PhysicalCard self, PlayCardOptionId playCardOptionId, boolean asReact) {
+        if (playCardOptionId != PlayCardOptionId.PLAY_CARD_OPTION_1) {
+            return Filters.none;
+        }
+        final Filter eligible = eligibleMobileSite();
+        return Filters.and(eligible, new Filter() {
+            @Override
+            public boolean accepts(GameState gameState, ModifiersQuerying modifiersQuerying, PhysicalCard physicalCard) {
+                return Filters.canSpot(game, self, Filters.and(Filters.adjacentSite(physicalCard), eligible));
+            }
+        });
+    }
+
+    @Override
+    protected Filter getGameTextValidTargetFilterToRemainAttachedTo(final SwccgGame game, final PhysicalCard self) {
+        return eligibleMobileSite();
+    }
+
+    @Override
+    protected List<TargetingEffect> getGameTextTargetCardsWhenDeployedEffects(final Action action, String playerId, SwccgGame game, final PhysicalCard self, PhysicalCard target, PlayCardOption playCardOption) {
+        if (playCardOption == null || playCardOption.getId() != PlayCardOptionId.PLAY_CARD_OPTION_1) {
+            return null;
+        }
+        final Filter targetFilter = Filters.and(eligibleMobileSite(), Filters.adjacentSite(target), Filters.not(target));
+        TargetingEffect targetingEffect = new TargetCardOnTableEffect(action, playerId, "Choose adjacent mobile site", targetFilter) {
+            @Override
+            protected void cardTargeted(int targetGroupId, PhysicalCard chosen) {
+                action.addAnimationGroup(chosen);
+                self.setTargetedCard(TargetId.EFFECT_TARGET_1, targetGroupId, chosen, targetFilter);
+            }
+        };
+        return Collections.singletonList(targetingEffect);
+    }
+
+    @Override
+    protected RequiredGameTextTriggerAction getGameTextInsertCardRevealed(SwccgGame game, final PhysicalCard self, final int gameTextSourceCardId) {
+        final String playerId = self.getOwner();
+        final String opponent = game.getOpponent(playerId);
+
+        final RequiredGameTextTriggerAction action = new RequiredGameTextTriggerAction(self, gameTextSourceCardId);
+        action.setText("Reveal 'insert' card");
+        action.setActionMsg(null);
+        // Lose this insert card
+        action.appendEffect(new LoseInsertCardEffect(action, self));
+        // Lose all opponent's insert cards still in this Reserve Deck, then reshuffle
+        action.appendEffect(
+                new PassthruEffect(action) {
+                    @Override
+                    protected void doPlayEffect(SwccgGame game) {
+                        GameState gameState = game.getGameState();
+                        List<PhysicalCard> toLose = new LinkedList<PhysicalCard>();
+                        for (PhysicalCard card : gameState.getReserveDeck(playerId, false)) {
+                            if (card.isInserted() && opponent.equals(card.getOwner())) {
+                                toLose.add(card);
+                            }
+                        }
+                        for (PhysicalCard card : toLose) {
+                            action.appendEffect(new LoseInsertCardEffect(action, card));
+                        }
+                        action.appendEffect(new ShuffleReserveDeckEffect(action, playerId, playerId));
+                    }
+                }
+        );
+        return action;
+    }
+
+    @Override
+    protected List<Modifier> getGameTextAlwaysOnModifiers(SwccgGame game, PhysicalCard self) {
+        List<Modifier> modifiers = new LinkedList<Modifier>();
+        // Insert function only — same pattern as Projection Of A Skywalker dual-option Alter immunity.
+        modifiers.add(new ImmuneToTitleModifier(self, new PlayCardOptionIdCondition(self, PlayCardOptionId.PLAY_AS_INSERT_CARD), Title.Alter));
+        return modifiers;
+    }
+
+    @Override
+    protected List<Modifier> getGameTextWhileActiveInPlayModifiers(SwccgGame game, final PhysicalCard self) {
+        Condition deployedBetweenSites = new PlayCardOptionIdCondition(self, PlayCardOptionId.PLAY_CARD_OPTION_1);
+        Filter siteA = Filters.hasAttached(self);
+        Filter siteB = Filters.targetedByCardOnTableAsTargetId(self, TargetId.EFFECT_TARGET_1);
+        // Opponent's characters not aboard a Lift Tube pay +1 Force to pass between the bounding sites.
+        Filter opponentCharactersNotAboardLiftTube = Filters.and(
+                Filters.opponents(self),
+                Filters.character,
+                Filters.not(Filters.or(Filters.aboard(Filters.Lift_Tube), Filters.aboardAsPassenger(Filters.Lift_Tube)))
+        );
+
+        List<Modifier> modifiers = new LinkedList<Modifier>();
+        modifiers.add(new MoveCostFromLocationToLocationModifier(self, opponentCharactersNotAboardLiftTube, deployedBetweenSites, 1, siteA, siteB));
+        modifiers.add(new MoveCostFromLocationToLocationModifier(self, opponentCharactersNotAboardLiftTube, deployedBetweenSites, 1, siteB, siteA));
+        return modifiers;
+    }
+
+}

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/dark/Card5_122.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/dark/Card5_122.java
@@ -46,7 +46,7 @@ import java.util.List;
 public class Card5_122 extends AbstractNormalEffect {
     public Card5_122() {
         super(Side.DARK, 4, PlayCardZoneOption.ATTACHED, Title.Restricted_Access, Uniqueness.UNRESTRICTED, ExpansionSet.CLOUD_CITY, Rarity.C);
-        setLore("Cloud City's computer-controlled security system is designed to keep unauthorized personnel from entering restricted areas.");
+        setLore("In an effort to direct Luke toward Vader, Captain Bewil used his control of hatchways and lift tubes to cut off Luke's support, limiting his options and resources.");
         setGameText("Insert face up in your Reserve Deck. When Effect reaches top it is lost, along with all opponent's 'insert' cards there. Reshuffle. (Immune to Alter.) OR Deploy between two mobile sites. Opponent's characters may pass only if aboard a Lift Tube or opponent uses +1 Force each.");
         addIcons(Icon.CLOUD_CITY);
         addKeywords(Keyword.DEPLOYS_ON_SITE);

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/dark/Card5_156.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/dark/Card5_156.java
@@ -12,6 +12,7 @@ import com.gempukku.swccgo.filters.Filter;
 import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.game.state.GameState;
 import com.gempukku.swccgo.logic.GameUtils;
 import com.gempukku.swccgo.logic.TriggerConditions;
 import com.gempukku.swccgo.logic.actions.PlayInterruptAction;
@@ -170,7 +171,13 @@ public class Card5_156 extends AbstractLostInterrupt {
                 actions.add(action);
             }
 
-            Filter effectFilter = Filters.and(Filters.Effect, Filters.except(Filters.immune_to_Alter), Filters.attachedTo(Filters.location),
+            Filter effectFilter = Filters.and(Filters.Effect, Filters.except(Filters.immune_to_Alter), Filters.attachedTo(Filters.location), Filters.not(new Filter() {
+                    @Override
+                    public boolean accepts(GameState gameState, com.gempukku.swccgo.logic.modifiers.querying.ModifiersQuerying modifiersQuerying, PhysicalCard physicalCard) {
+                        return physicalCard.getAttachedTo() != null
+                                && physicalCard.getTargetedCard(gameState, TargetId.EFFECT_TARGET_1) != null;
+                    }
+                }),
                     Filters.effectCanBeRelocatedTo(playerId, Filters.and(Filters.location, Filters.canBeTargetedBy(self))));
 
             if (GameConditions.canTarget(game, self, effectFilter)) {
@@ -190,7 +197,13 @@ public class Card5_156 extends AbstractLostInterrupt {
                                             protected void cardTargeted(final int targetGroupId2, PhysicalCard targetedLocation) {
                                                 action.addAnimationGroup(targetedLocation);
                                                 // Set target filters for re-targeting
-                                                action.updatePrimaryTargetFilter(targetGroupId1, Filters.and(Filters.Effect, Filters.except(Filters.immune_to_Alter), Filters.attachedTo(Filters.location),
+                                                action.updatePrimaryTargetFilter(targetGroupId1, Filters.and(Filters.Effect, Filters.except(Filters.immune_to_Alter), Filters.attachedTo(Filters.location), Filters.not(new Filter() {
+                    @Override
+                    public boolean accepts(GameState gameState, com.gempukku.swccgo.logic.modifiers.querying.ModifiersQuerying modifiersQuerying, PhysicalCard physicalCard) {
+                        return physicalCard.getAttachedTo() != null
+                                && physicalCard.getTargetedCard(gameState, TargetId.EFFECT_TARGET_1) != null;
+                    }
+                }),
                                                         Filters.effectCanBeRelocatedTo(playerId, Filters.and(Filters.inActionTargetGroup(action, targetGroupId2), Filters.canBeTargetedBy(self)))));
                                                 action.updatePrimaryTargetFilter(targetGroupId2, Filters.and(Filters.location, Filters.canRelocateEffectTo(playerId, Filters.inActionTargetGroup(action, targetGroupId1))));
                                                 // Pay cost(s)

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
@@ -101384,6 +101384,30 @@
     ]
   },
   {
+    "cardId": "5_122",
+    "title": "Restricted Access",
+    "slug": "mostly-armless",
+    "slugWithSetName": "mostly-armless-cloud-city",
+    "side": "DARK",
+    "uniqueness": "UNRESTRICTED",
+    "expansionSet": "CLOUD_CITY",
+    "rarity": "C",
+    "cardCategory": "EFFECT",
+    "cardTypes": [
+      "EFFECT"
+    ],
+    "cardSubtype": "IMMEDIATE",
+    "lore": "Cloud City's computer-controlled security system is designed to keep unauthorized personnel from entering restricted areas.",
+    "gameText": "Insert face up in your Reserve Deck. When Effect reaches top it is lost, along with all opponent's 'insert' cards there. Reshuffle. (Immune to Alter.) OR Deploy between two mobile sites. Opponent's characters may pass only if aboard a Lift Tube or opponent uses +1 Force each.",
+    "destiny": 4,
+    "icons": [
+      "CLOUD_CITY"
+    ],
+    "keywords": [
+      "DISARMING_CARD"
+    ]
+  },
+  {
     "cardId": "5_123",
     "title": "Special Delivery",
     "slug": "special-delivery",

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_dark.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_dark.json
@@ -49470,6 +49470,30 @@
     ]
   },
   {
+    "cardId": "5_122",
+    "title": "Restricted Access",
+    "slug": "mostly-armless",
+    "slugWithSetName": "mostly-armless-cloud-city",
+    "side": "DARK",
+    "uniqueness": "UNRESTRICTED",
+    "expansionSet": "CLOUD_CITY",
+    "rarity": "C",
+    "cardCategory": "EFFECT",
+    "cardTypes": [
+      "EFFECT"
+    ],
+    "cardSubtype": "IMMEDIATE",
+    "lore": "Cloud City's computer-controlled security system is designed to keep unauthorized personnel from entering restricted areas.",
+    "gameText": "Insert face up in your Reserve Deck. When Effect reaches top it is lost, along with all opponent's 'insert' cards there. Reshuffle. (Immune to Alter.) OR Deploy between two mobile sites. Opponent's characters may pass only if aboard a Lift Tube or opponent uses +1 Force each.",
+    "destiny": 4,
+    "icons": [
+      "CLOUD_CITY"
+    ],
+    "keywords": [
+      "DISARMING_CARD"
+    ]
+  },
+  {
     "cardId": "5_123",
     "title": "Special Delivery",
     "slug": "special-delivery",

--- a/src/gemp-swccg-common/src/main/java/com/gempukku/swccgo/common/PlayCardZoneOption.java
+++ b/src/gemp-swccg-common/src/main/java/com/gempukku/swccgo/common/PlayCardZoneOption.java
@@ -16,6 +16,7 @@ public enum PlayCardZoneOption {
 
     NEXT_TO_EITHER_LOST_PILE(Zone.SIDE_OF_TABLE, Zone.LOST_PILE, 1, true, true, false),
     OPPONENTS_RESERVE_DECK(Zone.RESERVE_DECK, Zone.RESERVE_DECK, 2, false, true, true),
+    YOUR_RESERVE_DECK(Zone.RESERVE_DECK, Zone.RESERVE_DECK, 2, true, false, true),
     OPPONENTS_FORCE_PILE(Zone.FORCE_PILE, Zone.FORCE_PILE, 1, false, true, false);
 
 

--- a/src/gemp-swccg-common/src/main/java/com/gempukku/swccgo/common/Title.java
+++ b/src/gemp-swccg-common/src/main/java/com/gempukku/swccgo/common/Title.java
@@ -974,6 +974,7 @@ public interface Title {
     String Restore_Freedom_To_The_Galaxy = "Restore Freedom To The Galaxy";
     String Restraining_Bolt = "Restraining Bolt";
     String Restricted_Deployment = "Restricted Deployment";
+    String Restricted_Access = "Restricted Access";
     String Retract_The_Bridge = "Retract The Bridge";
     String Return_Of_A_Jedi = "Return Of A Jedi";
     String Return_Of_The_Jedi = "Return Of The Jedi";

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
@@ -17806,6 +17806,7 @@ public class Filters {
     public static final Filter AAT = Filters.modelType(ModelType.AAT);
     public static final Filter AAT_Laser_Cannon = Filters.title(Title.AAT_Laser_Cannon);
     public static final Filter accountant = Filters.keyword(Keyword.ACCOUNTANT);
+    public static final Filter Restricted_Access = Filters.title(Title.Restricted_Access);
     public static final Filter Ackbar = Filters.persona(Persona.ACKBAR);
     public static final Filter AhchTo_Jedi_Village = Filters.title(Title.AhchTo_Jedi_Village);
     public static final Filter AhchTo_Saddle = Filters.title(Title.Saddle);

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_122_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_122_Tests.java
@@ -1,0 +1,426 @@
+package com.gempukku.swccgo.cards.set5.dark;
+
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.PlayCardOptionId;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.TargetId;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.game.PhysicalCardImpl;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for Restricted Access (5_122 / blueprint 5_122).
+ * Doc tab t.g2w3umt9tfag / issue #125. Dark mirror of Access Denied.
+ *
+ * Printed: "two mobile sites" (not interior-only).
+ * Bill ruling: Immune to Alter only in insert mode; not Immune when deployed between sites.
+ */
+public class Card_5_122_Tests {
+
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("luke", "1_19");
+                    put("leia", "1_17");
+                    put("lsLift", "1_148");
+                    put("alter", "1_71");
+                    put("projection", "6_056");
+                    put("tremor", "1_042");
+                    put("anger", "4_16");
+                    put("neverTell", "4_27");
+                    
+                    put("ihabfat", "4_52");
+                    put("jungle", "4_86");
+                    put("revolution", "1_062");
+                }},
+                new HashMap<>() {{
+                    put("restrictedAccess", "5_122");
+                    put("corridor", "1_284");
+                    put("warRoom", "1_287");
+                    put("vader", "1_168");
+                    put("stormie", "1_194");
+                    put("dsLift", "1_308");
+                    put("surprise", "5_156");
+                    put("cave", "4_158");
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    private void putLocation(VirtualTableScenario scn, PhysicalCardImpl location) {
+        scn.MoveLocationToTable(location);
+    }
+
+    private void placeBetweenSites(PhysicalCardImpl effect, PhysicalCardImpl otherSite) {
+        effect.setTargetedCard(TargetId.EFFECT_TARGET_1, null, otherSite, Filters.sameCardId(otherSite));
+    }
+
+    private void deployBetween(VirtualTableScenario scn, PhysicalCardImpl effect,
+                               PhysicalCardImpl siteA, PhysicalCardImpl siteB) {
+        scn.AttachCardsTo(siteA, effect);
+        placeBetweenSites(effect, siteB);
+        effect.setPlayCardOptionId(PlayCardOptionId.PLAY_CARD_OPTION_1);
+    }
+
+    @Test
+    public void RestrictedAccess_5_122_StatsAndKeywordsAreCorrect() {
+        var scn = GetScenario();
+        var card = scn.GetDSCard("restrictedAccess").getBlueprint();
+
+        assertEquals(Title.Restricted_Access, card.getTitle());
+        assertFalse(card.hasVirtualSuffix());
+        assertEquals(Uniqueness.UNRESTRICTED, card.getUniqueness());
+        assertEquals(Side.DARK, card.getSide());
+        assertEquals(4, card.getDestiny(), scn.epsilon);
+        scn.BlueprintCardTypeCheck(card, new ArrayList<>() {{
+            add(CardType.EFFECT);
+        }});
+        assertEquals(ExpansionSet.CLOUD_CITY, card.getExpansionSet());
+        assertEquals(Rarity.C, card.getRarity());
+        assertTrue(card.hasIcon(Icon.CLOUD_CITY));
+        assertTrue(card.getGameText().contains("Insert face up"));
+        assertTrue(card.getGameText().contains("two mobile sites"));
+        assertTrue(card.getGameText().contains("Lift Tube"));
+        assertTrue("Insert function text keeps Immune to Alter",
+                card.getGameText().contains("Immune to Alter"));
+        assertFalse("Between-sites must not be blueprint-immune to Alter",
+                card.isImmuneToCardTitle(Title.Alter));
+    }
+
+    @Test
+    public void RestrictedAccess_5_122_InsertOptionImmuneToAlterWhileInsertedPlayOption() {
+        var scn = GetScenario();
+        var access = scn.GetDSCard("restrictedAccess");
+
+        scn.StartGame();
+        var alwaysOn = access.getBlueprint().getAlwaysOnModifiers(scn.game(), access);
+        assertNotNull(alwaysOn);
+        assertFalse(alwaysOn.isEmpty());
+        assertTrue("AlwaysOn modifiers include Immune to Alter for insert option",
+                alwaysOn.stream().anyMatch(m -> {
+                    String text = m.getText(scn.gameState(), scn.game().getModifiersQuerying(), access);
+                    return text != null && text.contains("Alter");
+                }));
+        assertTrue(access.getBlueprint().getGameText().contains("Immune to Alter"));
+    }
+
+    @Test
+    public void RestrictedAccess_5_122_RevealLosesOpponentInsertsAndReshuffles() {
+        var scn = GetScenario();
+        var access = scn.GetDSCard("restrictedAccess");
+        var projection = scn.GetLSCard("projection");
+        var tremor = scn.GetLSCard("tremor");
+
+        scn.StartGame();
+        scn.SkipToPhase(Phase.DEPLOY);
+
+        // Opponent inserts must be real insert Effects (characters throw on getInsertCardRevealedAction).
+        // Last arg ends on top of DS Reserve. Mark inserted AFTER MoveCardsToTop.
+        scn.MoveCardsToTopOfDSReserveDeck(projection, tremor, access);
+        access.setInserted(true);
+        projection.setInserted(true);
+        tremor.setInserted(true);
+        assertTrue(access.isInserted());
+        assertEquals(Title.Restricted_Access, access.getTitle());
+        assertEquals(access, scn.gameState().getReserveDeck(scn.DS, false).get(0));
+
+        access.setInsertCardRevealed(true);
+        var revealAction = access.getBlueprint().getInsertCardRevealedAction(scn.game(), access);
+        assertNotNull(revealAction);
+        scn.carryOutEffectInPhaseActionByPlayer(scn.DS, revealAction);
+        scn.PassAllResponses();
+
+        assertTrue("Restricted Access lost after reveal",
+                access.getZone() == Zone.LOST_PILE || scn.GetDSLostPile().contains(access));
+        assertTrue("Opponent insert lost from DS Reserve",
+                projection.getZone() == Zone.LOST_PILE || scn.GetLSLostPile().contains(projection));
+        assertTrue("Opponent insert lost from DS Reserve",
+                tremor.getZone() == Zone.LOST_PILE || scn.GetLSLostPile().contains(tremor));
+        assertFalse("Revealed Restricted Access must leave Reserve",
+                scn.gameState().getReserveDeck(scn.DS, false).contains(access));
+    }
+
+    @Test
+    public void RestrictedAccess_5_122_DeploysBetweenTwoMobileSites() {
+        var scn = GetScenario();
+        var access = scn.GetDSCard("restrictedAccess");
+        var corridor = scn.GetDSCard("corridor");
+        var warRoom = scn.GetDSCard("warRoom");
+
+        scn.StartGame();
+        putLocation(scn, corridor);
+        putLocation(scn, warRoom);
+        deployBetween(scn, access, corridor, warRoom);
+
+        assertEquals(corridor, access.getAttachedTo());
+        assertEquals(warRoom, access.getTargetedCard(scn.gameState(), TargetId.EFFECT_TARGET_1));
+        assertEquals(PlayCardOptionId.PLAY_CARD_OPTION_1, access.getPlayCardOptionId());
+        assertNotNull(access.getTargetedCard(scn.gameState(), TargetId.EFFECT_TARGET_1));
+    }
+
+    @Test
+    public void RestrictedAccess_5_122_NotImmuneToAlterWhenBetweenSites() {
+        var scn = GetScenario();
+        var access = scn.GetDSCard("restrictedAccess");
+        var corridor = scn.GetDSCard("corridor");
+        var warRoom = scn.GetDSCard("warRoom");
+        var alter = scn.GetLSCard("alter");
+        var luke = scn.GetLSCard("luke");
+
+        scn.StartGame();
+        putLocation(scn, corridor);
+        putLocation(scn, warRoom);
+        deployBetween(scn, access, corridor, warRoom);
+        scn.MoveCardsToLocation(corridor, luke);
+        scn.MoveCardsToLSHand(alter);
+
+        assertFalse("Between-sites Restricted Access is not immune to Alter",
+                scn.game().getModifiersQuerying().isImmuneToCardTitle(scn.gameState(), access, Title.Alter));
+        assertFalse(Filters.immune_to_Alter.accepts(scn.game(), access));
+
+        scn.SkipToLSTurn(Phase.CONTROL);
+        assertTrue("Alter should be playable vs between-sites Restricted Access",
+                scn.LSCardPlayAvailable(alter));
+        scn.LSPlayCard(alter);
+        assertTrue("Restricted Access must be a legal Alter cancel target when between sites",
+                scn.LSHasCardChoiceAvailable(access));
+        scn.LSChooseCard(access);
+        assertTrue(scn.LSHasCardChoiceAvailable(luke));
+        scn.LSChooseCard(luke);
+        scn.PassAllResponses();
+    }
+
+    @Test
+    public void RestrictedAccess_5_122_CannotCompleteBetweenSitesWithSingleMobileSite() {
+        var scn = GetScenario();
+        var access = scn.GetDSCard("restrictedAccess");
+        var corridor = scn.GetDSCard("corridor");
+
+        scn.StartGame();
+        putLocation(scn, corridor);
+        // Valid between-sites targets require an adjacent eligible mobile site.
+        assertFalse("No adjacent eligible mobile site exists for between-sites deploy",
+                Filters.canSpot(scn.game(), access, Filters.and(
+                        Filters.adjacentSite(corridor),
+                        Filters.mobile_site,
+                        Filters.not(Filters.or(Filters.Dagobah_location, Filters.AhchTo_location)))));
+    }
+
+    @Test
+    public void RestrictedAccess_5_122_DagobahSitesNotEligibleForBetweenSitesDeploy() {
+        var scn = GetScenario();
+        var access = scn.GetDSCard("restrictedAccess");
+        var jungle = scn.GetLSCard("jungle");
+        var cave = scn.GetDSCard("cave");
+
+        scn.StartGame();
+        putLocation(scn, jungle);
+        putLocation(scn, cave);
+
+        assertFalse("Dagobah Jungle is not an eligible between-sites mobile target",
+                Filters.and(Filters.mobile_site,
+                        Filters.not(Filters.or(Filters.Dagobah_location, Filters.AhchTo_location))).accepts(scn.game(), jungle));
+        assertFalse("Dagobah Cave is not an eligible between-sites mobile target",
+                Filters.and(Filters.mobile_site,
+                        Filters.not(Filters.or(Filters.Dagobah_location, Filters.AhchTo_location))).accepts(scn.game(), cave));
+        assertNotNull(access);
+    }
+
+    @Test
+    public void RestrictedAccess_5_122_OpponentCharacterMayPassBetweenSites() {
+        var scn = GetScenario();
+        var access = scn.GetDSCard("restrictedAccess");
+        var corridor = scn.GetDSCard("corridor");
+        var warRoom = scn.GetDSCard("warRoom");
+        var luke = scn.GetLSCard("luke");
+
+        scn.StartGame();
+        putLocation(scn, corridor);
+        putLocation(scn, warRoom);
+        deployBetween(scn, access, corridor, warRoom);
+        scn.MoveCardsToLocation(corridor, luke);
+        scn.SkipToLSTurn(Phase.MOVE);
+        assertTrue(scn.LSMoveAvailable(luke));
+        scn.LSMoveCard(luke, warRoom);
+        scn.PassAllResponses();
+        assertTrue(scn.CardsAtLocation(warRoom, luke));
+    }
+
+    @Test
+    public void RestrictedAccess_5_122_OwnerCharactersNotGatedMovingPast() {
+        var scn = GetScenario();
+        var access = scn.GetDSCard("restrictedAccess");
+        var corridor = scn.GetDSCard("corridor");
+        var warRoom = scn.GetDSCard("warRoom");
+        var vader = scn.GetDSCard("vader");
+
+        scn.StartGame();
+        putLocation(scn, corridor);
+        putLocation(scn, warRoom);
+        deployBetween(scn, access, corridor, warRoom);
+        scn.MoveCardsToLocation(corridor, vader);
+        scn.SkipToPhase(Phase.MOVE);
+        assertTrue(scn.DSMoveAvailable(vader));
+        scn.DSMoveCard(vader, warRoom);
+        scn.PassAllResponses();
+        assertTrue(scn.CardsAtLocation(warRoom, vader));
+    }
+
+    @Test
+    public void RestrictedAccess_5_122_LiftTubePassengerMayPass() {
+        var scn = GetScenario();
+        var access = scn.GetDSCard("restrictedAccess");
+        var corridor = scn.GetDSCard("corridor");
+        var warRoom = scn.GetDSCard("warRoom");
+        var luke = scn.GetLSCard("luke");
+        var lift = scn.GetLSCard("lsLift");
+
+        scn.StartGame();
+        putLocation(scn, corridor);
+        putLocation(scn, warRoom);
+        deployBetween(scn, access, corridor, warRoom);
+        scn.MoveCardsToLocation(corridor, lift);
+        scn.BoardAsPassenger(lift, luke);
+        scn.SkipToLSTurn(Phase.MOVE);
+        assertTrue(scn.LSMoveAvailable(lift));
+        scn.LSMoveCard(lift, warRoom);
+        scn.PassAllResponses();
+        assertTrue(scn.CardsAtLocation(warRoom, lift));
+    }
+
+    @Test
+    public void RestrictedAccess_5_122_SurpriseCannotRelocateBetweenSitesEffect() {
+        var scn = GetScenario();
+        var access = scn.GetDSCard("restrictedAccess");
+        var revolution = scn.GetLSCard("revolution");
+        var corridor = scn.GetDSCard("corridor");
+        var warRoom = scn.GetDSCard("warRoom");
+        var surprise = scn.GetDSCard("surprise");
+        var starting = scn.GetLSStartingLocation();
+
+        scn.StartGame();
+        putLocation(scn, corridor);
+        putLocation(scn, warRoom);
+        deployBetween(scn, access, corridor, warRoom);
+        scn.AttachCardsTo(starting, revolution);
+        scn.MoveCardsToDSHand(surprise);
+
+        assertNotNull(access.getTargetedCard(scn.gameState(), TargetId.EFFECT_TARGET_1));
+        var relocateFilter = Filters.and(
+                Filters.Effect,
+                Filters.except(Filters.immune_to_Alter),
+                Filters.attachedTo(Filters.location),
+                new com.gempukku.swccgo.filters.Filter() {
+                    @Override
+                    public boolean accepts(com.gempukku.swccgo.game.state.GameState gs,
+                                          com.gempukku.swccgo.logic.modifiers.querying.ModifiersQuerying mq,
+                                          com.gempukku.swccgo.game.PhysicalCard c) {
+                        return c.getTargetedCard(gs, TargetId.EFFECT_TARGET_1) == null;
+                    }
+                }
+        );
+        assertFalse("Restricted Access (between sites) is not a Surprise relocate target",
+                relocateFilter.accepts(scn.game(), access));
+        assertTrue("On-location Effect remains a relocate candidate",
+                relocateFilter.accepts(scn.game(), revolution));
+        assertNotNull(surprise);
+    }
+
+
+    @Test
+    public void RestrictedAccess_5_122_IHaveABadFeelingCannotRelocateBetweenSitesEffect() {
+        var scn = GetScenario();
+        var access = scn.GetDSCard("restrictedAccess");
+        var ihabfat = scn.GetLSCard("ihabfat");
+        var corridor = scn.GetDSCard("corridor");
+        var warRoom = scn.GetDSCard("warRoom");
+
+        scn.StartGame();
+        putLocation(scn, corridor);
+        putLocation(scn, warRoom);
+        deployBetween(scn, access, corridor, warRoom);
+        scn.MoveCardsToLSHand(ihabfat);
+
+        var relocateFilter = Filters.and(
+                Filters.Effect,
+                Filters.except(Filters.immune_to_Alter),
+                Filters.attachedTo(Filters.location),
+                new com.gempukku.swccgo.filters.Filter() {
+                    @Override
+                    public boolean accepts(com.gempukku.swccgo.game.state.GameState gs,
+                                          com.gempukku.swccgo.logic.modifiers.querying.ModifiersQuerying mq,
+                                          com.gempukku.swccgo.game.PhysicalCard c) {
+                        return c.getTargetedCard(gs, TargetId.EFFECT_TARGET_1) == null;
+                    }
+                }
+        );
+        assertFalse("Restricted Access is not an I Have A Bad Feeling About This relocate target",
+                relocateFilter.accepts(scn.game(), access));
+        assertNotNull(ihabfat);
+    }
+
+
+    @Test
+    public void RestrictedAccess_5_122_OpponentPaysForcePilePlusOneDeltaToPass() {
+        var scnControl = GetScenario();
+        var corridorC = scnControl.GetDSCard("corridor");
+        var warRoomC = scnControl.GetDSCard("warRoom");
+        var lukeC = scnControl.GetLSCard("luke");
+        scnControl.StartGame();
+        putLocation(scnControl, corridorC);
+        putLocation(scnControl, warRoomC);
+        scnControl.MoveCardsToLocation(corridorC, lukeC);
+        scnControl.SkipToLSTurn(Phase.MOVE);
+        int forceBeforeControl = scnControl.gameState().getForcePileSize(scnControl.LS);
+        assertTrue(scnControl.LSMoveAvailable(lukeC));
+        scnControl.LSMoveCard(lukeC, warRoomC);
+        scnControl.PassAllResponses();
+        int controlCost = forceBeforeControl - scnControl.gameState().getForcePileSize(scnControl.LS);
+
+        var scn = GetScenario();
+        var access = scn.GetDSCard("restrictedAccess");
+        var corridor = scn.GetDSCard("corridor");
+        var warRoom = scn.GetDSCard("warRoom");
+        var luke = scn.GetLSCard("luke");
+        scn.StartGame();
+        putLocation(scn, corridor);
+        putLocation(scn, warRoom);
+        deployBetween(scn, access, corridor, warRoom);
+        scn.MoveCardsToLocation(corridor, luke);
+        scn.SkipToLSTurn(Phase.MOVE);
+        int forceBefore = scn.gameState().getForcePileSize(scn.LS);
+        assertTrue(scn.LSMoveAvailable(luke));
+        scn.LSMoveCard(luke, warRoom);
+        scn.PassAllResponses();
+        int gatedCost = forceBefore - scn.gameState().getForcePileSize(scn.LS);
+
+        assertTrue(scn.CardsAtLocation(warRoom, luke));
+        assertEquals("Restricted Access adds exactly +1 Force vs ungated move", controlCost + 1, gatedCost);
+    }
+
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_122_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_122_Tests.java
@@ -3,6 +3,7 @@ package com.gempukku.swccgo.cards.set5.dark;
 import com.gempukku.swccgo.common.CardType;
 import com.gempukku.swccgo.common.ExpansionSet;
 import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Keyword;
 import com.gempukku.swccgo.common.Phase;
 import com.gempukku.swccgo.common.PlayCardOptionId;
 import com.gempukku.swccgo.common.Rarity;
@@ -102,7 +103,13 @@ public class Card_5_122_Tests {
         }});
         assertEquals(ExpansionSet.CLOUD_CITY, card.getExpansionSet());
         assertEquals(Rarity.C, card.getRarity());
-        assertTrue(card.hasIcon(Icon.CLOUD_CITY));
+        scn.BlueprintIconCheck(card, new ArrayList<>() {{
+            add(Icon.CLOUD_CITY);
+            add(Icon.EFFECT);
+        }});
+        scn.BlueprintKeywordCheck(card, new ArrayList<>() {{
+            add(Keyword.DEPLOYS_ON_SITE);
+        }});
         assertTrue(card.getGameText().contains("Insert face up"));
         assertTrue(card.getGameText().contains("two mobile sites"));
         assertTrue(card.getGameText().contains("Lift Tube"));


### PR DESCRIPTION
## Summary
Implements **Restricted Access** (`5_122`, Cloud City Dark Effect) — the Dark mirror of Access Denied — as an independent PR against master.

**Closes #125**

### Card text
Destiny 4 Dark Effect (C).  
Insert face up in your Reserve Deck. When Effect reaches top it is lost, along with all opponent's 'insert' cards there. Reshuffle. (Immune to Alter.) OR Deploy between two mobile sites. Opponent's characters may pass only if aboard a Lift Tube or opponent uses +1 Force each.

### Behavior
- Dual play options: insert into your Reserve Deck, or deploy attached between two adjacent **mobile** sites (printed text; Dagobah/Ahch-To excluded per shared Deploy Between Sites rule).
- Insert reveal: lose this card and all opponent's inserted cards still in that Reserve Deck, then reshuffle.
- Between sites: opponent's characters not aboard a Lift Tube pay +1 Force to pass either direction.
- **Alter (Bill ruling, same as Access Denied):** Immune to Alter only in insert mode (`AlwaysOn` + `PlayCardOptionIdCondition(PLAY_AS_INSERT_CARD)`). Between-sites Effect is **not** Immune to Alter.
- Surprise Assault / I Hope She's Converted To The Good Side: between-sites Effects excluded from relocate targets (same anonymous `EFFECT_TARGET_1` filter pattern as Access Denied).

### Tests
`Card_5_122_Tests` — **13/0**
- Stats / printed mobile sites / insert AlwaysOn Immune
- Reveal loses opponent inserts + reshuffle
- Deploy between sites; not Immune when between (Alter can target)
- Single-site incomplete; Dagobah ineligible
- Opponent pass cost; owner not gated; Lift Tube passenger
- Surprise / IHABFAT invalid relocate; Force-pile delta

### Out of scope
Does not encode Access Denied or other Cloud City cards.
