### PR TITLE
Add Descent Into The Dark (4_20)

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set4/light/Card4_020.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set4/light/Card4_020.java
@@ -98,6 +98,10 @@ public class Card4_020 extends AbstractImmediateEffect {
      * Covers from-table, from-off-table (including played Used Interrupts), and forfeit-to-Used.
      */
     private boolean justPlacedCardInAUsedPile(SwccgGame game, EffectResult effectResult) {
+        // Using Force places the top Force Pile card into Used Pile (emits FORCE_USED, not PutInUsedPile).
+        if (effectResult.getType() == EffectResult.Type.FORCE_USED) {
+            return true;
+        }
         if (TriggerConditions.justPlacedInUsedPileFromTable(game, effectResult, Filters.any)) {
             return true;
         }

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set4/light/Card4_020.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set4/light/Card4_020.java
@@ -1,0 +1,117 @@
+package com.gempukku.swccgo.cards.set4.light;
+
+import com.gempukku.swccgo.cards.AbstractImmediateEffect;
+import com.gempukku.swccgo.cards.GameConditions;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.GameTextActionId;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.PlayCardZoneOption;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.TriggerConditions;
+import com.gempukku.swccgo.logic.actions.PlayCardAction;
+import com.gempukku.swccgo.logic.actions.RequiredGameTextTriggerAction;
+import com.gempukku.swccgo.logic.effects.CancelCardOnTableEffect;
+import com.gempukku.swccgo.logic.effects.RecirculateEffect;
+import com.gempukku.swccgo.logic.timing.EffectResult;
+import com.gempukku.swccgo.logic.timing.results.ForfeitedCardToUsedPileFromTableResult;
+import com.gempukku.swccgo.logic.timing.results.PutCardInCardPileFromOffTableResult;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Set: Dagobah
+ * Type: Effect
+ * Subtype: Immediate
+ * Title: Descent Into The Dark
+ */
+public class Card4_020 extends AbstractImmediateEffect {
+    public Card4_020() {
+        super(Side.LIGHT, 4, PlayCardZoneOption.YOUR_SIDE_OF_TABLE, Title.Descent_Into_The_Dark, Uniqueness.UNIQUE, ExpansionSet.DAGOBAH, Rarity.R);
+        setLore("Jedi training is a journey into the depths of an apprentice's subconscious, where one must learn to use the Force wisely. \"A Jedi's strength flows from the Force.\"");
+        setGameText("During your turn, if either player just placed a card in a Used Pile, deploy on table. All Used Piles are immediately re-circulated. When any player places one or more cards in a Used Pile, Immediate Effect canceled.");
+        addIcons(Icon.DAGOBAH);
+    }
+
+    @Override
+    protected List<PlayCardAction> getGameTextOptionalAfterActions(final String playerId, SwccgGame game, EffectResult effectResult, final PhysicalCard self, int gameTextSourceCardId) {
+        // Check condition(s)
+        if (GameConditions.isDuringYourTurn(game, playerId)
+                && justPlacedCardInAUsedPile(game, effectResult)) {
+
+            PlayCardAction action = getPlayCardAction(playerId, game, self, self, false, 0, null, null, null, null, null, false, 0, null, null);
+            if (action != null) {
+                return Collections.singletonList(action);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    protected List<RequiredGameTextTriggerAction> getGameTextRequiredAfterTriggers(SwccgGame game, EffectResult effectResult, final PhysicalCard self, int gameTextSourceCardId) {
+        List<RequiredGameTextTriggerAction> actions = new LinkedList<RequiredGameTextTriggerAction>();
+
+        String playerId = self.getOwner();
+        String opponent = game.getOpponent(playerId);
+
+        // Check condition(s) - on deploy, recirculate all Used Piles
+        if (TriggerConditions.justDeployed(game, effectResult, self)) {
+            RequiredGameTextTriggerAction action = new RequiredGameTextTriggerAction(self, gameTextSourceCardId, GameTextActionId.OTHER_CARD_ACTION_1);
+            action.setText("Re-circulate Used Piles");
+            action.setActionMsg("Re-circulate all Used Piles");
+            // Perform result(s)
+            action.appendEffect(
+                    new RecirculateEffect(action, playerId));
+            action.appendEffect(
+                    new RecirculateEffect(action, opponent));
+            actions.add(action);
+        }
+
+        // Check condition(s) - cancel when any player places one or more cards in a Used Pile
+        if (justPlacedCardInAUsedPile(game, effectResult)
+                && GameConditions.canBeCanceled(game, self)) {
+
+            RequiredGameTextTriggerAction action = new RequiredGameTextTriggerAction(self, gameTextSourceCardId, GameTextActionId.OTHER_CARD_ACTION_2);
+            action.setSingletonTrigger(true);
+            action.setText("Cancel");
+            action.setActionMsg("Cancel " + GameUtils.getCardLink(self));
+            // Perform result(s)
+            action.appendEffect(
+                    new CancelCardOnTableEffect(action, self));
+            actions.add(action);
+        }
+
+        return actions;
+    }
+
+    /**
+     * Card-local Used Pile placement check (does not broaden shared TriggerConditions).
+     * Covers from-table, from-off-table (including played Used Interrupts), and forfeit-to-Used.
+     */
+    private boolean justPlacedCardInAUsedPile(SwccgGame game, EffectResult effectResult) {
+        if (TriggerConditions.justPlacedInUsedPileFromTable(game, effectResult, Filters.any)) {
+            return true;
+        }
+        if (effectResult.getType() == EffectResult.Type.FORFEITED_TO_USED_PILE_FROM_TABLE) {
+            PhysicalCard card = ((ForfeitedCardToUsedPileFromTableResult) effectResult).getCard();
+            return card != null && GameUtils.getZoneFromZoneTop(card.getZone()) == Zone.USED_PILE;
+        }
+        if (effectResult.getType() == EffectResult.Type.PUT_IN_CARD_PILE_FROM_OFF_TABLE) {
+            PutCardInCardPileFromOffTableResult result = (PutCardInCardPileFromOffTableResult) effectResult;
+            if (result.getCardPile() == Zone.USED_PILE) {
+                PhysicalCard card = result.getCard();
+                return card != null && GameUtils.getZoneFromZoneTop(card.getZone()) == Zone.USED_PILE;
+            }
+        }
+        return false;
+    }
+}

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
@@ -97982,6 +97982,34 @@
     ]
   },
   {
+    "cardId": "4_20",
+    "title": "Descent Into The Dark",
+    "slug": "descent-into-the-dark",
+    "slugWithSetName": "descent-into-the-dark-dagobah",
+    "side": "LIGHT",
+    "uniqueness": "UNIQUE",
+    "expansionSet": "DAGOBAH",
+    "rarity": "R",
+    "cardCategory": "EFFECT",
+    "cardTypes": [
+      "EFFECT"
+    ],
+    "cardSubtype": "IMMEDIATE",
+    "lore": "Jedi training is a journey into the depths of an apprentice's subconscious, where one must learn to use the Force wisely. \"A Jedi's strength flows from the Force.\"",
+    "gameText": "During your turn, if either player just placed a card in a Used Pile, deploy on table. All Used Piles are immediately re-circulated. When any player places one or more cards in a Used Pile, Immediate Effect canceled.",
+    "destiny": 4,
+    "icons": [
+      {
+        "icon": "DAGOBAH",
+        "count": 1
+      },
+      {
+        "icon": "EFFECT",
+        "count": 1
+      }
+    ]
+  },
+  {
     "cardId": "4_21",
     "title": "Do, Or Do Not",
     "slug": "do-or-do-not",

--- a/src/gemp-swccg-common/src/main/java/com/gempukku/swccgo/common/Title.java
+++ b/src/gemp-swccg-common/src/main/java/com/gempukku/swccgo/common/Title.java
@@ -314,6 +314,7 @@ public interface Title {
     String Den_Of_Thieves = "Den Of Thieves";
     String Dengars_Blaster_Carbine =  "Dengar's Blaster Carbine";
     String Derlin = "Major Bren Derlin";
+    String Descent_Into_The_Dark = "Descent Into The Dark";
     String Desert_Heart = "Tatooine: Desert Heart";
     String Desert_Landing_Site = "Tatooine: Desert Landing Site";
     String Despair = "Despair";

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
@@ -18227,6 +18227,7 @@ public class Filters {
     public static final Filter Deploys_at_Yavin_4 = Filters.or(Filters.placeToBePresentOnPlanet(Title.Yavin_4), Filters.locationAndCardsAtLocation(Filters.title(Title.Yavin_4)));
     public static final Filter Deploys_on_Yavin_4 = Filters.placeToBePresentOnPlanet(Title.Yavin_4);
     public static final Filter Derlin = Filters.title(Title.Derlin);
+    public static final Filter Descent_Into_The_Dark = Filters.title(Title.Descent_Into_The_Dark);
     public static final Filter desert = Filters.keyword(Keyword.DESERT);
     public static final Filter Desert_Heart = Filters.title(Title.Desert_Heart);
     public static final Filter Desert_Landing_Site = Filters.title(Title.Desert_Landing_Site);

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set4/light/Card_4_20_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set4/light/Card_4_20_Tests.java
@@ -1,0 +1,188 @@
+package com.gempukku.swccgo.cards.set4.light;
+
+import com.gempukku.swccgo.common.CardSubtype;
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Keyword;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Card_4_20_Tests {
+
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("descent", "4_20");
+                    put("luke", "1_019"); // deploy 5 - uses Force into Used
+                    put("leia", "1_017"); // deploy 4 - second Force use for cancel
+                    put("han", "1_011"); // presence
+                }},
+                new HashMap<>() {{
+                    put("viper", "1_282");
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void DescentIntoTheDarkStatsAndKeywordsAreCorrect() {
+        /**
+         * Title: Descent Into The Dark
+         * Uniqueness: Unique
+         * Side: Light
+         * Type: Effect
+         * Subtype: Immediate
+         * Destiny: 4
+         * Icons: Dagobah, Effect
+         * Game Text: During your turn, if either player just placed a card in a Used Pile, deploy on table.
+         *         All Used Piles are immediately re-circulated. When any player places one or more cards in a
+         *         Used Pile, Immediate Effect canceled.
+         * Lore: Jedi training is a journey into the depths of an apprentice's subconscious, where one must learn
+         *         to use the Force wisely. "A Jedi's strength flows from the Force."
+         * Set: Dagobah
+         * Rarity: R
+         */
+
+        var scn = GetScenario();
+
+        var card = scn.GetLSCard("descent").getBlueprint();
+
+        assertEquals("Descent Into The Dark", card.getTitle());
+        assertFalse(card.hasVirtualSuffix());
+        assertEquals(Uniqueness.UNIQUE, card.getUniqueness());
+        assertEquals(Side.LIGHT, card.getSide());
+        scn.BlueprintCardTypeCheck(card, new ArrayList<>() {{
+            add(CardType.EFFECT);
+        }});
+        assertEquals(CardSubtype.IMMEDIATE, card.getCardSubtype());
+        assertEquals(4, card.getDestiny(), scn.epsilon);
+        scn.BlueprintIconCheck(card, new ArrayList<>() {{
+            add(Icon.DAGOBAH);
+            add(Icon.EFFECT);
+        }});
+        scn.BlueprintKeywordCheck(card, new ArrayList<Keyword>() {{
+        }});
+        assertEquals(ExpansionSet.DAGOBAH, card.getExpansionSet());
+        assertEquals(Rarity.R, card.getRarity());
+    }
+
+    @Test
+    public void DescentIntoTheDarkDeploysDuringYourTurnWhenCardPlacedInUsedPileAndRecirculates() {
+        var scn = GetScenario();
+
+        var descent = scn.GetLSCard("descent");
+        var luke = scn.GetLSCard("luke");
+        var site = scn.GetLSStartingLocation();
+
+        scn.StartGame();
+
+        scn.MoveCardsToLSHand(descent, luke);
+        // Seed some Used Pile cards so recirculate is observable
+        scn.MoveCardsToTopOfLSUsedPile(scn.GetTopOfLSReserveDeck());
+        scn.MoveCardsToTopOfDSUsedPile(scn.GetTopOfDSReserveDeck());
+
+        // Presence so Luke can deploy
+        scn.MoveCardsToLocation(site, scn.GetLSCard("leia"));
+
+        scn.SkipToLSTurn(Phase.DEPLOY);
+
+        int lsUsedBeforeDeploy = scn.GetLSUsedPileCount();
+        int dsUsedBeforeDeploy = scn.GetDSUsedPileCount();
+        assertTrue(lsUsedBeforeDeploy >= 1);
+        assertTrue(dsUsedBeforeDeploy >= 1);
+
+        assertTrue(scn.LSDeployAvailable(luke));
+        scn.LSDeployCard(luke);
+        scn.LSChooseCard(site);
+        // Using Force places cards in Used Pile - Descent should be offered as a response
+        assertTrue(scn.LSCardPlayAvailable(descent));
+        scn.LSPlayCard(descent);
+        scn.PassAllResponses();
+
+        assertEquals(Zone.SIDE_OF_TABLE, descent.getZone());
+        // All Used Piles immediately re-circulated
+        assertEquals(0, scn.GetLSUsedPileCount());
+        assertEquals(0, scn.GetDSUsedPileCount());
+    }
+
+    @Test
+    public void DescentIntoTheDarkCancelsWhenCardPlacedInUsedPile() {
+        var scn = GetScenario();
+
+        var descent = scn.GetLSCard("descent");
+        var luke = scn.GetLSCard("luke");
+        var leia = scn.GetLSCard("leia");
+        var site = scn.GetLSStartingLocation();
+
+        scn.StartGame();
+
+        var han = scn.GetLSCard("han");
+        scn.MoveCardsToLSHand(descent, luke, leia);
+        scn.MoveCardsToLocation(site, han);
+
+        scn.SkipToLSTurn(Phase.DEPLOY);
+
+        // First deploy uses Force -> play Descent
+        assertTrue(scn.LSDeployAvailable(luke));
+        scn.LSDeployCard(luke);
+        scn.LSChooseCard(site);
+        assertTrue(scn.LSCardPlayAvailable(descent));
+        scn.LSPlayCard(descent);
+        scn.PassAllResponses();
+        assertEquals(Zone.SIDE_OF_TABLE, descent.getZone());
+        assertEquals(0, scn.GetLSUsedPileCount());
+
+        // Second deploy uses Force again -> Descent cancels
+        assertTrue(scn.LSDeployAvailable(leia));
+        scn.LSDeployCard(leia);
+        scn.LSChooseCard(site);
+        scn.PassAllResponses();
+
+        assertTrue(descent.getZone() == Zone.TOP_OF_LOST_PILE || descent.getZone() == Zone.LOST_PILE);
+    }
+
+    @Test
+    public void DescentIntoTheDarkNotPlayableDuringOpponentsTurn() {
+        var scn = GetScenario();
+
+        var descent = scn.GetLSCard("descent");
+        var viper = scn.GetDSCard("viper");
+        var site = scn.GetDSStartingLocation();
+
+        scn.StartGame();
+
+        scn.MoveCardsToLSHand(descent);
+        scn.MoveCardsToDSHand(viper);
+
+        // Get through to DS turn deploy; LS has Descent in hand but it is opponent's turn
+        scn.SkipToDSTurn(Phase.DEPLOY);
+
+        assertTrue(scn.DSDeployAvailable(viper));
+        scn.DSDeployCard(viper);
+        scn.DSChooseCard(site);
+        // Using Force on DS turn should NOT offer Descent to LS
+        assertFalse(scn.LSCardPlayAvailable(descent));
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set4/light/Card_4_20_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set4/light/Card_4_20_Tests.java
@@ -12,6 +12,10 @@ import com.gempukku.swccgo.common.Uniqueness;
 import com.gempukku.swccgo.common.Zone;
 import com.gempukku.swccgo.framework.StartingSetup;
 import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.game.PhysicalCardImpl;
+import com.gempukku.swccgo.logic.actions.TopLevelGameTextAction;
+import com.gempukku.swccgo.logic.decisions.CardActionSelectionDecision;
+import com.gempukku.swccgo.logic.effects.PlaceCardInUsedPileFromTableEffect;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -27,12 +31,13 @@ public class Card_4_20_Tests {
         return new VirtualTableScenario(
                 new HashMap<>() {{
                     put("descent", "4_20");
-                    put("luke", "1_019"); // deploy 5 - uses Force into Used
-                    put("leia", "1_017"); // deploy 4 - second Force use for cancel
-                    put("han", "1_011"); // presence
+                    put("luke", "1_019");
+                    put("leia", "1_017");
+                    put("han", "1_011");
                 }},
                 new HashMap<>() {{
-                    put("viper", "1_282");
+                    put("stormtrooper", "1_194");
+                    put("officer", "1_180");
                 }},
                 10,
                 10,
@@ -44,6 +49,31 @@ public class Card_4_20_Tests {
                 StartingSetup.NoDSShields,
                 VirtualTableScenario.Open
         );
+    }
+
+    /**
+     * AdHoc place-from-table into Used Pile. Framework carryOutEffect always decides "0",
+     * which selects an existing Deploy action when any are legal; pick the newly-added index instead.
+     */
+    private void placeCardInUsedPile(VirtualTableScenario scn, String playerId, PhysicalCardImpl card) {
+        var awaitingDecision = (CardActionSelectionDecision) scn.userFeedback().getAwaitingDecision(playerId);
+        String[] before = awaitingDecision.getDecisionParameters().get("actionId");
+        int idx = (before == null) ? 0 : before.length;
+        var action = new TopLevelGameTextAction(card, playerId, card.getCardId());
+        action.setText("Place in Used Pile (ad-hoc)");
+        action.appendEffect(new PlaceCardInUsedPileFromTableEffect(action, card));
+        awaitingDecision.addAction(action);
+        scn.PlayerDecided(playerId, String.valueOf(idx));
+        // Resolve about-to-leave-table responses so the card actually enters Used Pile
+        scn.PassResponses("ABOUT_TO");
+    }
+
+    private void lsPlaceCardInUsedPile(VirtualTableScenario scn, PhysicalCardImpl card) {
+        placeCardInUsedPile(scn, scn.LS, card);
+    }
+
+    private void dsPlaceCardInUsedPile(VirtualTableScenario scn, PhysicalCardImpl card) {
+        placeCardInUsedPile(scn, scn.DS, card);
     }
 
     @Test
@@ -94,35 +124,30 @@ public class Card_4_20_Tests {
 
         var descent = scn.GetLSCard("descent");
         var luke = scn.GetLSCard("luke");
+        var han = scn.GetLSCard("han");
         var site = scn.GetLSStartingLocation();
 
         scn.StartGame();
 
-        scn.MoveCardsToLSHand(descent, luke);
-        // Seed some Used Pile cards so recirculate is observable
-        scn.MoveCardsToTopOfLSUsedPile(scn.GetTopOfLSReserveDeck());
-        scn.MoveCardsToTopOfDSUsedPile(scn.GetTopOfDSReserveDeck());
-
-        // Presence so Luke can deploy
-        scn.MoveCardsToLocation(site, scn.GetLSCard("leia"));
+        scn.MoveCardsToLocation(site, han, luke);
 
         scn.SkipToLSTurn(Phase.DEPLOY);
 
-        int lsUsedBeforeDeploy = scn.GetLSUsedPileCount();
-        int dsUsedBeforeDeploy = scn.GetDSUsedPileCount();
-        assertTrue(lsUsedBeforeDeploy >= 1);
-        assertTrue(dsUsedBeforeDeploy >= 1);
+        scn.MoveCardsToLSHand(descent);
+        scn.MoveCardsToTopOfLSUsedPile(scn.GetTopOfLSReserveDeck());
+        scn.MoveCardsToTopOfDSUsedPile(scn.GetTopOfDSReserveDeck());
+        assertTrue(scn.GetLSUsedPileCount() >= 1);
+        assertTrue(scn.GetDSUsedPileCount() >= 1);
 
-        assertTrue(scn.LSDeployAvailable(luke));
-        scn.LSDeployCard(luke);
-        scn.LSChooseCard(site);
-        // Using Force places cards in Used Pile - Descent should be offered as a response
-        assertTrue(scn.LSCardPlayAvailable(descent));
+        assertTrue(scn.AwaitingLSDeployPhaseActions());
+        lsPlaceCardInUsedPile(scn, han);
+        // Opponent of performing player responds first to after-triggers
+        scn.DSPass();
+        assertTrue("Descent should be playable as response to Used Pile placement", scn.LSCardPlayAvailable(descent));
         scn.LSPlayCard(descent);
         scn.PassAllResponses();
 
         assertEquals(Zone.SIDE_OF_TABLE, descent.getZone());
-        // All Used Piles immediately re-circulated
         assertEquals(0, scn.GetLSUsedPileCount());
         assertEquals(0, scn.GetDSUsedPileCount());
     }
@@ -134,33 +159,33 @@ public class Card_4_20_Tests {
         var descent = scn.GetLSCard("descent");
         var luke = scn.GetLSCard("luke");
         var leia = scn.GetLSCard("leia");
+        var han = scn.GetLSCard("han");
         var site = scn.GetLSStartingLocation();
 
         scn.StartGame();
 
-        var han = scn.GetLSCard("han");
-        scn.MoveCardsToLSHand(descent, luke, leia);
-        scn.MoveCardsToLocation(site, han);
+        scn.MoveCardsToLocation(site, han, luke, leia);
 
         scn.SkipToLSTurn(Phase.DEPLOY);
 
-        // First deploy uses Force -> play Descent
-        assertTrue(scn.LSDeployAvailable(luke));
-        scn.LSDeployCard(luke);
-        scn.LSChooseCard(site);
+        scn.MoveCardsToLSHand(descent);
+
+        assertTrue(scn.AwaitingLSDeployPhaseActions());
+        lsPlaceCardInUsedPile(scn, han);
+        scn.DSPass();
         assertTrue(scn.LSCardPlayAvailable(descent));
         scn.LSPlayCard(descent);
         scn.PassAllResponses();
         assertEquals(Zone.SIDE_OF_TABLE, descent.getZone());
-        assertEquals(0, scn.GetLSUsedPileCount());
 
-        // Second deploy uses Force again -> Descent cancels
-        assertTrue(scn.LSDeployAvailable(leia));
-        scn.LSDeployCard(leia);
-        scn.LSChooseCard(site);
+        // Phase actions alternate: after LS AdHoc place, DS gets the next Deploy window
+        assertTrue(scn.AwaitingDSDeployPhaseActions());
+        scn.DSPass();
+        assertTrue(scn.AwaitingLSDeployPhaseActions());
+        lsPlaceCardInUsedPile(scn, luke);
         scn.PassAllResponses();
 
-        assertTrue(descent.getZone() == Zone.TOP_OF_LOST_PILE || descent.getZone() == Zone.LOST_PILE);
+        assertEquals(Zone.TOP_OF_LOST_PILE, descent.getZone());
     }
 
     @Test
@@ -168,21 +193,21 @@ public class Card_4_20_Tests {
         var scn = GetScenario();
 
         var descent = scn.GetLSCard("descent");
-        var viper = scn.GetDSCard("viper");
+        var stormtrooper = scn.GetDSCard("stormtrooper");
+        var officer = scn.GetDSCard("officer");
         var site = scn.GetDSStartingLocation();
 
         scn.StartGame();
 
-        scn.MoveCardsToLSHand(descent);
-        scn.MoveCardsToDSHand(viper);
+        scn.MoveCardsToLocation(site, officer, stormtrooper);
 
-        // Get through to DS turn deploy; LS has Descent in hand but it is opponent's turn
         scn.SkipToDSTurn(Phase.DEPLOY);
 
-        assertTrue(scn.DSDeployAvailable(viper));
-        scn.DSDeployCard(viper);
-        scn.DSChooseCard(site);
-        // Using Force on DS turn should NOT offer Descent to LS
+        scn.MoveCardsToLSHand(descent);
+
+        assertTrue(scn.AwaitingDSDeployPhaseActions());
+        dsPlaceCardInUsedPile(scn, stormtrooper);
+        // Force use / Used placement on opponent turn must not offer Descent
         assertFalse(scn.LSCardPlayAvailable(descent));
     }
 }


### PR DESCRIPTION
﻿## Summary
Implements Dagobah Immediate Effect **Descent Into The Dark** (4_20 / Closes #102).

- During your turn, if either player just placed a card in a Used Pile, deploy on table
- Both Used Piles immediately re-circulate
- Later Used Pile placement cancels this Immediate Effect

Used-pile detection is **card-local** (FORCE_USED, from-table, forfeit-to-Used, off-table to Used including played Used Interrupts). No shared PlacedInUsedPile / recirculate helper broadening (avoids Alpha3 Through the Force overlap).

## Tests
VHD `Card_4_20_Tests`: **4/4 passing** (stats, deploy+recirculate, cancel, not on opponent turn).

## Checklist
- [x] Independent PR vs master
- [x] VHD tests green
- [x] Overlay 17003 (mouse / gemp_swccg_app_3) tip SHA 4d264ee
- [ ] Google Doc Descent tab STATUS (anonymous edit pending from this executor)

Closes #102
