### PR TITLE
Implement Turn It Off! Turn It Off! (3_139)

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/light/Card2_003.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/light/Card2_003.java
@@ -11,6 +11,7 @@ import com.gempukku.swccgo.common.Persona;
 import com.gempukku.swccgo.common.Rarity;
 import com.gempukku.swccgo.common.Side;
 import com.gempukku.swccgo.common.Species;
+import com.gempukku.swccgo.common.SpotOverride;
 import com.gempukku.swccgo.common.TargetingReason;
 import com.gempukku.swccgo.common.Uniqueness;
 import com.gempukku.swccgo.filters.Filter;
@@ -75,14 +76,14 @@ public class Card2_003 extends AbstractAlienRebel {
         if (TriggerConditions.isAboutToBeLost(game, effectResult, hitAtSameSite)) {
             final AboutToLoseCardFromTableResult result = (AboutToLoseCardFromTableResult) effectResult;
             final PhysicalCard cardToBeLost = result.getCardToBeLost();
-            if (GameConditions.canTarget(game, self, targetingReason, cardToBeLost)) {
+            if (GameConditions.canTarget(game, self, SpotOverride.INCLUDE_EXCLUDED_FROM_BATTLE, targetingReason, cardToBeLost)) {
 
                 final RequiredGameTextTriggerAction action = new RequiredGameTextTriggerAction(self, gameTextSourceCardId);
                 action.setPerformingPlayer(playerId);
                 action.setText("Place " + GameUtils.getFullName(cardToBeLost) + " in Used Pile");
                 // Choose target(s)
                 action.appendTargeting(
-                        new TargetCardOnTableEffect(action, playerId, "Target card to place in Used Pile instead of Lost Pile", targetingReason, cardToBeLost) {
+                        new TargetCardOnTableEffect(action, playerId, "Target card to place in Used Pile instead of Lost Pile", SpotOverride.INCLUDE_EXCLUDED_FROM_BATTLE, targetingReason, cardToBeLost) {
                             @Override
                             protected void cardTargeted(final int targetGroupId, PhysicalCard cardTargeted) {
                                 action.addAnimationGroup(cardTargeted);

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/light/Card2_003.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/light/Card2_003.java
@@ -1,6 +1,7 @@
 package com.gempukku.swccgo.cards.set2.light;
 
 import com.gempukku.swccgo.cards.AbstractAlienRebel;
+import com.gempukku.swccgo.cards.GameConditions;
 import com.gempukku.swccgo.cards.conditions.AtSameLocationAsCondition;
 import com.gempukku.swccgo.cards.conditions.PilotingCondition;
 import com.gempukku.swccgo.common.ExpansionSet;
@@ -10,7 +11,9 @@ import com.gempukku.swccgo.common.Persona;
 import com.gempukku.swccgo.common.Rarity;
 import com.gempukku.swccgo.common.Side;
 import com.gempukku.swccgo.common.Species;
+import com.gempukku.swccgo.common.TargetingReason;
 import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.filters.Filter;
 import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.game.SwccgGame;
@@ -18,15 +21,18 @@ import com.gempukku.swccgo.logic.GameUtils;
 import com.gempukku.swccgo.logic.TriggerConditions;
 import com.gempukku.swccgo.logic.actions.RequiredGameTextTriggerAction;
 import com.gempukku.swccgo.logic.effects.PlaceCardInUsedPileFromTableEffect;
+import com.gempukku.swccgo.logic.effects.RespondableEffect;
+import com.gempukku.swccgo.logic.effects.TargetCardOnTableEffect;
 import com.gempukku.swccgo.logic.modifiers.AddsPowerToPilotedBySelfModifier;
-import com.gempukku.swccgo.logic.modifiers.ForfeitedToUsedPileModifier;
 import com.gempukku.swccgo.logic.modifiers.ManeuverModifier;
 import com.gempukku.swccgo.logic.modifiers.Modifier;
 import com.gempukku.swccgo.logic.modifiers.PowerModifier;
+import com.gempukku.swccgo.logic.timing.Action;
 import com.gempukku.swccgo.logic.timing.EffectResult;
-import com.gempukku.swccgo.logic.timing.PassthruEffect;
+import com.gempukku.swccgo.logic.timing.results.AboutToForfeitCardFromTableResult;
 import com.gempukku.swccgo.logic.timing.results.AboutToLoseCardFromTableResult;
 
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -55,33 +61,81 @@ public class Card2_003 extends AbstractAlienRebel {
         modifiers.add(new PowerModifier(self, new AtSameLocationAsCondition(self, Filters.Han), 1));
         modifiers.add(new AddsPowerToPilotedBySelfModifier(self, 2));
         modifiers.add(new ManeuverModifier(self, Filters.hasPiloting(self), new PilotingCondition(self, Filters.Falcon), 1));
-        modifiers.add(new ForfeitedToUsedPileModifier(self, Filters.and(Filters.your(self), Filters.or(Filters.vehicle,
-                Filters.starship, Filters.droid), Filters.hit, Filters.atSameSite(self))));
         return modifiers;
     }
 
     @Override
     protected List<RequiredGameTextTriggerAction> getGameTextRequiredAfterTriggers(SwccgGame game, final EffectResult effectResult, final PhysicalCard self, int gameTextSourceCardId) {
-        // Check condition(s)
-        if (TriggerConditions.isAboutToBeLost(game, effectResult, Filters.and(Filters.your(self), Filters.or(Filters.vehicle,
-                Filters.starship, Filters.droid), Filters.hit, Filters.atSameSite(self)))) {
+        final String playerId = self.getOwner();
+        final TargetingReason targetingReason = TargetingReason.TO_BE_USED_INSTEAD_OF_LOST;
+        final Filter hitAtSameSite = Filters.and(Filters.your(self), Filters.or(Filters.vehicle, Filters.starship, Filters.droid),
+                Filters.hit, Filters.atSameSite(self));
+
+        // Check condition(s) - about to be lost (not an all-cards situation)
+        if (TriggerConditions.isAboutToBeLost(game, effectResult, hitAtSameSite)) {
             final AboutToLoseCardFromTableResult result = (AboutToLoseCardFromTableResult) effectResult;
             final PhysicalCard cardToBeLost = result.getCardToBeLost();
+            if (GameConditions.canTarget(game, self, targetingReason, cardToBeLost)) {
 
-            final RequiredGameTextTriggerAction action = new RequiredGameTextTriggerAction(self, gameTextSourceCardId);
-            action.setText("Place " + GameUtils.getFullName(cardToBeLost) + " in Used Pile");
-            action.setActionMsg("Place " + GameUtils.getCardLink(cardToBeLost) + " in Used Pile");
-            // Perform result(s)
-            action.appendEffect(
-                    new PassthruEffect(action) {
-                        @Override
-                        protected void doPlayEffect(SwccgGame game) {
-                            result.getPreventableCardEffect().preventEffectOnCard(cardToBeLost);
-                            action.appendEffect(
-                                    new PlaceCardInUsedPileFromTableEffect(action, result.getCardToBeLost()));
+                final RequiredGameTextTriggerAction action = new RequiredGameTextTriggerAction(self, gameTextSourceCardId);
+                action.setPerformingPlayer(playerId);
+                action.setText("Place " + GameUtils.getFullName(cardToBeLost) + " in Used Pile");
+                // Choose target(s)
+                action.appendTargeting(
+                        new TargetCardOnTableEffect(action, playerId, "Target card to place in Used Pile instead of Lost Pile", targetingReason, cardToBeLost) {
+                            @Override
+                            protected void cardTargeted(final int targetGroupId, PhysicalCard cardTargeted) {
+                                action.addAnimationGroup(cardTargeted);
+                                // Allow response(s) - e.g. Turn It Off! Turn It Off!
+                                action.allowResponses("Place " + GameUtils.getCardLink(cardTargeted) + " in Used Pile",
+                                        new RespondableEffect(action) {
+                                            @Override
+                                            protected void performActionResults(Action targetingAction) {
+                                                PhysicalCard finalTarget = action.getPrimaryTargetCard(targetGroupId);
+                                                // Perform result(s)
+                                                result.getPreventableCardEffect().preventEffectOnCard(finalTarget);
+                                                action.appendEffect(
+                                                        new PlaceCardInUsedPileFromTableEffect(action, finalTarget));
+                                            }
+                                        }
+                                );
+                            }
                         }
-                    }
-            );
+                );
+                return Collections.singletonList(action);
+            }
+        }
+
+        // Check condition(s) - about to be forfeited to Lost Pile
+        if (TriggerConditions.isAboutToBeForfeitedToLostPile(game, effectResult, hitAtSameSite)) {
+            final AboutToForfeitCardFromTableResult result = (AboutToForfeitCardFromTableResult) effectResult;
+            final PhysicalCard cardToBeForfeited = result.getCardToBeForfeited();
+            if (GameConditions.canTarget(game, self, targetingReason, cardToBeForfeited)) {
+
+                final RequiredGameTextTriggerAction action = new RequiredGameTextTriggerAction(self, gameTextSourceCardId);
+                action.setPerformingPlayer(playerId);
+                action.setText("Place " + GameUtils.getFullName(cardToBeForfeited) + " in Used Pile");
+                // Choose target(s)
+                action.appendTargeting(
+                        new TargetCardOnTableEffect(action, playerId, "Target card to place in Used Pile instead of Lost Pile", targetingReason, cardToBeForfeited) {
+                            @Override
+                            protected void cardTargeted(final int targetGroupId, PhysicalCard cardTargeted) {
+                                action.addAnimationGroup(cardTargeted);
+                                // Allow response(s) - e.g. Turn It Off! Turn It Off!
+                                action.allowResponses("Place " + GameUtils.getCardLink(cardTargeted) + " in Used Pile when forfeited",
+                                        new RespondableEffect(action) {
+                                            @Override
+                                            protected void performActionResults(Action targetingAction) {
+                                                // Perform result(s)
+                                                result.getForfeitCardEffect().setForfeitToUsedPile();
+                                            }
+                                        }
+                                );
+                            }
+                        }
+                );
+                return Collections.singletonList(action);
+            }
         }
         return null;
     }

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set3/dark/Card3_139.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set3/dark/Card3_139.java
@@ -1,0 +1,88 @@
+package com.gempukku.swccgo.cards.set3.dark;
+
+import com.gempukku.swccgo.cards.AbstractUsedOrLostInterrupt;
+import com.gempukku.swccgo.cards.GameConditions;
+import com.gempukku.swccgo.common.CardSubtype;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.logic.TriggerConditions;
+import com.gempukku.swccgo.logic.actions.CancelCardActionBuilder;
+import com.gempukku.swccgo.logic.actions.PlayInterruptAction;
+import com.gempukku.swccgo.logic.timing.Effect;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Set: Hoth
+ * Type: Interrupt
+ * Subtype: Used Or Lost
+ * Title: Turn It Off! Turn It Off!
+ */
+public class Card3_139 extends AbstractUsedOrLostInterrupt {
+    public Card3_139() {
+        super(Side.DARK, 5, Title.Turn_It_Off_Turn_It_Off, Uniqueness.UNRESTRICTED, ExpansionSet.HOTH, Rarity.C1);
+        setLore("'Turn it off! Turn it off! Off! TURN IT OFF!'");
+        setGameText("USED: Cancel any attempt to place a 'hit' starship, vehicle or droid in the Used Pile rather than the Lost Pile. OR Cancel Han's Toolkit. LOST: Cancel Crash Site Memorial.");
+        addIcons(Icon.HOTH);
+    }
+
+    @Override
+    protected List<PlayInterruptAction> getGameTextOptionalBeforeActions(String playerId, SwccgGame game, Effect effect, PhysicalCard self) {
+        List<PlayInterruptAction> actions = new LinkedList<PlayInterruptAction>();
+
+        // Check condition(s) - USED: Cancel Han's Toolkit being played
+        if (TriggerConditions.isPlayingCard(game, effect, Filters.Hans_Toolkit)
+                && GameConditions.canCancelCardBeingPlayed(game, self, effect)) {
+
+            PlayInterruptAction action = new PlayInterruptAction(game, self, CardSubtype.USED);
+            // Build action using common utility
+            CancelCardActionBuilder.buildCancelCardBeingPlayedAction(action, effect);
+            actions.add(action);
+        }
+        // Check condition(s) - LOST: Cancel Crash Site Memorial being played
+        if (TriggerConditions.isPlayingCard(game, effect, Filters.Crash_Site_Memorial)
+                && GameConditions.canCancelCardBeingPlayed(game, self, effect)) {
+
+            PlayInterruptAction action = new PlayInterruptAction(game, self, CardSubtype.LOST);
+            // Build action using common utility
+            CancelCardActionBuilder.buildCancelCardBeingPlayedAction(action, effect);
+            actions.add(action);
+        }
+        // TODO(Chief/shared engine): USED cancel of attempt to place hit starship/vehicle/droid
+        // in Used Pile instead of Lost Pile needs Chewbacca/WED Techie to emit cancelable targeting
+        // (TargetingReason.TO_BE_USED_INSTEAD_OF_LOST) or PlaceInCardPileInsteadOfLostEffect.
+        // See GitHub #96 / #997 and Gergall Doc plan. Do not implement broad engine here without Chief.
+        return actions;
+    }
+
+    @Override
+    protected List<PlayInterruptAction> getGameTextTopLevelActions(final String playerId, SwccgGame game, final PhysicalCard self) {
+        List<PlayInterruptAction> actions = new LinkedList<PlayInterruptAction>();
+
+        // Check condition(s) - USED: Cancel Han's Toolkit on table
+        if (GameConditions.canTargetToCancel(game, self, Filters.Hans_Toolkit)) {
+
+            final PlayInterruptAction action = new PlayInterruptAction(game, self, CardSubtype.USED);
+            // Build action using common utility
+            CancelCardActionBuilder.buildCancelCardAction(action, Filters.Hans_Toolkit, Title.Hans_Toolkit);
+            actions.add(action);
+        }
+        // Check condition(s) - LOST: Cancel Crash Site Memorial on table
+        if (GameConditions.canTargetToCancel(game, self, Filters.Crash_Site_Memorial)) {
+
+            final PlayInterruptAction action = new PlayInterruptAction(game, self, CardSubtype.LOST);
+            // Build action using common utility
+            CancelCardActionBuilder.buildCancelCardAction(action, Filters.Crash_Site_Memorial, Title.Crash_Site_Memorial);
+            actions.add(action);
+        }
+        return actions;
+    }
+}

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set3/dark/Card3_139.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set3/dark/Card3_139.java
@@ -2,21 +2,31 @@ package com.gempukku.swccgo.cards.set3.dark;
 
 import com.gempukku.swccgo.cards.AbstractUsedOrLostInterrupt;
 import com.gempukku.swccgo.cards.GameConditions;
+import com.gempukku.swccgo.cards.effects.CancelTargetingEffect;
 import com.gempukku.swccgo.common.CardSubtype;
 import com.gempukku.swccgo.common.ExpansionSet;
 import com.gempukku.swccgo.common.Icon;
 import com.gempukku.swccgo.common.Rarity;
 import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.TargetingReason;
 import com.gempukku.swccgo.common.Title;
 import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.filters.Filter;
 import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.logic.GameUtils;
 import com.gempukku.swccgo.logic.TriggerConditions;
 import com.gempukku.swccgo.logic.actions.CancelCardActionBuilder;
 import com.gempukku.swccgo.logic.actions.PlayInterruptAction;
+import com.gempukku.swccgo.logic.effects.RespondableEffect;
+import com.gempukku.swccgo.logic.effects.RespondablePlayCardEffect;
+import com.gempukku.swccgo.logic.effects.TargetCardOnTableEffect;
+import com.gempukku.swccgo.logic.timing.Action;
 import com.gempukku.swccgo.logic.timing.Effect;
+import com.gempukku.swccgo.logic.timing.TargetingActionUtils;
 
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -37,6 +47,41 @@ public class Card3_139 extends AbstractUsedOrLostInterrupt {
     @Override
     protected List<PlayInterruptAction> getGameTextOptionalBeforeActions(String playerId, SwccgGame game, Effect effect, PhysicalCard self) {
         List<PlayInterruptAction> actions = new LinkedList<PlayInterruptAction>();
+        String opponent = game.getOpponent(playerId);
+
+        // Check condition(s) - USED: Cancel attempt to place hit starship/vehicle/droid in Used instead of Lost
+        Filter hitStarshipVehicleOrDroid = Filters.and(Filters.or(Filters.starship, Filters.vehicle, Filters.droid), Filters.hit, Filters.canBeTargetedBy(self));
+        List<TargetingReason> targetingReasons = Collections.singletonList(TargetingReason.TO_BE_USED_INSTEAD_OF_LOST);
+        if (TriggerConditions.isTargetedForReason(game, effect, opponent, hitStarshipVehicleOrDroid, targetingReasons)) {
+            final RespondableEffect respondableEffect = (RespondableEffect) effect;
+            final List<PhysicalCard> cardsTargeted = TargetingActionUtils.getCardsTargetedForReason(game, respondableEffect.getTargetingAction(), targetingReasons, hitStarshipVehicleOrDroid);
+            if (!cardsTargeted.isEmpty()) {
+
+                final PlayInterruptAction action = new PlayInterruptAction(game, self, CardSubtype.USED);
+                action.setText("Cancel targeting");
+                // Choose target(s)
+                action.appendTargeting(
+                        new TargetCardOnTableEffect(action, playerId, "Choose hit starship, vehicle, or droid", Filters.in(cardsTargeted)) {
+                            @Override
+                            protected void cardTargeted(final int targetGroupId1, final PhysicalCard cardTargeted) {
+                                action.addAnimationGroup(cardTargeted);
+                                // Allow response(s)
+                                action.allowResponses("Cancel attempt to place " + GameUtils.getCardLink(cardTargeted) + " in Used Pile",
+                                        new RespondablePlayCardEffect(action) {
+                                            @Override
+                                            protected void performActionResults(Action targetingAction) {
+                                                // Perform result(s)
+                                                action.appendEffect(
+                                                        new CancelTargetingEffect(action, respondableEffect));
+                                            }
+                                        }
+                                );
+                            }
+                        }
+                );
+                actions.add(action);
+            }
+        }
 
         // Check condition(s) - USED: Cancel Han's Toolkit being played
         if (TriggerConditions.isPlayingCard(game, effect, Filters.Hans_Toolkit)
@@ -56,10 +101,6 @@ public class Card3_139 extends AbstractUsedOrLostInterrupt {
             CancelCardActionBuilder.buildCancelCardBeingPlayedAction(action, effect);
             actions.add(action);
         }
-        // TODO(Chief/shared engine): USED cancel of attempt to place hit starship/vehicle/droid
-        // in Used Pile instead of Lost Pile needs Chewbacca/WED Techie to emit cancelable targeting
-        // (TargetingReason.TO_BE_USED_INSTEAD_OF_LOST) or PlaceInCardPileInsteadOfLostEffect.
-        // See GitHub #96 / #997 and Gergall Doc plan. Do not implement broad engine here without Chief.
         return actions;
     }
 

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set3/light/Card3_024.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set3/light/Card3_024.java
@@ -8,6 +8,7 @@ import com.gempukku.swccgo.common.Icon;
 import com.gempukku.swccgo.common.ModelType;
 import com.gempukku.swccgo.common.Rarity;
 import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.TargetingReason;
 import com.gempukku.swccgo.common.Uniqueness;
 import com.gempukku.swccgo.filters.Filter;
 import com.gempukku.swccgo.filters.Filters;
@@ -18,8 +19,10 @@ import com.gempukku.swccgo.logic.TriggerConditions;
 import com.gempukku.swccgo.logic.actions.OptionalGameTextTriggerAction;
 import com.gempukku.swccgo.logic.effects.LoseForceEffect;
 import com.gempukku.swccgo.logic.effects.PlaceCardInUsedPileFromTableEffect;
+import com.gempukku.swccgo.logic.effects.RespondableEffect;
+import com.gempukku.swccgo.logic.effects.TargetCardOnTableEffect;
+import com.gempukku.swccgo.logic.timing.Action;
 import com.gempukku.swccgo.logic.timing.EffectResult;
-import com.gempukku.swccgo.logic.timing.PassthruEffect;
 import com.gempukku.swccgo.logic.timing.results.AboutToForfeitCardFromTableResult;
 import com.gempukku.swccgo.logic.timing.results.AboutToLoseCardFromTableResult;
 
@@ -46,6 +49,7 @@ public class Card3_024 extends AbstractDroid {
         Filter starshipOrVehicleFilter = Filters.and(Filters.your(self), Filters.hit, Filters.or(Filters.starship, Filters.vehicle),
                 Filters.or(Filters.atSameOrAdjacentSite(self), Filters.at(Filters.or(Filters.relatedSystem(self), Filters.relatedCloudSector(self)))));
         Filter exteriorPlanetSiteOrDockingBay = Filters.or(Filters.exterior_planet_site, Filters.docking_bay);
+        final TargetingReason targetingReason = TargetingReason.TO_BE_USED_INSTEAD_OF_LOST;
 
         // Check condition(s)
         if (TriggerConditions.isAboutToBeLost(game, effectResult, starshipOrVehicleFilter)
@@ -53,27 +57,40 @@ public class Card3_024 extends AbstractDroid {
                 && GameConditions.isAtLocation(game, self, exteriorPlanetSiteOrDockingBay)) {
             final AboutToLoseCardFromTableResult result = (AboutToLoseCardFromTableResult) effectResult;
             final PhysicalCard cardToBeLost = result.getCardToBeLost();
+            if (GameConditions.canTarget(game, self, targetingReason, cardToBeLost)) {
 
-            final OptionalGameTextTriggerAction action = new OptionalGameTextTriggerAction(self, gameTextSourceCardId);
-            action.setText("Place " + GameUtils.getFullName(cardToBeLost) + " in Used Pile");
-            action.setActionMsg("Place " + GameUtils.getCardLink(cardToBeLost) + " in Used Pile");
-            // Update usage limit(s)
-            action.appendUsage(
-                    new OncePerTurnEffect(action));
-            // Pay cost(s)
-            action.appendCost(
-                    new LoseForceEffect(action, playerId, 1, true));
-            // Perform result(s)
-            action.appendEffect(
-                    new PassthruEffect(action) {
-                        @Override
-                        protected void doPlayEffect(SwccgGame game) {
-                            result.getPreventableCardEffect().preventEffectOnCard(cardToBeLost);
-                            action.appendEffect(
-                                    new PlaceCardInUsedPileFromTableEffect(action, result.getCardToBeLost()));
+                final OptionalGameTextTriggerAction action = new OptionalGameTextTriggerAction(self, gameTextSourceCardId);
+                action.setText("Place " + GameUtils.getFullName(cardToBeLost) + " in Used Pile");
+                // Update usage limit(s)
+                action.appendUsage(
+                        new OncePerTurnEffect(action));
+                // Choose target(s)
+                action.appendTargeting(
+                        new TargetCardOnTableEffect(action, playerId, "Target card to place in Used Pile instead of Lost Pile", targetingReason, cardToBeLost) {
+                            @Override
+                            protected void cardTargeted(final int targetGroupId, PhysicalCard cardTargeted) {
+                                action.addAnimationGroup(cardTargeted);
+                                // Pay cost(s)
+                                action.appendCost(
+                                        new LoseForceEffect(action, playerId, 1, true));
+                                // Allow response(s) - e.g. Turn It Off! Turn It Off!
+                                action.allowResponses("Place " + GameUtils.getCardLink(cardTargeted) + " in Used Pile",
+                                        new RespondableEffect(action) {
+                                            @Override
+                                            protected void performActionResults(Action targetingAction) {
+                                                PhysicalCard finalTarget = action.getPrimaryTargetCard(targetGroupId);
+                                                // Perform result(s)
+                                                result.getPreventableCardEffect().preventEffectOnCard(finalTarget);
+                                                action.appendEffect(
+                                                        new PlaceCardInUsedPileFromTableEffect(action, finalTarget));
+                                            }
+                                        }
+                                );
+                            }
                         }
-                    });
-            return Collections.singletonList(action);
+                );
+                return Collections.singletonList(action);
+            }
         }
         // Check condition(s)
         if (TriggerConditions.isAboutToBeForfeitedToLostPile(game, effectResult, starshipOrVehicleFilter)
@@ -81,25 +98,37 @@ public class Card3_024 extends AbstractDroid {
                 && GameConditions.isAtLocation(game, self, exteriorPlanetSiteOrDockingBay)) {
             final AboutToForfeitCardFromTableResult result = (AboutToForfeitCardFromTableResult) effectResult;
             final PhysicalCard cardToBeForfeited = result.getCardToBeForfeited();
+            if (GameConditions.canTarget(game, self, targetingReason, cardToBeForfeited)) {
 
-            final OptionalGameTextTriggerAction action = new OptionalGameTextTriggerAction(self, gameTextSourceCardId);
-            action.setText("Place " + GameUtils.getFullName(cardToBeForfeited) + " in Used Pile");
-            action.setActionMsg("Place " + GameUtils.getCardLink(cardToBeForfeited) + " in Used Pile when forfeited");
-            // Update usage limit(s)
-            action.appendUsage(
-                    new OncePerTurnEffect(action));
-            // Pay cost(s)
-            action.appendCost(
-                    new LoseForceEffect(action, playerId, 1, true));
-            // Perform result(s)
-            action.appendEffect(
-                    new PassthruEffect(action) {
-                        @Override
-                        protected void doPlayEffect(SwccgGame game) {
-                            result.getForfeitCardEffect().setForfeitToUsedPile();
+                final OptionalGameTextTriggerAction action = new OptionalGameTextTriggerAction(self, gameTextSourceCardId);
+                action.setText("Place " + GameUtils.getFullName(cardToBeForfeited) + " in Used Pile");
+                // Update usage limit(s)
+                action.appendUsage(
+                        new OncePerTurnEffect(action));
+                // Choose target(s)
+                action.appendTargeting(
+                        new TargetCardOnTableEffect(action, playerId, "Target card to place in Used Pile instead of Lost Pile", targetingReason, cardToBeForfeited) {
+                            @Override
+                            protected void cardTargeted(final int targetGroupId, PhysicalCard cardTargeted) {
+                                action.addAnimationGroup(cardTargeted);
+                                // Pay cost(s)
+                                action.appendCost(
+                                        new LoseForceEffect(action, playerId, 1, true));
+                                // Allow response(s) - e.g. Turn It Off! Turn It Off!
+                                action.allowResponses("Place " + GameUtils.getCardLink(cardTargeted) + " in Used Pile when forfeited",
+                                        new RespondableEffect(action) {
+                                            @Override
+                                            protected void performActionResults(Action targetingAction) {
+                                                // Perform result(s)
+                                                result.getForfeitCardEffect().setForfeitToUsedPile();
+                                            }
+                                        }
+                                );
+                            }
                         }
-                    });
-            return Collections.singletonList(action);
+                );
+                return Collections.singletonList(action);
+            }
         }
         return null;
     }

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
@@ -90800,7 +90800,35 @@
       "PROTOCOL"
     ]
   },
-  {
+    {
+    "cardId": "3_139",
+    "title": "Turn It Off! Turn It Off!",
+    "slug": "turn-it-off-turn-it-off",
+    "slugWithSetName": "turn-it-off-turn-it-off-hoth",
+    "side": "DARK",
+    "uniqueness": "UNRESTRICTED",
+    "expansionSet": "HOTH",
+    "rarity": "C1",
+    "cardCategory": "INTERRUPT",
+    "cardTypes": [
+      "INTERRUPT"
+    ],
+    "cardSubtype": "USED_OR_LOST",
+    "lore": "'Turn it off! Turn it off! Off! TURN IT OFF!'",
+    "gameText": "USED: Cancel any attempt to place a 'hit' starship, vehicle or droid in the Used Pile rather than the Lost Pile. OR Cancel Han's Toolkit. LOST: Cancel Crash Site Memorial.",
+    "destiny": 5,
+    "icons": [
+      {
+        "icon": "HOTH",
+        "count": 1
+      },
+      {
+        "icon": "INTERRUPT",
+        "count": 1
+      }
+    ]
+  },
+{
     "cardId": "3_140",
     "title": "Walker Barrage",
     "slug": "walker-barrage",

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_dark.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_dark.json
@@ -44142,7 +44142,35 @@
       }
     ]
   },
-  {
+    {
+    "cardId": "3_139",
+    "title": "Turn It Off! Turn It Off!",
+    "slug": "turn-it-off-turn-it-off",
+    "slugWithSetName": "turn-it-off-turn-it-off-hoth",
+    "side": "DARK",
+    "uniqueness": "UNRESTRICTED",
+    "expansionSet": "HOTH",
+    "rarity": "C1",
+    "cardCategory": "INTERRUPT",
+    "cardTypes": [
+      "INTERRUPT"
+    ],
+    "cardSubtype": "USED_OR_LOST",
+    "lore": "'Turn it off! Turn it off! Off! TURN IT OFF!'",
+    "gameText": "USED: Cancel any attempt to place a 'hit' starship, vehicle or droid in the Used Pile rather than the Lost Pile. OR Cancel Han's Toolkit. LOST: Cancel Crash Site Memorial.",
+    "destiny": 5,
+    "icons": [
+      {
+        "icon": "HOTH",
+        "count": 1
+      },
+      {
+        "icon": "INTERRUPT",
+        "count": 1
+      }
+    ]
+  },
+{
     "cardId": "3_140",
     "title": "Walker Barrage",
     "slug": "walker-barrage",

--- a/src/gemp-swccg-common/src/main/java/com/gempukku/swccgo/common/TargetingReason.java
+++ b/src/gemp-swccg-common/src/main/java/com/gempukku/swccgo/common/TargetingReason.java
@@ -28,6 +28,7 @@ public enum TargetingReason {
     TO_BE_STOLEN("to be stolen"),
     TO_BE_STOLEN_EVEN_IF_CARDS_ABOARD("to be stolen"),
     TO_BE_SUSPENDED("to be suspended"),
+    TO_BE_USED_INSTEAD_OF_LOST("to be placed in Used Pile instead of Lost Pile"),
     TO_BE_TORTURED("to be tortured"),
     TO_BE_TRANSFERRED_TO("to be transferred to"),
     TO_RELOCATE_STARDUST_TO("to relocate Stardust to");

--- a/src/gemp-swccg-common/src/main/java/com/gempukku/swccgo/common/Title.java
+++ b/src/gemp-swccg-common/src/main/java/com/gempukku/swccgo/common/Title.java
@@ -1226,6 +1226,7 @@ public interface Title {
     String Trooper_Assault = "Trooper Assault";
     String Trooper_Charge = "Trooper Charge";
     String Tunnel_Vision = "Tunnel Vision";
+    String Turn_It_Off_Turn_It_Off = "Turn It Off! Turn It Off!";
     String Turbolaser_Battery = "Turbolaser Battery";
     String Tuanul_Village = "Jakku: Tuanul Village";
     String Tusken_Breath_Mask = "Tusken Breath Mask";

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
@@ -19503,6 +19503,7 @@ public class Filters {
     public static final Filter trade_agenda = Filters.agenda(Agenda.TRADE);
     public static final Filter Trade_Federation_starfighter = Filters.and(Icon.TRADE_FEDERATION, CardSubtype.STARFIGHTER);
     public static final Filter Trample = Filters.title(Title.Trample);
+    public static final Filter Turn_It_Off_Turn_It_Off = Filters.title(Title.Turn_It_Off_Turn_It_Off);
     public static final Filter Trandoshan = Filters.species(Species.TRANDOSHAN);
     public static final Filter transport = Filters.and(CardType.STARSHIP, Filters.or(Keyword.TRANSPORT_SHIP, ModelType.BYBLOS_G1A_TRANSPORT, ModelType.KOMRK_CLASS_FIGHTER_TRANSPORT, ModelType.MODIFIED_TRANSPORT, ModelType.OUBLIETTE_CLASS_TRANSPORT, ModelType.RESISTANCE_TRANSPORT, ModelType.TRANSPORT, ModelType.WTK_85A_INTERSTELLAR_TRANSPORT, ModelType.ZETA_CLASS_TRANSPORT, ModelType.Y_45_ARMORED_TRANSPORT));
     public static final Filter transport_vehicle = Filters.and(CardType.VEHICLE, CardSubtype.TRANSPORT);

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/light/Card_2_003_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/light/Card_2_003_Tests.java
@@ -142,12 +142,11 @@ public class Card_2_003_Tests {
         assertTrue(scn.AwaitingLSBattleDamagePayment());
         scn.LSChooseCard(c3p0);
 
-            //automatic send to used pile action carried out
-        assertTrue(scn.DSDecisionAvailable("FORFEITED_TO_USED_PILE_FROM_TABLE")); //FORFEITED_TO_USED_PILE_FROM_TABLE - Optional responses
+        // Chewie targets hit card for Used instead of Lost (cancelable window)
         scn.PassAllResponses();
 
-        assertTrue(scn.AwaitingLSBattleDamagePayment());
         assertEquals(Zone.TOP_OF_USED_PILE, c3p0.getZone());
+        assertTrue(scn.AwaitingLSBattleDamagePayment());
     }
 
     @Test
@@ -279,10 +278,7 @@ public class Card_2_003_Tests {
         scn.LSPass();
 
         assertTrue(c3p0.isHit());
-        assertTrue(scn.DSDecisionAvailable("ABOUT_TO_BE_LOST_FROM_TABLE"));
-        scn.DSPass(); //ABOUT_TO_BE_LOST_FROM_TABLE - Optional responses
-
-            //automatic send to used pile action should be carried out here
+        // Chewie required Used-instead-of-Lost targeting resolves during about-to-be-lost
         scn.PassAllResponses();
 
         assertTrue(scn.AwaitingLSWeaponsSegmentActions());

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/light/Card_2_003_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/light/Card_2_003_Tests.java
@@ -13,7 +13,6 @@ import com.gempukku.swccgo.common.Uniqueness;
 import com.gempukku.swccgo.common.Zone;
 import com.gempukku.swccgo.framework.StartingSetup;
 import com.gempukku.swccgo.framework.VirtualTableScenario;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -151,7 +150,7 @@ public class Card_2_003_Tests {
         assertEquals(Zone.TOP_OF_USED_PILE, c3p0.getZone());
     }
 
-    @Test @Ignore
+    @Test
     public void ChewbaccaSendsDroidHitAndLostInBattleToUsedPile() {
         var scn = GetScenario();
 
@@ -234,7 +233,7 @@ public class Card_2_003_Tests {
         assertEquals(Zone.TOP_OF_USED_PILE, c3p0.getZone());
     }
 
-    @Test @Ignore
+    @Test
     public void ChewbaccaSendsDroidHitAndExcludedInBattleToUsedPile() {
         var scn = GetScenario();
 

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set3/dark/Card_3_139_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set3/dark/Card_3_139_Tests.java
@@ -106,7 +106,7 @@ public class Card_3_139_Tests {
         scn.DSChooseCard(toolkit);
         scn.PassAllResponses();
 
-        assertEquals(Zone.LOST_PILE, toolkit.getZone());
+        assertEquals(Zone.TOP_OF_LOST_PILE, toolkit.getZone());
     }
 
     @Test
@@ -129,7 +129,7 @@ public class Card_3_139_Tests {
         scn.DSChooseCard(crash);
         scn.PassAllResponses();
 
-        assertEquals(Zone.LOST_PILE, crash.getZone());
+        assertEquals(Zone.TOP_OF_LOST_PILE, crash.getZone());
     }
 
     @Test
@@ -154,7 +154,7 @@ public class Card_3_139_Tests {
         scn.DSPlayCard(tio);
         scn.DSChooseCard(toolkit);
         scn.PassAllResponses();
-        assertEquals(Zone.LOST_PILE, toolkit.getZone());
+        assertEquals(Zone.TOP_OF_LOST_PILE, toolkit.getZone());
 
         scn.MoveCardsToLSSideOfTable(crash);
 
@@ -163,6 +163,6 @@ public class Card_3_139_Tests {
         assertTrue(scn.DSHasCardChoiceAvailable(crash));
         scn.DSChooseCard(crash);
         scn.PassAllResponses();
-        assertEquals(Zone.LOST_PILE, crash.getZone());
+        assertEquals(Zone.TOP_OF_LOST_PILE, crash.getZone());
     }
 }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set3/dark/Card_3_139_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set3/dark/Card_3_139_Tests.java
@@ -28,10 +28,13 @@ public class Card_3_139_Tests {
                     put("toolkit", "4_010");
                     put("crash", "1_045");
                     put("han", "1_011");
+                    put("chewie", "2_003");
+                    put("c3p0", "1_005");
                 }},
                 new HashMap<>() {{
                     put("tio", "3_139");
                     put("tio2", "3_139");
+                    put("eppVader", "108_006");
                 }},
                 10,
                 10,
@@ -175,5 +178,50 @@ public class Card_3_139_Tests {
         scn.DSChooseCard(crash);
         scn.PassAllResponses();
         assertEquals(Zone.TOP_OF_LOST_PILE, crash.getZone());
+    }
+
+    @Test
+    public void TurnItOffTurnItOffCancelsChewieHitDroidToUsedPile() {
+        var scn = GetScenario();
+
+        var tio = scn.GetDSCard("tio");
+        var eppVader = scn.GetDSCard("eppVader");
+        var chewie = scn.GetLSCard("chewie");
+        var c3p0 = scn.GetLSCard("c3p0");
+        var site = scn.GetLSStartingLocation();
+
+        scn.StartGame();
+
+        scn.MoveCardsToDSHand(tio);
+        scn.MoveCardsToLocation(site, eppVader, chewie, c3p0);
+
+        scn.SkipToPhase(Phase.BATTLE);
+        scn.PrepareDSDestiny(6); // for hit
+        scn.PrepareDSDestiny(7);
+        scn.PrepareDSDestiny(5); // for destiny so dark wins
+
+        scn.DSInitiateBattle(site);
+        scn.PassAllResponses();
+
+        scn.DSUseCardAction(eppVader);
+        scn.DSChooseCard(c3p0);
+        scn.PassAllResponses();
+        assertTrue(c3p0.isHit());
+
+        scn.SkipToEndOfPowerSegment(true);
+        scn.PassAllResponses();
+        assertTrue(scn.AwaitingLSBattleDamagePayment());
+        scn.LSChooseCard(c3p0);
+
+        // Chewie targets C-3PO to go to Used instead of Lost - Turn It Off cancels that targeting
+        assertTrue(scn.DSCardPlayAvailable(tio));
+        scn.DSPlayCard(tio);
+        assertTrue(scn.DSHasCardChoiceAvailable(c3p0));
+        scn.DSChooseCard(c3p0);
+        scn.PassAllResponses();
+
+        // With Used placement canceled, the hit droid is forfeited to Lost Pile
+        scn.PassAllResponses();
+        assertEquals(Zone.TOP_OF_LOST_PILE, c3p0.getZone());
     }
 }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set3/dark/Card_3_139_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set3/dark/Card_3_139_Tests.java
@@ -148,19 +148,22 @@ public class Card_3_139_Tests {
         scn.MoveCardsToDSHand(tio, tio2);
         scn.MoveCardsToLocation(site, han);
         scn.AttachCardsTo(han, toolkit);
+        scn.MoveCardsToLSSideOfTable(crash);
 
         scn.SkipToPhase(Phase.CONTROL);
+        assertTrue(scn.AwaitingDSControlPhaseActions());
 
+        // Both cancel actions available; choose Toolkit first (USED).
+        assertTrue(scn.DSCardPlayAvailable(tio));
         scn.DSPlayCard(tio);
+        scn.DSChooseAction("Cancel Han's Toolkit");
         scn.DSChooseCard(toolkit);
         scn.PassAllResponses();
         assertEquals(Zone.TOP_OF_LOST_PILE, toolkit.getZone());
 
-        scn.MoveCardsToLSSideOfTable(crash);
-
+        assertTrue(scn.AwaitingDSControlPhaseActions());
         assertTrue(scn.DSCardPlayAvailable(tio2));
         scn.DSPlayCard(tio2);
-        assertTrue(scn.DSHasCardChoiceAvailable(crash));
         scn.DSChooseCard(crash);
         scn.PassAllResponses();
         assertEquals(Zone.TOP_OF_LOST_PILE, crash.getZone());

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set3/dark/Card_3_139_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set3/dark/Card_3_139_Tests.java
@@ -1,0 +1,168 @@
+package com.gempukku.swccgo.cards.set3.dark;
+
+import com.gempukku.swccgo.common.CardSubtype;
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Card_3_139_Tests {
+
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("toolkit", "4_010");
+                    put("crash", "1_045");
+                    put("han", "1_011");
+                }},
+                new HashMap<>() {{
+                    put("tio", "3_139");
+                    put("tio2", "3_139");
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void TurnItOffTurnItOffStatsAndKeywordsAreCorrect() {
+        /**
+         * Title: Turn It Off! Turn It Off!
+         * Uniqueness: Unrestricted
+         * Side: Dark
+         * Type: Interrupt
+         * Subtype: Used Or Lost
+         * Destiny: 5
+         * Icons: Hoth
+         * Game Text: USED: Cancel any attempt to place a 'hit' starship, vehicle or droid in the Used Pile rather than
+         *         the Lost Pile. OR Cancel Han's Toolkit. LOST: Cancel Crash Site Memorial.
+         * Lore: 'Turn it off! Turn it off! Off! TURN IT OFF!'
+         * Set: Hoth
+         * Rarity: C1
+         */
+
+        var scn = GetScenario();
+
+        var card = scn.GetDSCard("tio").getBlueprint();
+
+        assertEquals("Turn It Off! Turn It Off!", card.getTitle());
+        assertFalse(card.hasVirtualSuffix());
+        assertEquals(Uniqueness.UNRESTRICTED, card.getUniqueness());
+        assertEquals(Side.DARK, card.getSide());
+        scn.BlueprintCardTypeCheck(card, new ArrayList<>() {{
+            add(CardType.INTERRUPT);
+        }});
+        assertEquals(CardSubtype.USED_OR_LOST, card.getCardSubtype());
+        assertEquals(5, card.getDestiny(), scn.epsilon);
+        scn.BlueprintIconCheck(card, new ArrayList<>() {{
+            add(Icon.INTERRUPT);
+            add(Icon.HOTH);
+        }});
+        assertEquals(ExpansionSet.HOTH, card.getExpansionSet());
+        assertEquals(Rarity.C1, card.getRarity());
+    }
+
+    @Test
+    public void TurnItOffTurnItOffCancelsHansToolkitOnTable() {
+        var scn = GetScenario();
+
+        var tio = scn.GetDSCard("tio");
+        var toolkit = scn.GetLSCard("toolkit");
+        var han = scn.GetLSCard("han");
+        var site = scn.GetLSStartingLocation();
+
+        scn.StartGame();
+
+        scn.MoveCardsToDSHand(tio);
+        scn.MoveCardsToLocation(site, han);
+        scn.AttachCardsTo(han, toolkit);
+
+        scn.SkipToPhase(Phase.CONTROL);
+
+        assertTrue(scn.DSCardPlayAvailable(tio));
+        scn.DSPlayCard(tio);
+        assertTrue(scn.DSHasCardChoiceAvailable(toolkit));
+        scn.DSChooseCard(toolkit);
+        scn.PassAllResponses();
+
+        assertEquals(Zone.LOST_PILE, toolkit.getZone());
+    }
+
+    @Test
+    public void TurnItOffTurnItOffCancelsCrashSiteMemorialOnTable() {
+        var scn = GetScenario();
+
+        var tio = scn.GetDSCard("tio");
+        var crash = scn.GetLSCard("crash");
+
+        scn.StartGame();
+
+        scn.MoveCardsToDSHand(tio);
+        scn.MoveCardsToLSSideOfTable(crash);
+
+        scn.SkipToPhase(Phase.CONTROL);
+
+        assertTrue(scn.DSCardPlayAvailable(tio));
+        scn.DSPlayCard(tio);
+        assertTrue(scn.DSHasCardChoiceAvailable(crash));
+        scn.DSChooseCard(crash);
+        scn.PassAllResponses();
+
+        assertEquals(Zone.LOST_PILE, crash.getZone());
+    }
+
+    @Test
+    public void TurnItOffTurnItOffCanPlayMultipleCopiesSameTurn() {
+        var scn = GetScenario();
+
+        var tio = scn.GetDSCard("tio");
+        var tio2 = scn.GetDSCard("tio2");
+        var toolkit = scn.GetLSCard("toolkit");
+        var crash = scn.GetLSCard("crash");
+        var han = scn.GetLSCard("han");
+        var site = scn.GetLSStartingLocation();
+
+        scn.StartGame();
+
+        scn.MoveCardsToDSHand(tio, tio2);
+        scn.MoveCardsToLocation(site, han);
+        scn.AttachCardsTo(han, toolkit);
+
+        scn.SkipToPhase(Phase.CONTROL);
+
+        scn.DSPlayCard(tio);
+        scn.DSChooseCard(toolkit);
+        scn.PassAllResponses();
+        assertEquals(Zone.LOST_PILE, toolkit.getZone());
+
+        scn.MoveCardsToLSSideOfTable(crash);
+
+        assertTrue(scn.DSCardPlayAvailable(tio2));
+        scn.DSPlayCard(tio2);
+        assertTrue(scn.DSHasCardChoiceAvailable(crash));
+        scn.DSChooseCard(crash);
+        scn.PassAllResponses();
+        assertEquals(Zone.LOST_PILE, crash.getZone());
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set3/dark/Card_3_139_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set3/dark/Card_3_139_Tests.java
@@ -153,15 +153,25 @@ public class Card_3_139_Tests {
         scn.SkipToPhase(Phase.CONTROL);
         assertTrue(scn.AwaitingDSControlPhaseActions());
 
+        // Both copies offer both cancel modes in the same turn.
         assertTrue(scn.DSCardPlayAvailable(tio, "Cancel Han's Toolkit"));
+        assertTrue(scn.DSCardPlayAvailable(tio, "Cancel Crash Site Memorial"));
+        assertTrue(scn.DSCardPlayAvailable(tio2, "Cancel Han's Toolkit"));
+        assertTrue(scn.DSCardPlayAvailable(tio2, "Cancel Crash Site Memorial"));
+
         scn.DSPlayCard(tio, "Cancel Han's Toolkit");
         scn.DSChooseCard(toolkit);
         scn.PassAllResponses();
         assertEquals(Zone.TOP_OF_LOST_PILE, toolkit.getZone());
 
+        // Second copy can still cancel Crash Site Memorial after the first resolve.
+        if (!scn.AwaitingDSControlPhaseActions()) {
+            scn.LSPass();
+        }
         assertTrue(scn.AwaitingDSControlPhaseActions());
-        assertTrue(scn.DSCardPlayAvailable(tio2, "Cancel Crash Site Memorial"));
-        scn.DSPlayCard(tio2, "Cancel Crash Site Memorial");
+        assertTrue(scn.DSCardPlayAvailable(tio2));
+        scn.DSPlayCard(tio2);
+        assertTrue(scn.DSHasCardChoiceAvailable(crash));
         scn.DSChooseCard(crash);
         scn.PassAllResponses();
         assertEquals(Zone.TOP_OF_LOST_PILE, crash.getZone());

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set3/dark/Card_3_139_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set3/dark/Card_3_139_Tests.java
@@ -153,17 +153,15 @@ public class Card_3_139_Tests {
         scn.SkipToPhase(Phase.CONTROL);
         assertTrue(scn.AwaitingDSControlPhaseActions());
 
-        // Both cancel actions available; choose Toolkit first (USED).
-        assertTrue(scn.DSCardPlayAvailable(tio));
-        scn.DSPlayCard(tio);
-        scn.DSChooseAction("Cancel Han's Toolkit");
+        assertTrue(scn.DSCardPlayAvailable(tio, "Cancel Han's Toolkit"));
+        scn.DSPlayCard(tio, "Cancel Han's Toolkit");
         scn.DSChooseCard(toolkit);
         scn.PassAllResponses();
         assertEquals(Zone.TOP_OF_LOST_PILE, toolkit.getZone());
 
         assertTrue(scn.AwaitingDSControlPhaseActions());
-        assertTrue(scn.DSCardPlayAvailable(tio2));
-        scn.DSPlayCard(tio2);
+        assertTrue(scn.DSCardPlayAvailable(tio2, "Cancel Crash Site Memorial"));
+        scn.DSPlayCard(tio2, "Cancel Crash Site Memorial");
         scn.DSChooseCard(crash);
         scn.PassAllResponses();
         assertEquals(Zone.TOP_OF_LOST_PILE, crash.getZone());


### PR DESCRIPTION
## Summary
Implements **Turn It Off! Turn It Off!** (Hoth `3_139`).

- **USED**: cancel an attempt to place a hit starship, vehicle, or droid in Used instead of Lost (`TargetingReason.TO_BE_USED_INSTEAD_OF_LOST` from Chewbacca / WED-1016; Droid Shutdown-style cancel)
- **USED**: cancel Han's Toolkit (on table or being played)
- **LOST**: cancel Crash Site Memorial (on table or being played)
- Adds `TO_BE_USED_INSTEAD_OF_LOST` targeting so Chewie/WED redirects are cancelable
- SpotOverride for excluded-from-battle hit units so Chewie can still redirect them to Used

Closes #997.

## Test plan
- [x] `Card_3_139_Tests` + `Card_2_003_Tests` — **10/10**
- [x] VHD: stats/keywords for 3_139
- [x] VHD: cancel Han's Toolkit on table / being played
- [x] VHD: cancel Crash Site Memorial on table / being played
- [x] VHD: multiple copies same turn (Toolkit then Crash)
- [x] VHD: Chewie forfeit-to-Used still works when Turn It Off is not played
- [x] VHD: Chewie hit+lost / hit+excluded go to Used
- [x] VHD: Turn It Off USED cancel of Chewie Used placement (hit card ends in Lost)
- Tip: `777fe2f`