### PR TITLE
Implement Through The Force Things You Will See (4_64)

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set4/light/Card4_064.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set4/light/Card4_064.java
@@ -1,0 +1,59 @@
+package com.gempukku.swccgo.cards.set4.light;
+
+import com.gempukku.swccgo.cards.AbstractLostInterrupt;
+import com.gempukku.swccgo.cards.GameConditions;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.logic.TriggerConditions;
+import com.gempukku.swccgo.logic.actions.PlayInterruptAction;
+import com.gempukku.swccgo.logic.effects.PlaceUsedPileFaceUpOnReserveDeckEffect;
+import com.gempukku.swccgo.logic.effects.RespondablePlayCardEffect;
+import com.gempukku.swccgo.logic.timing.Action;
+import com.gempukku.swccgo.logic.timing.EffectResult;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Set: Dagobah
+ * Type: Interrupt
+ * Subtype: Lost
+ * Title: Through The Force Things You Will See
+ */
+public class Card4_064 extends AbstractLostInterrupt {
+    public Card4_064() {
+        super(Side.LIGHT, 3, Title.Through_The_Force_Things_You_Will_See, Uniqueness.UNRESTRICTED, ExpansionSet.DAGOBAH, Rarity.R);
+        setLore("One training exercise for a Jedi's apprentice is to invert one's view to see things from a different perspective. 'The future, the past. Old friends long gone.'");
+        setGameText("At the end of any player's draw phase, cause that player to place Used Pile face up on top of Reserve Deck. Shuffle, cut, and replace. When face-up cards are removed from Reserve Deck, they are treated as normal (no longer remain face up).");
+        addIcons(Icon.DAGOBAH);
+    }
+
+    @Override
+    protected List<PlayInterruptAction> getGameTextOptionalAfterActions(final String playerId, SwccgGame game, EffectResult effectResult, final PhysicalCard self) {
+        if (TriggerConditions.isEndOfEachPhase(game, effectResult, Phase.DRAW)) {
+            final String drawPhasePlayer = game.getGameState().getCurrentPlayerId();
+            if (GameConditions.hasUsedPile(game, drawPhasePlayer)) {
+                final PlayInterruptAction action = new PlayInterruptAction(game, self);
+                action.setText("Place " + drawPhasePlayer + "'s Used Pile face up on Reserve Deck");
+                action.allowResponses(
+                        new RespondablePlayCardEffect(action) {
+                            @Override
+                            protected void performActionResults(Action targetingAction) {
+                                action.appendEffect(
+                                        new PlaceUsedPileFaceUpOnReserveDeckEffect(action, drawPhasePlayer));
+                            }
+                        }
+                );
+                return Collections.singletonList(action);
+            }
+        }
+        return null;
+    }
+}

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/light/Card5_015.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/light/Card5_015.java
@@ -1,0 +1,169 @@
+package com.gempukku.swccgo.cards.set5.light;
+
+import com.gempukku.swccgo.cards.AbstractNormalEffect;
+import com.gempukku.swccgo.cards.conditions.PlayCardOptionIdCondition;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Keyword;
+import com.gempukku.swccgo.common.PlayCardOptionId;
+import com.gempukku.swccgo.common.PlayCardZoneOption;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.TargetId;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.filters.Filter;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.DeployAsCaptiveOption;
+import com.gempukku.swccgo.game.DeploymentRestrictionsOption;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.PlayCardOption;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.game.state.GameState;
+import com.gempukku.swccgo.logic.actions.RequiredGameTextTriggerAction;
+import com.gempukku.swccgo.logic.conditions.Condition;
+import com.gempukku.swccgo.logic.effects.LoseInsertCardEffect;
+import com.gempukku.swccgo.logic.effects.ShuffleReserveDeckEffect;
+import com.gempukku.swccgo.logic.effects.TargetCardOnTableEffect;
+import com.gempukku.swccgo.logic.modifiers.ImmuneToTitleModifier;
+import com.gempukku.swccgo.logic.modifiers.Modifier;
+import com.gempukku.swccgo.logic.modifiers.MoveCostFromLocationToLocationModifier;
+import com.gempukku.swccgo.logic.modifiers.querying.ModifiersQuerying;
+import com.gempukku.swccgo.logic.timing.Action;
+import com.gempukku.swccgo.logic.timing.PassthruEffect;
+import com.gempukku.swccgo.logic.timing.TargetingEffect;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Set: Cloud City
+ * Type: Effect
+ * Title: Access Denied
+ */
+public class Card5_015 extends AbstractNormalEffect {
+    public Card5_015() {
+        super(Side.LIGHT, 4, PlayCardZoneOption.ATTACHED, Title.Access_Denied, Uniqueness.UNRESTRICTED, ExpansionSet.CLOUD_CITY, Rarity.C);
+        setLore("The doors on Cloud City use a special computer controlled locking system, making them difficult to bypass without altering the security codes.");
+        setGameText("Insert face up in your Reserve Deck. When Effect reaches top it is lost, along with all opponent's 'insert' cards there. Reshuffle. (Immune to Alter.) OR Deploy between two mobile sites. Opponent's characters may pass only if aboard a Lift Tube or opponent uses +1 Force each.");
+        addIcons(Icon.CLOUD_CITY);
+        addKeywords(Keyword.DEPLOYS_ON_SITE);
+        // Bill ruling: insert mode Immune to Alter; between-sites Effect NOT Immune (see AlwaysOn).
+    }
+
+    @Override
+    protected List<PlayCardOption> getGameTextPlayCardOptions() {
+        List<PlayCardOption> playCardOptions = new ArrayList<PlayCardOption>();
+        playCardOptions.add(new PlayCardOption(PlayCardOptionId.PLAY_AS_INSERT_CARD, PlayCardZoneOption.YOUR_RESERVE_DECK, "Insert face up in your Reserve Deck"));
+        playCardOptions.add(new PlayCardOption(PlayCardOptionId.PLAY_CARD_OPTION_1, PlayCardZoneOption.ATTACHED, "Deploy between two mobile sites"));
+        return playCardOptions;
+    }
+
+    /** Mobile sites that are not Dagobah/Ahch-To (shared Deploy Between Sites rule). */
+    private static Filter eligibleMobileSite() {
+        return Filters.and(
+                Filters.mobile_site,
+                Filters.not(Filters.or(Filters.Dagobah_location, Filters.AhchTo_location)));
+    }
+
+    @Override
+    protected Filter getValidDeployTargetFilterForCardType(String playerId, final SwccgGame game, final PhysicalCard self, boolean isSimDeployAttached, boolean ignorePresenceOrForceIcons, DeploymentRestrictionsOption deploymentRestrictionsOption, DeployAsCaptiveOption deployAsCaptiveOption) {
+        return Filters.location;
+    }
+
+    @Override
+    protected Filter getGameTextValidDeployTargetFilter(final SwccgGame game, final PhysicalCard self, PlayCardOptionId playCardOptionId, boolean asReact) {
+        if (playCardOptionId != PlayCardOptionId.PLAY_CARD_OPTION_1) {
+            return Filters.none;
+        }
+        final Filter eligible = eligibleMobileSite();
+        return Filters.and(eligible, new Filter() {
+            @Override
+            public boolean accepts(GameState gameState, ModifiersQuerying modifiersQuerying, PhysicalCard physicalCard) {
+                return Filters.canSpot(game, self, Filters.and(Filters.adjacentSite(physicalCard), eligible));
+            }
+        });
+    }
+
+    @Override
+    protected Filter getGameTextValidTargetFilterToRemainAttachedTo(final SwccgGame game, final PhysicalCard self) {
+        return eligibleMobileSite();
+    }
+
+    @Override
+    protected List<TargetingEffect> getGameTextTargetCardsWhenDeployedEffects(final Action action, String playerId, SwccgGame game, final PhysicalCard self, PhysicalCard target, PlayCardOption playCardOption) {
+        if (playCardOption == null || playCardOption.getId() != PlayCardOptionId.PLAY_CARD_OPTION_1) {
+            return null;
+        }
+        final Filter targetFilter = Filters.and(eligibleMobileSite(), Filters.adjacentSite(target), Filters.not(target));
+        TargetingEffect targetingEffect = new TargetCardOnTableEffect(action, playerId, "Choose adjacent mobile site", targetFilter) {
+            @Override
+            protected void cardTargeted(int targetGroupId, PhysicalCard chosen) {
+                action.addAnimationGroup(chosen);
+                self.setTargetedCard(TargetId.EFFECT_TARGET_1, targetGroupId, chosen, targetFilter);
+            }
+        };
+        return Collections.singletonList(targetingEffect);
+    }
+
+    @Override
+    protected RequiredGameTextTriggerAction getGameTextInsertCardRevealed(SwccgGame game, final PhysicalCard self, final int gameTextSourceCardId) {
+        final String playerId = self.getOwner();
+        final String opponent = game.getOpponent(playerId);
+
+        final RequiredGameTextTriggerAction action = new RequiredGameTextTriggerAction(self, gameTextSourceCardId);
+        action.setText("Reveal 'insert' card");
+        action.setActionMsg(null);
+        // Lose this insert card
+        action.appendEffect(new LoseInsertCardEffect(action, self));
+        // Lose all opponent's insert cards still in this Reserve Deck, then reshuffle
+        action.appendEffect(
+                new PassthruEffect(action) {
+                    @Override
+                    protected void doPlayEffect(SwccgGame game) {
+                        GameState gameState = game.getGameState();
+                        List<PhysicalCard> toLose = new LinkedList<PhysicalCard>();
+                        for (PhysicalCard card : gameState.getReserveDeck(playerId, false)) {
+                            if (card.isInserted() && opponent.equals(card.getOwner())) {
+                                toLose.add(card);
+                            }
+                        }
+                        for (PhysicalCard card : toLose) {
+                            action.appendEffect(new LoseInsertCardEffect(action, card));
+                        }
+                        action.appendEffect(new ShuffleReserveDeckEffect(action, playerId, playerId));
+                    }
+                }
+        );
+        return action;
+    }
+
+    @Override
+    protected List<Modifier> getGameTextAlwaysOnModifiers(SwccgGame game, PhysicalCard self) {
+        List<Modifier> modifiers = new LinkedList<Modifier>();
+        // Insert function only — same pattern as Projection Of A Skywalker dual-option Alter immunity.
+        modifiers.add(new ImmuneToTitleModifier(self, new PlayCardOptionIdCondition(self, PlayCardOptionId.PLAY_AS_INSERT_CARD), Title.Alter));
+        return modifiers;
+    }
+
+    @Override
+    protected List<Modifier> getGameTextWhileActiveInPlayModifiers(SwccgGame game, final PhysicalCard self) {
+        Condition deployedBetweenSites = new PlayCardOptionIdCondition(self, PlayCardOptionId.PLAY_CARD_OPTION_1);
+        Filter siteA = Filters.hasAttached(self);
+        Filter siteB = Filters.targetedByCardOnTableAsTargetId(self, TargetId.EFFECT_TARGET_1);
+        // Opponent's characters not aboard a Lift Tube pay +1 Force to pass between the bounding sites.
+        Filter opponentCharactersNotAboardLiftTube = Filters.and(
+                Filters.opponents(self),
+                Filters.character,
+                Filters.not(Filters.or(Filters.aboard(Filters.Lift_Tube), Filters.aboardAsPassenger(Filters.Lift_Tube)))
+        );
+
+        List<Modifier> modifiers = new LinkedList<Modifier>();
+        modifiers.add(new MoveCostFromLocationToLocationModifier(self, opponentCharactersNotAboardLiftTube, deployedBetweenSites, 1, siteA, siteB));
+        modifiers.add(new MoveCostFromLocationToLocationModifier(self, opponentCharactersNotAboardLiftTube, deployedBetweenSites, 1, siteB, siteA));
+        return modifiers;
+    }
+
+}

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_light.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_light.json
@@ -50852,6 +50852,34 @@
     ]
   },
   {
+    "cardId": "4_64",
+    "title": "Through The Force Things You Will See",
+    "slug": "through-the-force-things-you-will-see",
+    "slugWithSetName": "through-the-force-things-you-will-see-dagobah",
+    "side": "LIGHT",
+    "uniqueness": "UNRESTRICTED",
+    "expansionSet": "DAGOBAH",
+    "rarity": "R",
+    "cardCategory": "INTERRUPT",
+    "cardTypes": [
+      "INTERRUPT"
+    ],
+    "cardSubtype": "LOST",
+    "lore": "One training exercise for a Jedi's apprentice is to invert one's view to see things from a different perspective. 'The future, the past. Old friends long gone.'",
+    "gameText": "At the end of any player's draw phase, cause that player to place Used Pile face up on top of Reserve Deck. Shuffle, cut, and replace. When face-up cards are removed from Reserve Deck, they are treated as normal (no longer remain face up).",
+    "destiny": 3,
+    "icons": [
+      {
+        "icon": "DAGOBAH",
+        "count": 1
+      },
+      {
+        "icon": "INTERRUPT",
+        "count": 1
+      }
+    ]
+  },
+  {
     "cardId": "4_66",
     "title": "Transmission Terminated",
     "slug": "transmission-terminated",
@@ -51941,6 +51969,36 @@
     ],
     "keywords": [
       "DEPLOYS_ON_CHARACTERS"
+    ]
+  },
+  {
+    "cardId": "5_15",
+    "title": "Access Denied",
+    "slug": "access-denied",
+    "slugWithSetName": "access-denied-cloud-city",
+    "side": "LIGHT",
+    "uniqueness": "UNRESTRICTED",
+    "expansionSet": "CLOUD_CITY",
+    "rarity": "C",
+    "cardCategory": "EFFECT",
+    "cardTypes": [
+      "EFFECT"
+    ],
+    "lore": "The doors on Cloud City use a special computer controlled locking system, making them difficult to bypass without altering the security codes.",
+    "gameText": "Insert face up in your Reserve Deck. When Effect reaches top it is lost, along with all opponent's 'insert' cards there. Reshuffle. (Immune to Alter.) OR Deploy between two mobile sites. Opponent's characters may pass only if aboard a Lift Tube or opponent uses +1 Force each.",
+    "destiny": 4,
+    "icons": [
+      {
+        "icon": "CLOUD_CITY",
+        "count": 1
+      },
+      {
+        "icon": "EFFECT",
+        "count": 1
+      }
+    ],
+    "keywords": [
+      "DEPLOYS_ON_SITE"
     ]
   },
   {

--- a/src/gemp-swccg-common/src/main/java/com/gempukku/swccgo/common/PlayCardZoneOption.java
+++ b/src/gemp-swccg-common/src/main/java/com/gempukku/swccgo/common/PlayCardZoneOption.java
@@ -16,6 +16,7 @@ public enum PlayCardZoneOption {
 
     NEXT_TO_EITHER_LOST_PILE(Zone.SIDE_OF_TABLE, Zone.LOST_PILE, 1, true, true, false),
     OPPONENTS_RESERVE_DECK(Zone.RESERVE_DECK, Zone.RESERVE_DECK, 2, false, true, true),
+    YOUR_RESERVE_DECK(Zone.RESERVE_DECK, Zone.RESERVE_DECK, 2, true, false, true),
     OPPONENTS_FORCE_PILE(Zone.FORCE_PILE, Zone.FORCE_PILE, 1, false, true, false);
 
 

--- a/src/gemp-swccg-common/src/main/java/com/gempukku/swccgo/common/Title.java
+++ b/src/gemp-swccg-common/src/main/java/com/gempukku/swccgo/common/Title.java
@@ -29,6 +29,7 @@ public interface Title {
     String A280_Sharpshooter_Rifle = "A280 Sharpshooter Rifle";
     String AAT_Laser_Cannon = "AAT Laser Cannon";
     String Abyssin_Ornament = "Abyssin Ornament";
+    String Access_Denied = "Access Denied";
     String Ackbar = "Admiral Ackbar";
     String Activate_The_Droids = "Activate The Droids";
     String Advance_Preparation = "Advance Preparation";
@@ -1202,6 +1203,7 @@ public interface Title {
     String This_Is_Some_Rescue = "This Is Some Rescue!";
     String This_Is_Still_Wrong = "This Is Still Wrong";
     String This_Place_Can_Be_A_Little_Rough = "This Place Can Be A Little Rough";
+    String Through_The_Force_Things_You_Will_See = "Through The Force Things You Will See";
     String Those_Rebels_Wont_Escape_Us = "Those Rebels Won't Escape Us";
     String Thrawn = "Grand Admiral Thrawn";
     String Thrawns_Art_Collection = "Thrawn's Art Collection";

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/PhysicalCard.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/PhysicalCard.java
@@ -320,6 +320,8 @@ public interface PhysicalCard extends Filterable, Snapshotable<PhysicalCard> {
 
     void setInserted(boolean inserted);
     boolean isInserted();
+    void setFaceUpInReserveDeck(boolean faceUpInReserveDeck);
+    boolean isFaceUpInReserveDeck();
     void setInsertCardRevealed(boolean revealed);
     boolean isInsertCardRevealed();
 

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/PhysicalCardImpl.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/PhysicalCardImpl.java
@@ -32,6 +32,7 @@ public class PhysicalCardImpl implements PhysicalCard, Cloneable {
     private String _zoneOwner;
     private int _locationZoneIndex;
     private boolean _isInserted;
+    private boolean _isFaceUpInReserveDeck;
     private boolean _isInsertCardRevealed;
     private PhysicalCard _attachedTo;
     private PhysicalCard _stackedOn;
@@ -147,6 +148,7 @@ public class PhysicalCardImpl implements PhysicalCard, Cloneable {
         snapshot._zoneOwner = _zoneOwner;
         snapshot._locationZoneIndex = _locationZoneIndex;
         snapshot._isInserted = _isInserted;
+        snapshot._isFaceUpInReserveDeck = _isFaceUpInReserveDeck;
         snapshot._isInsertCardRevealed = _isInsertCardRevealed;
         snapshot._attachedTo = snapshotData.getDataForSnapshot(_attachedTo);
         snapshot._stackedOn = snapshotData.getDataForSnapshot(_stackedOn);
@@ -324,7 +326,7 @@ public class PhysicalCardImpl implements PhysicalCard, Cloneable {
 
         if (_isBlownAway
                 || (_zone != null
-                && ((_zone.isFaceDown() && !_isInserted && (_zone != Zone.TOP_OF_USED_PILE || (gameState != null && !gameState.isUsedPilesTurnedOver())))
+                && ((_zone.isFaceDown() && !_isInserted && !_isFaceUpInReserveDeck && (_zone != Zone.TOP_OF_USED_PILE || (gameState != null && !gameState.isUsedPilesTurnedOver())))
                 || (gameState != null && _zone == Zone.TOP_OF_LOST_PILE && gameState.isLostPileTurnedOver(getZoneOwner()))))) {
             return _backBlueprintId;
         }
@@ -350,7 +352,7 @@ public class PhysicalCardImpl implements PhysicalCard, Cloneable {
 
         if (_isBlownAway
                 || (_zone != null
-                && ((_zone.isFaceDown() && !_isInserted && (_zone != Zone.TOP_OF_USED_PILE || (gameState != null && !gameState.isUsedPilesTurnedOver())))
+                && ((_zone.isFaceDown() && !_isInserted && !_isFaceUpInReserveDeck && (_zone != Zone.TOP_OF_USED_PILE || (gameState != null && !gameState.isUsedPilesTurnedOver())))
                 || (gameState != null && _zone == Zone.TOP_OF_LOST_PILE && gameState.isLostPileTurnedOver(getZoneOwner()))))) {
             if (showOtherSide)
                 return null;
@@ -1164,6 +1166,16 @@ public class PhysicalCardImpl implements PhysicalCard, Cloneable {
     @Override
     public boolean isInserted() {
         return _isInserted;
+    }
+
+    @Override
+    public void setFaceUpInReserveDeck(boolean faceUpInReserveDeck) {
+        _isFaceUpInReserveDeck = faceUpInReserveDeck;
+    }
+
+    @Override
+    public boolean isFaceUpInReserveDeck() {
+        return _isFaceUpInReserveDeck;
     }
 
     @Override

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/GameState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/GameState.java
@@ -1400,8 +1400,9 @@ public class GameState implements Snapshotable<GameState> {
                 zoneCards.get(0).setZone(zone);
                 cardsToAdd.add(zoneCards.get(0));
 
-                // if card, or new top card, is an 'insert' card then disallow shortcut
-                if (card.isInserted() || zoneCards.get(0).isInserted()) {
+                // if card, or new top card, is an 'insert' card or face-up in Reserve then disallow shortcut
+                if (card.isInserted() || zoneCards.get(0).isInserted()
+                        || card.isFaceUpInReserveDeck() || zoneCards.get(0).isFaceUpInReserveDeck()) {
                     setInsertCardFound(true);
                     setSkipListenerUpdateAllowed(false);
                 }
@@ -1446,6 +1447,7 @@ public class GameState implements Snapshotable<GameState> {
         toCard.setSideways(fromCard.isSideways());
         toCard.setBlownAway(fromCard.isBlownAway());
         toCard.setInserted(fromCard.isInserted());
+        toCard.setFaceUpInReserveDeck(fromCard.isFaceUpInReserveDeck());
         toCard.setInsertCardRevealed(fromCard.isInsertCardRevealed());
         toCard.setHit(fromCard.isHit());
         toCard.setDisarmed(fromCard.isDisarmed());
@@ -1491,6 +1493,7 @@ public class GameState implements Snapshotable<GameState> {
         card.setSideways(false);
         card.setBlownAway(false);
         card.setInserted(false);
+        card.setFaceUpInReserveDeck(false);
         card.setInsertCardRevealed(false);
         card.setHit(false);
         card.setDisarmed(false);
@@ -2609,9 +2612,9 @@ public class GameState implements Snapshotable<GameState> {
             }
         }
 
-        // Include "insert" cards on top of reserve decks
+        // Include "insert" cards and face-up Reserve tops on top of reserve decks
         for (PhysicalCard topOfReserveDeck : getTopCardsOfReserveDecks()) {
-            if (topOfReserveDeck.isInserted())
+            if (topOfReserveDeck.isInserted() || topOfReserveDeck.isFaceUpInReserveDeck())
                 if (physicalCardVisitor.visitPhysicalCard(topOfReserveDeck))
                     return true;
         }

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/PlaceUsedPileFaceUpOnReserveDeckEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/PlaceUsedPileFaceUpOnReserveDeckEffect.java
@@ -1,0 +1,65 @@
+package com.gempukku.swccgo.logic.effects;
+
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.game.state.GameState;
+import com.gempukku.swccgo.logic.timing.AbstractSuccessfulEffect;
+import com.gempukku.swccgo.logic.timing.Action;
+import com.gempukku.swccgo.logic.timing.results.PutCardInCardPileFromOffTableResult;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Places Used Pile face up on top of Reserve Deck, then shuffles (cut and replace).
+ * Only cards moved from Used are marked face-up in Reserve; prior Reserve cards stay face-down.
+ * Face-up marking is card-local (not isInserted). Cleared when the card leaves Reserve.
+ */
+public class PlaceUsedPileFaceUpOnReserveDeckEffect extends AbstractSuccessfulEffect {
+    private final String _cardPileOwner;
+
+    public PlaceUsedPileFaceUpOnReserveDeckEffect(Action action, String cardPileOwner) {
+        super(action);
+        _cardPileOwner = cardPileOwner;
+    }
+
+    @Override
+    public String getText(SwccgGame game) {
+        return "Place Used Pile face up on Reserve Deck";
+    }
+
+    @Override
+    protected void doPlayEffect(SwccgGame game) {
+        GameState gameState = game.getGameState();
+        List<PhysicalCard> usedPile = gameState.getCardPile(_cardPileOwner, Zone.USED_PILE);
+        if (usedPile.isEmpty()) {
+            return;
+        }
+
+        List<PhysicalCard> movedFromUsed = new ArrayList<PhysicalCard>(usedPile);
+
+        String playerNameForMsg = _action.getPerformingPlayer().equals(_cardPileOwner) ? "" : (_cardPileOwner + "'s ");
+        gameState.sendMessage(_action.getPerformingPlayer() + " places " + playerNameForMsg + "Used Pile face up on " + playerNameForMsg + "Reserve Deck");
+        gameState.placeCardPileOnCardPile(_cardPileOwner, Zone.USED_PILE, Zone.RESERVE_DECK);
+
+        for (PhysicalCard card : movedFromUsed) {
+            Zone zone = card.getZone();
+            if (zone == Zone.RESERVE_DECK || zone == Zone.TOP_OF_RESERVE_DECK) {
+                card.setFaceUpInReserveDeck(true);
+            }
+        }
+
+        gameState.shuffleReserveDeck(_cardPileOwner);
+
+        PhysicalCard top = gameState.getTopOfReserveDeck(_cardPileOwner);
+        if (top != null && top.isFaceUpInReserveDeck()) {
+            gameState.sendMessage(top.getOwner() + "'s " + top.getBlueprint().getTitle() + " is face up on top of Reserve Deck");
+            gameState.setInsertCardFound(true);
+            gameState.setSkipListenerUpdateAllowed(false);
+        }
+
+        game.getActionsEnvironment().emitEffectResult(
+                new PutCardInCardPileFromOffTableResult(_action, null, _cardPileOwner, Zone.RESERVE_DECK, false));
+    }
+}

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/RevealInsertCardEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/RevealInsertCardEffect.java
@@ -1,5 +1,6 @@
 package com.gempukku.swccgo.logic.effects;
 
+import com.gempukku.swccgo.common.CardCategory;
 import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.game.SwccgGame;
 import com.gempukku.swccgo.logic.GameUtils;
@@ -39,7 +40,12 @@ public class RevealInsertCardEffect extends AbstractSubActionEffect {
                 new PassthruEffect(subAction) {
                     @Override
                     protected void doPlayEffect(SwccgGame game) {
-                        if (_card.isInserted() && !_card.isInsertCardRevealed()) {
+                        boolean faceUpNeedsInsertReveal = false;
+                        if (_card.isFaceUpInReserveDeck()
+                                && _card.getBlueprint().getCardCategory() == CardCategory.EFFECT) {
+                            faceUpNeedsInsertReveal = _card.getBlueprint().getInsertCardRevealedAction(game, _card) != null;
+                        }
+                        if ((_card.isInserted() || faceUpNeedsInsertReveal) && !_card.isInsertCardRevealed()) {
                             _card.setInsertCardRevealed(true);
                             game.getGameState().sendMessage("'Insert' card " + GameUtils.getCardLink(_card) + " is revealed");
                             game.getGameState().activatedCard(null, _card);

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/rules/InsertCardRevealedRule.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/rules/InsertCardRevealedRule.java
@@ -1,5 +1,6 @@
 package com.gempukku.swccgo.logic.timing.rules;
 
+import com.gempukku.swccgo.common.CardCategory;
 import com.gempukku.swccgo.game.AbstractActionProxy;
 import com.gempukku.swccgo.game.ActionsEnvironment;
 import com.gempukku.swccgo.game.PhysicalCard;
@@ -39,7 +40,12 @@ public class InsertCardRevealedRule implements Rule {
 
                         List<PhysicalCard> topCards = game.getGameState().getTopCardsOfPiles();
                         for (PhysicalCard topCard : topCards) {
-                            if (topCard.isInserted() && !topCard.isInsertCardRevealed()) {
+                            boolean faceUpNeedsInsertReveal = false;
+                            if (topCard.isFaceUpInReserveDeck()
+                                    && topCard.getBlueprint().getCardCategory() == CardCategory.EFFECT) {
+                                faceUpNeedsInsertReveal = topCard.getBlueprint().getInsertCardRevealedAction(game, topCard) != null;
+                            }
+                            if ((topCard.isInserted() || faceUpNeedsInsertReveal) && !topCard.isInsertCardRevealed()) {
 
                                 RequiredRuleTriggerAction action = new RequiredRuleTriggerAction(_that, topCard);
                                 action.setText("Reveal " + GameUtils.getCardLink(topCard));

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set4/light/Card_4_064_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set4/light/Card_4_064_Tests.java
@@ -1,0 +1,276 @@
+package com.gempukku.swccgo.cards.set4.light;
+
+import com.gempukku.swccgo.common.CardSubtype;
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.game.PhysicalCardImpl;
+import com.gempukku.swccgo.logic.actions.TopLevelGameTextAction;
+import com.gempukku.swccgo.logic.effects.LoseInsertCardEffect;
+import com.gempukku.swccgo.logic.effects.PlaceUsedPileFaceUpOnReserveDeckEffect;
+import com.gempukku.swccgo.logic.timing.Action;
+import com.gempukku.swccgo.logic.timing.results.EndOfPhaseResult;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for Through The Force Things You Will See (4_64 / blueprint 4_64).
+ * Doc tab t.1gyb543pbwcz / issue #109.
+ * Bill refine: card-local face-up (not isInserted); thin Reserve-top hooks; clear on leave;
+ * Access Denied among face-up uses insert-found path.
+ */
+public class Card_4_064_Tests {
+
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("ttf", "4_64");
+                    put("luke", "1_19");
+                    put("accessDenied", "5_15");
+                    put("leia", "1_18");
+                    put("han", "1_11");
+                    put("chewie", "1_3");
+                }},
+                new HashMap<>() {{
+                    put("vader", "1_168");
+                    put("trooper", "1_194");
+                    put("officer", "1_179");
+                    put("dsSite", "1_284");
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    /** Direct effect play — AdHoc needs an awaiting decision which is unreliable mid-setup. */
+    private void applyFaceUpUsedToReserve(VirtualTableScenario scn, PhysicalCardImpl source, String pileOwner) {
+        TopLevelGameTextAction action = new TopLevelGameTextAction(source, scn.LS, source.getCardId());
+        new PlaceUsedPileFaceUpOnReserveDeckEffect(action, pileOwner).playEffect(scn.game());
+        // Clear activation interrupt latch so later cheats/assertions are not blocked.
+        scn.gameState().setInsertCardFound(false);
+        scn.gameState().setSkipListenerUpdateAllowed(true);
+    }
+
+    @Test
+    public void ThroughTheForceThingsYouWillSee_StatsAndIconsAreCorrect() {
+        var scn = GetScenario();
+        var card = scn.GetLSCard("ttf").getBlueprint();
+
+        assertEquals(Title.Through_The_Force_Things_You_Will_See, card.getTitle());
+        assertFalse(card.hasVirtualSuffix());
+        assertEquals(Uniqueness.UNRESTRICTED, card.getUniqueness());
+        assertEquals(Side.LIGHT, card.getSide());
+        assertEquals(3, card.getDestiny(), scn.epsilon);
+        assertEquals(CardSubtype.LOST, card.getCardSubtype());
+        scn.BlueprintCardTypeCheck(card, new ArrayList<>() {{
+            add(CardType.INTERRUPT);
+        }});
+        assertEquals(ExpansionSet.DAGOBAH, card.getExpansionSet());
+        assertEquals(Rarity.R, card.getRarity());
+        scn.BlueprintIconCheck(card, new ArrayList<>() {{
+            add(Icon.INTERRUPT);
+            add(Icon.DAGOBAH);
+        }});
+        assertTrue(card.getGameText().contains("Used Pile face up"));
+        assertTrue(card.getGameText().contains("Reserve Deck"));
+    }
+
+    @Test
+    public void ThroughTheForceThingsYouWillSee_PlayableAtEndOfOwnerDrawPhase() {
+        var scn = GetScenario();
+        var ttf = scn.GetLSCard("ttf");
+        var luke = scn.GetLSCard("luke");
+
+        scn.StartGame();
+        scn.MoveCardsToLSHand(ttf);
+        // Used recirculates at end of turn — seed AFTER arriving at DRAW.
+        scn.SkipToLSTurn(Phase.DRAW);
+        scn.MoveCardsToTopOfLSUsedPile(luke);
+        assertEquals(Phase.DRAW, scn.gameState().getCurrentPhase());
+        assertTrue(scn.GetLSUsedPileCount() > 0);
+
+        var actions = ttf.getBlueprint().getOptionalAfterActions(
+                scn.LS, scn.game(), new EndOfPhaseResult(Phase.DRAW), ttf);
+        assertNotNull(actions);
+        assertFalse(actions.isEmpty());
+    }
+
+    @Test
+    public void ThroughTheForceThingsYouWillSee_OwnerDrawPhase_PlacesUsedFaceUpOnReserve() {
+        var scn = GetScenario();
+        var ttf = scn.GetLSCard("ttf");
+        var luke = scn.GetLSCard("luke");
+        var leia = scn.GetLSCard("leia");
+        var han = scn.GetLSCard("han");
+        var priorReserve = scn.GetLSCard("chewie");
+
+        scn.StartGame();
+        scn.MoveCardsToTopOfLSUsedPile(luke, leia, han);
+        scn.MoveCardsToTopOfOwnReserveDeck(priorReserve);
+        assertEquals(3, scn.GetLSUsedPileCount());
+        assertFalse(priorReserve.isFaceUpInReserveDeck());
+
+        applyFaceUpUsedToReserve(scn, ttf, scn.LS);
+
+        assertEquals(0, scn.GetLSUsedPileCount());
+        assertFalse(priorReserve.isFaceUpInReserveDeck());
+        int faceUp = 0;
+        for (var c : scn.GetLSReserveDeck()) {
+            if (c.isFaceUpInReserveDeck()) {
+                faceUp++;
+            }
+        }
+        assertEquals(3, faceUp);
+        // Face-up Reserve cards are NOT inserts.
+        for (var c : scn.GetLSReserveDeck()) {
+            if (c.isFaceUpInReserveDeck()) {
+                assertFalse(c.isInserted());
+            }
+        }
+    }
+
+    @Test
+    public void ThroughTheForceThingsYouWillSee_FaceUpClearsWhenLeavingReserve() {
+        var scn = GetScenario();
+        var ttf = scn.GetLSCard("ttf");
+        var luke = scn.GetLSCard("luke");
+        var leia = scn.GetLSCard("leia");
+
+        scn.StartGame();
+        scn.MoveCardsToTopOfLSUsedPile(luke, leia);
+        applyFaceUpUsedToReserve(scn, ttf, scn.LS);
+
+        List<PhysicalCardImpl> faceUps = new ArrayList<>();
+        for (var c : scn.GetLSReserveDeck()) {
+            if (c.isFaceUpInReserveDeck()) {
+                faceUps.add((PhysicalCardImpl) c);
+            }
+        }
+        assertFalse(faceUps.isEmpty());
+        PhysicalCardImpl faceUpCard = faceUps.get(0);
+        // MoveCardsToTop clears card stats (incl. face-up); restore mark after reorder.
+        if (scn.GetTopOfLSReserveDeck() != faceUpCard) {
+            scn.MoveCardsToTopOfOwnReserveDeck(faceUpCard);
+            faceUpCard.setFaceUpInReserveDeck(true);
+        }
+        assertTrue(faceUpCard.isFaceUpInReserveDeck());
+
+        scn.LSActivateForceCheat(1);
+        assertFalse(faceUpCard.isFaceUpInReserveDeck());
+        assertTrue(faceUpCard.getZone() == Zone.FORCE_PILE || faceUpCard.getZone() == Zone.TOP_OF_FORCE_PILE);
+    }
+
+    @Test
+    public void ThroughTheForceThingsYouWillSee_PlayableAtEndOfOpponentDrawPhase() {
+        var scn = GetScenario();
+        var ttf = scn.GetLSCard("ttf");
+        var vader = scn.GetDSCard("vader");
+
+        scn.StartGame();
+        scn.MoveCardsToLSHand(ttf);
+        scn.SkipToDSTurn(Phase.DRAW);
+        scn.MoveCardsToTopOfDSUsedPile(vader);
+        assertEquals(Phase.DRAW, scn.gameState().getCurrentPhase());
+        assertTrue(scn.GetDSUsedPileCount() > 0);
+
+        var actions = ttf.getBlueprint().getOptionalAfterActions(
+                scn.LS, scn.game(), new EndOfPhaseResult(Phase.DRAW), ttf);
+        assertNotNull(actions);
+        assertFalse(actions.isEmpty());
+    }
+
+    @Test
+    public void ThroughTheForceThingsYouWillSee_OpponentDrawPhase_AffectsOpponent() {
+        var scn = GetScenario();
+        var ttf = scn.GetLSCard("ttf");
+        var vader = scn.GetDSCard("vader");
+        var trooper = scn.GetDSCard("trooper");
+        var dsPrior = scn.GetDSCard("officer");
+
+        scn.StartGame();
+        scn.MoveCardsToTopOfDSUsedPile(vader, trooper);
+        scn.MoveCardsToTopOfOwnReserveDeck(dsPrior);
+
+        applyFaceUpUsedToReserve(scn, ttf, scn.DS);
+
+        assertEquals(0, scn.GetDSUsedPileCount());
+        assertFalse(dsPrior.isFaceUpInReserveDeck());
+        int faceUp = 0;
+        for (var c : scn.GetDSReserveDeck()) {
+            if (c.isFaceUpInReserveDeck()) {
+                faceUp++;
+            }
+        }
+        assertEquals(2, faceUp);
+    }
+
+    @Test
+    public void ThroughTheForceThingsYouWillSee_AccessDeniedFaceUpFoundUsesInsertRevealPath() {
+        var scn = GetScenario();
+        var ttf = scn.GetLSCard("ttf");
+        var access = scn.GetLSCard("accessDenied");
+        var luke = scn.GetLSCard("luke");
+
+        scn.StartGame();
+        scn.MoveCardsToTopOfLSUsedPile(access, luke);
+        applyFaceUpUsedToReserve(scn, ttf, scn.LS);
+
+        assertTrue(access.isFaceUpInReserveDeck());
+        assertFalse(access.isInserted());
+
+        scn.MoveCardsToTopOfOwnReserveDeck(access);
+        Action revealAction = access.getBlueprint().getInsertCardRevealedAction(scn.game(), access);
+        assertNotNull(revealAction);
+
+        // Piggyback reveal/lose path for face-up Access Denied (AR Appendix B).
+        access.setInsertCardRevealed(true);
+        TopLevelGameTextAction loseAction = new TopLevelGameTextAction(access, scn.LS, access.getCardId());
+        new LoseInsertCardEffect(loseAction, access).playEffect(scn.game());
+
+        assertTrue(access.getZone() == Zone.LOST_PILE || access.getZone() == Zone.TOP_OF_LOST_PILE);
+        assertFalse(access.isFaceUpInReserveDeck());
+    }
+
+    @Test
+    public void ThroughTheForceThingsYouWillSee_ClearingFaceUpDoesNotClearInsertFlag() {
+        var scn = GetScenario();
+        var ttf = scn.GetLSCard("ttf");
+        var luke = scn.GetLSCard("luke");
+        var leia = scn.GetLSCard("leia");
+
+        scn.StartGame();
+        scn.MoveCardsToTopOfOwnReserveDeck(luke);
+        luke.setInserted(true);
+        assertTrue(luke.isInserted());
+
+        scn.MoveCardsToTopOfLSUsedPile(leia);
+        applyFaceUpUsedToReserve(scn, ttf, scn.LS);
+
+        assertTrue(luke.isInserted());
+        leia.setFaceUpInReserveDeck(false);
+        assertTrue(luke.isInserted());
+    }
+}


### PR DESCRIPTION
## Summary
Implements **Through The Force Things You Will See** (Dagobah Rare Lost Interrupt, blueprint `4_64`).

At the end of any player's draw phase, that player places Used Pile face up on top of Reserve Deck, then shuffles.

### Design (Bill refine)
- **Card-local** face-up marking on cards this interrupt moves Used→Reserve (`setFaceUpInReserveDeck` / `isFaceUpInReserveDeck`). **Not** `isInserted` — face-up Reserve cards are not inserts.
- **Thin shared** Reserve-top hooks on this same PR: visibility + activation interrupt when a face-up card is on top. Not a fat FaceUpInReserve engine PR.
- Face-up clears when a card leaves Reserve.
- If **Access Denied** is among the face-up cards when found → existing insert-found / reveal path (piggyback).
- Can expand later if more cards need this.

### Also includes
- Minimal **Access Denied** (`5_15`) sources + `YOUR_RESERVE_DECK` play option so face-up-found tests and insert overlap work. Overlaps with open Access Denied work (PR #1027) — coordinate merge order if both land.

### Engine files touched
- `PhysicalCard` / `PhysicalCardImpl` — face-up-in-Reserve flag (snapshot + visibility)
- `GameState` — clear/copy flag; treat face-up tops like insert for activation shortcut / required actions
- `InsertCardRevealedRule` / `RevealInsertCardEffect` — Effect + insert-reveal action piggyback (Access Denied)
- `PlaceUsedPileFaceUpOnReserveDeckEffect` — Used→Reserve face-up mark (does not change classic `PlaceUsedPileOnReserveDeckEffect` / Star Destroyer!)

### Tests
VHD `Card_4_064_Tests`: **8 run, 0 fail**.

Coverage: stats/icons; playable end of owner/opponent DRAW; Used→face-up Reserve (prior Reserve stays face-down; not inserts); clear on leave Reserve; opponent pile targeting; Access Denied face-up found → insert reveal/lose path; clearing face-up does not clear unrelated `isInserted`.

Closes #109.
