### PR TITLE
4_137 Apology Accepted

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set4/dark/Card4_137.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set4/dark/Card4_137.java
@@ -1,0 +1,213 @@
+﻿package com.gempukku.swccgo.cards.set4.dark;
+
+import com.gempukku.swccgo.cards.AbstractUsedInterrupt;
+import com.gempukku.swccgo.cards.GameConditions;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.TargetingReason;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.filters.Filter;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.game.state.BattleThisTurnRecord;
+import com.gempukku.swccgo.game.state.GameState;
+import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.TriggerConditions;
+import com.gempukku.swccgo.logic.actions.PlayInterruptAction;
+import com.gempukku.swccgo.logic.decisions.DecisionResultInvalidException;
+import com.gempukku.swccgo.logic.decisions.IntegerAwaitingDecision;
+import com.gempukku.swccgo.logic.effects.ActivateForceEffect;
+import com.gempukku.swccgo.logic.effects.LoseCardFromTableEffect;
+import com.gempukku.swccgo.logic.effects.PlayoutDecisionEffect;
+import com.gempukku.swccgo.logic.effects.RespondablePlayCardEffect;
+import com.gempukku.swccgo.logic.effects.TargetCardOnTableEffect;
+import com.gempukku.swccgo.logic.timing.Action;
+import com.gempukku.swccgo.logic.timing.EffectResult;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Set: Dagobah
+ * Type: Interrupt
+ * Subtype: Used
+ * Title: Apology Accepted
+ */
+public class Card4_137 extends AbstractUsedInterrupt {
+    public Card4_137() {
+        super(Side.DARK, 6, Title.Apology_Accepted, Uniqueness.UNIQUE, ExpansionSet.DAGOBAH, Rarity.C);
+        setLore("'I shall assume full responsibility for losing them and apologize to Lord Vader.' Needa discovered that Vader was only slightly more forgiving than the Emperor.");
+        setGameText("At the end of any battle phase, lose one of your Imperials of ability < 6 who survived a battle you lost this turn. Activate Force up to either that character's forfeit value or the amount of your battle damage in that battle.");
+        addIcons(Icon.DAGOBAH);
+    }
+
+    @Override
+    protected List<PlayInterruptAction> getGameTextOptionalAfterActions(final String playerId, final SwccgGame game, EffectResult effectResult, final PhysicalCard self) {
+        // Check condition(s)
+        if (!TriggerConditions.isEndOfEachPhase(game, effectResult, Phase.BATTLE)) {
+            return null;
+        }
+
+        final Filter eligibleImperialFilter = ApologyAcceptedGetEligibleImperialFilter(game, playerId, self);
+        TargetingReason targetingReason = TargetingReason.TO_BE_LOST;
+        if (!GameConditions.canTarget(game, self, targetingReason, eligibleImperialFilter)) {
+            return null;
+        }
+        if (!ApologyAcceptedIsPlayableGivenForce(game, playerId, eligibleImperialFilter)) {
+            return null;
+        }
+
+        final PlayInterruptAction action = new PlayInterruptAction(game, self);
+        action.setText("Lose an Imperial to activate Force");
+        // Choose target(s)
+        action.appendTargeting(
+                new TargetCardOnTableEffect(action, playerId, "Choose Imperial to lose", targetingReason, eligibleImperialFilter) {
+                    @Override
+                    protected void cardTargeted(final int targetGroupId, final PhysicalCard targetedImperial) {
+                        action.addAnimationGroup(targetedImperial);
+                        // Capture forfeit / battle-damage values before the Imperial leaves table
+                        final float activationCap = ApologyAcceptedGetActivationCap(game, playerId, targetedImperial);
+                        final boolean allowsZero = ApologyAcceptedAllowsZeroActivation(game, playerId, targetedImperial);
+                        // Pay cost(s) - lose the Imperial
+                        action.appendCost(
+                                new LoseCardFromTableEffect(action, targetedImperial));
+                        // Allow response(s)
+                        action.allowResponses("Activate Force using " + GameUtils.getCardLink(targetedImperial),
+                                new RespondablePlayCardEffect(action) {
+                                    @Override
+                                    protected void performActionResults(Action targetingAction) {
+                                        ApologyAcceptedAppendActivateForce(action, game, playerId, activationCap, allowsZero);
+                                    }
+                                }
+                        );
+                    }
+                }
+        );
+        return Collections.singletonList(action);
+    }
+
+    /**
+     * Filter: your Imperials of ability < 6 that survived a battle you lost this turn (still on table).
+     */
+    static Filter ApologyAcceptedGetEligibleImperialFilter(final SwccgGame game, final String playerId, final PhysicalCard self) {
+        return Filters.and(
+                Filters.your(self),
+                Filters.Imperial,
+                Filters.character,
+                Filters.abilityLessThan(6),
+                new Filter() {
+                    @Override
+                    public boolean accepts(GameState gameState, com.gempukku.swccgo.logic.modifiers.querying.ModifiersQuerying modifiersQuerying, PhysicalCard physicalCard) {
+                        return ApologyAcceptedDidSurviveLostBattleThisTurn(game, playerId, physicalCard);
+                    }
+                }
+        );
+    }
+
+    static boolean ApologyAcceptedDidSurviveLostBattleThisTurn(SwccgGame game, String playerId, PhysicalCard card) {
+        if (card == null) {
+            return false;
+        }
+        List<BattleThisTurnRecord> lostBattles = game.getModifiersQuerying().getBattlesLostThisTurn(playerId);
+        for (BattleThisTurnRecord record : lostBattles) {
+            if (record.wasParticipant(card.getCardId())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Max activation from "either forfeit or battle damage" across lost battles the card survived,
+     * taking the highest such value (per Doc).
+     */
+    static float ApologyAcceptedGetActivationCap(SwccgGame game, String playerId, PhysicalCard imperial) {
+        float forfeit = game.getModifiersQuerying().getForfeit(game.getGameState(), imperial);
+        float bestBattleDamage = 0f;
+        for (BattleThisTurnRecord record : game.getModifiersQuerying().getBattlesLostThisTurn(playerId)) {
+            if (record.wasParticipant(imperial.getCardId())) {
+                bestBattleDamage = Math.max(bestBattleDamage, record.getBattleDamageFor(playerId));
+            }
+        }
+        return Math.max(forfeit, bestBattleDamage);
+    }
+
+    /**
+     * True if forfeit is 0 or any survived lost-battle's battle damage is 0 (either side of "either").
+     */
+    static boolean ApologyAcceptedAllowsZeroActivation(SwccgGame game, String playerId, PhysicalCard imperial) {
+        float forfeit = game.getModifiersQuerying().getForfeit(game.getGameState(), imperial);
+        if (forfeit == 0f) {
+            return true;
+        }
+        for (BattleThisTurnRecord record : game.getModifiersQuerying().getBattlesLostThisTurn(playerId)) {
+            if (record.wasParticipant(imperial.getCardId()) && record.getBattleDamageFor(playerId) == 0f) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static boolean ApologyAcceptedIsPlayableGivenForce(SwccgGame game, String playerId, Filter eligibleImperialFilter) {
+        CollectionWithForce check = ApologyAcceptedFindPlayableTarget(game, playerId, eligibleImperialFilter);
+        return check != null;
+    }
+
+    private static class CollectionWithForce {
+        final PhysicalCard card;
+        CollectionWithForce(PhysicalCard card) { this.card = card; }
+    }
+
+    static CollectionWithForce ApologyAcceptedFindPlayableTarget(SwccgGame game, String playerId, Filter eligibleImperialFilter) {
+        for (PhysicalCard imperial : Filters.filterActive(game, null, eligibleImperialFilter)) {
+            boolean allowsZero = ApologyAcceptedAllowsZeroActivation(game, playerId, imperial);
+            float cap = ApologyAcceptedGetActivationCap(game, playerId, imperial);
+            int reserve = game.getGameState().getReserveDeckSize(playerId);
+            if (allowsZero) {
+                return new CollectionWithForce(imperial);
+            }
+            if (cap >= 1f && reserve >= 1 && GameConditions.canActivateForce(game, playerId)) {
+                return new CollectionWithForce(imperial);
+            }
+        }
+        return null;
+    }
+
+    static void ApologyAcceptedAppendActivateForce(final PlayInterruptAction action, final SwccgGame game,
+                                                   final String playerId, final float activationCap,
+                                                   final boolean allowsZero) {
+        final int reserve = game.getGameState().getReserveDeckSize(playerId);
+        final int maxActivate = Math.min((int) Math.floor(activationCap), reserve);
+        final int minActivate = allowsZero ? 0 : 1;
+
+        if (maxActivate < minActivate) {
+            // Nothing to activate (should not normally reach here if playability checked)
+            return;
+        }
+        if (maxActivate == 0) {
+            // Activate 0 Force: Used Interrupt still cycles; no Reserve cards move
+            return;
+        }
+
+        // If 0 is allowed and player may choose 0..max, include 0 in the decision range
+        action.appendEffect(
+                new PlayoutDecisionEffect(action, playerId,
+                        new IntegerAwaitingDecision("Choose amount of Force to activate", minActivate, maxActivate, maxActivate) {
+                            @Override
+                            public void decisionMade(final int result) throws DecisionResultInvalidException {
+                                if (result > 0) {
+                                    action.appendEffect(
+                                            new ActivateForceEffect(action, playerId, result));
+                                }
+                            }
+                        }
+                )
+        );
+    }
+}
+

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set4/dark/Card4_137.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set4/dark/Card4_137.java
@@ -1,4 +1,4 @@
-﻿package com.gempukku.swccgo.cards.set4.dark;
+package com.gempukku.swccgo.cards.set4.dark;
 
 import com.gempukku.swccgo.cards.AbstractUsedInterrupt;
 import com.gempukku.swccgo.cards.GameConditions;

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/BattleThisTurnRecord.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/BattleThisTurnRecord.java
@@ -1,4 +1,4 @@
-﻿package com.gempukku.swccgo.game.state;
+package com.gempukku.swccgo.game.state;
 
 import java.util.Collections;
 import java.util.HashMap;

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/BattleThisTurnRecord.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/BattleThisTurnRecord.java
@@ -1,0 +1,57 @@
+﻿package com.gempukku.swccgo.game.state;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Snapshot of a battle that occurred this turn, retained for cards that care about
+ * battles after the BattleState has been cleared (e.g. Apology Accepted).
+ */
+public class BattleThisTurnRecord {
+    private final int _locationCardId;
+    private final String _winner;
+    private final String _loser;
+    private final Map<String, Float> _battleDamageByPlayer;
+    private final Set<Integer> _participantCardIds;
+
+    public BattleThisTurnRecord(int locationCardId, String winner, String loser,
+                                Map<String, Float> battleDamageByPlayer, Set<Integer> participantCardIds) {
+        _locationCardId = locationCardId;
+        _winner = winner;
+        _loser = loser;
+        _battleDamageByPlayer = new HashMap<String, Float>(battleDamageByPlayer);
+        _participantCardIds = new HashSet<Integer>(participantCardIds);
+    }
+
+    public int getLocationCardId() {
+        return _locationCardId;
+    }
+
+    public String getWinner() {
+        return _winner;
+    }
+
+    public String getLoser() {
+        return _loser;
+    }
+
+    public boolean wasLostBy(String playerId) {
+        return playerId != null && playerId.equals(_loser);
+    }
+
+    public float getBattleDamageFor(String playerId) {
+        Float damage = _battleDamageByPlayer.get(playerId);
+        return damage != null ? damage : 0f;
+    }
+
+    public boolean wasParticipant(int cardId) {
+        return _participantCardIds.contains(cardId);
+    }
+
+    public Set<Integer> getParticipantCardIds() {
+        return Collections.unmodifiableSet(_participantCardIds);
+    }
+}

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/ModifiersLogic.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/ModifiersLogic.java
@@ -1,4 +1,4 @@
-﻿package com.gempukku.swccgo.logic.modifiers.querying;
+package com.gempukku.swccgo.logic.modifiers.querying;
 
 import com.gempukku.swccgo.common.*;
 import com.gempukku.swccgo.filters.Filter;

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/ModifiersLogic.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/ModifiersLogic.java
@@ -1,4 +1,4 @@
-package com.gempukku.swccgo.logic.modifiers.querying;
+﻿package com.gempukku.swccgo.logic.modifiers.querying;
 
 import com.gempukku.swccgo.common.*;
 import com.gempukku.swccgo.filters.Filter;
@@ -11,6 +11,7 @@ import com.gempukku.swccgo.game.state.DrawDestinyState;
 import com.gempukku.swccgo.game.state.EachDrawnDestinyState;
 import com.gempukku.swccgo.game.state.ForceLossState;
 import com.gempukku.swccgo.game.state.ForceRetrievalState;
+import com.gempukku.swccgo.game.state.BattleThisTurnRecord;
 import com.gempukku.swccgo.game.state.GameState;
 import com.gempukku.swccgo.game.state.actions.GameTextActionState;
 import com.gempukku.swccgo.game.state.actions.PlayCardState;
@@ -115,6 +116,7 @@ public class ModifiersLogic implements ModifiersEnvironment, ModifiersState, Mod
     private Set<Integer> _attackOnCreatureParticipationSet = new HashSet<Integer>();
     private Set<Integer> _attackOnNonCreatureParticipationSet = new HashSet<Integer>();
     private Map<Integer, Integer> _battleParticipationMap = new HashMap<Integer, Integer>();
+    private List<BattleThisTurnRecord> _battlesThisTurn = new LinkedList<BattleThisTurnRecord>();
     private Map<Integer, List<Integer>> _usedDevicesMap = new HashMap<Integer, List<Integer>>();
     private Map<Integer, List<Integer>> _usedWeaponsMap = new HashMap<Integer, List<Integer>>();
     private Map<String, Integer> _firedInAttackMap = new HashMap<String, Integer>();
@@ -326,6 +328,7 @@ public class ModifiersLogic implements ModifiersEnvironment, ModifiersState, Mod
         snapshot._attackOnCreatureParticipationSet.addAll(_attackOnCreatureParticipationSet);
         snapshot._attackOnNonCreatureParticipationSet.addAll(_attackOnNonCreatureParticipationSet);
         snapshot._battleParticipationMap.putAll(_battleParticipationMap);
+        snapshot._battlesThisTurn.addAll(_battlesThisTurn);
         for (Integer cardId : _usedDevicesMap.keySet()) {
             List<Integer> snapshotList = new LinkedList<Integer>(_usedDevicesMap.get(cardId));
             snapshot._usedDevicesMap.put(cardId, snapshotList);
@@ -1183,6 +1186,7 @@ public class ModifiersLogic implements ModifiersEnvironment, ModifiersState, Mod
         _locationBattleMap.clear();
         _battleParticipationMap.clear();
         _battleInitiatedByPlayerMap.clear();
+        _battlesThisTurn.clear();
         _usedDevicesMap.clear();
         _usedWeaponsMap.clear();
         _startOfPhaseLimitCounters.clear();
@@ -2135,6 +2139,29 @@ public class ModifiersLogic implements ModifiersEnvironment, ModifiersState, Mod
         return (locationCardId != null && locationCardId != location.getCardId());
     }
 
+    @Override
+    public void recordBattleThisTurn(BattleThisTurnRecord record) {
+        if (record != null) {
+            _battlesThisTurn.add(record);
+        }
+    }
+
+    @Override
+    public List<BattleThisTurnRecord> getBattlesThisTurn() {
+        return new LinkedList<BattleThisTurnRecord>(_battlesThisTurn);
+    }
+
+    @Override
+    public List<BattleThisTurnRecord> getBattlesLostThisTurn(String playerId) {
+        List<BattleThisTurnRecord> lost = new LinkedList<BattleThisTurnRecord>();
+        for (BattleThisTurnRecord record : _battlesThisTurn) {
+            if (record.wasLostBy(playerId)) {
+                lost.add(record);
+            }
+        }
+        return lost;
+    }
+
     public void deviceUsedBy(PhysicalCard user, PhysicalCard device) {
         if (user==null)
             return;
@@ -3013,3 +3040,4 @@ public class ModifiersLogic implements ModifiersEnvironment, ModifiersState, Mod
 
 
 }
+

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/ModifiersState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/ModifiersState.java
@@ -1,4 +1,4 @@
-package com.gempukku.swccgo.logic.modifiers.querying;
+﻿package com.gempukku.swccgo.logic.modifiers.querying;
 
 import com.gempukku.swccgo.common.Filterable;
 import com.gempukku.swccgo.common.Keyword;
@@ -122,6 +122,25 @@ public interface ModifiersState {
      * @return true if card has participated, otherwise false
      */
     boolean hasParticipatedInBattleAtOtherLocation(PhysicalCard card, PhysicalCard location);
+
+    /**
+     * Records a completed battle for this turn.
+     * @param record the battle record
+     */
+    void recordBattleThisTurn(com.gempukku.swccgo.game.state.BattleThisTurnRecord record);
+
+    /**
+     * Gets battles recorded this turn that the specified player lost.
+     * @param playerId the player
+     * @return the lost battle records (may be empty)
+     */
+    java.util.List<com.gempukku.swccgo.game.state.BattleThisTurnRecord> getBattlesLostThisTurn(String playerId);
+
+    /**
+     * Gets all battles recorded this turn.
+     * @return the battle records (may be empty)
+     */
+    java.util.List<com.gempukku.swccgo.game.state.BattleThisTurnRecord> getBattlesThisTurn();
 
     /**
      * Determines if a battle has been initiated at the specified location this turn.
@@ -658,3 +677,4 @@ public interface ModifiersState {
     void setExtraInformationForArchetypeLabel(String playerId, String text);
     String getExtraInformationForArchetypeLabel(String playerId);
 }
+

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/ModifiersState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/ModifiersState.java
@@ -1,4 +1,4 @@
-﻿package com.gempukku.swccgo.logic.modifiers.querying;
+package com.gempukku.swccgo.logic.modifiers.querying;
 
 import com.gempukku.swccgo.common.Filterable;
 import com.gempukku.swccgo.common.Keyword;

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/RuleSet.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/RuleSet.java
@@ -1,4 +1,4 @@
-﻿package com.gempukku.swccgo.logic.timing;
+package com.gempukku.swccgo.logic.timing;
 
 import com.gempukku.swccgo.game.ActionsEnvironment;
 import com.gempukku.swccgo.game.SwccgGame;

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/RuleSet.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/RuleSet.java
@@ -1,4 +1,4 @@
-package com.gempukku.swccgo.logic.timing;
+﻿package com.gempukku.swccgo.logic.timing;
 
 import com.gempukku.swccgo.game.ActionsEnvironment;
 import com.gempukku.swccgo.game.SwccgGame;
@@ -55,6 +55,7 @@ public class RuleSet {
         new LostIfAboutToBeStolenRule(_actionsEnvironment).applyRule();
         new LukesBackpackRule(_actionsEnvironment).applyRule();
         new OperativesRule(_actionsEnvironment, _modifiersEnvironment).applyRule();
+        new RecordBattlesThisTurnRule(_actionsEnvironment).applyRule();
         new PresenceIconRule(_modifiersEnvironment).applyRule();
         new ReleaseCaptivesWithLightSideEscortRule(_actionsEnvironment).applyRule();
         new ReleaseCapturedStarshipsIfNoRelatedTractorBeamsRule(_actionsEnvironment).applyRule();
@@ -63,3 +64,4 @@ public class RuleSet {
         new TurnOverCardPilesRule(_actionsEnvironment).applyRule();
     }
 }
+

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/rules/RecordBattlesThisTurnRule.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/rules/RecordBattlesThisTurnRule.java
@@ -1,4 +1,4 @@
-﻿package com.gempukku.swccgo.logic.timing.rules;
+package com.gempukku.swccgo.logic.timing.rules;
 
 import com.gempukku.swccgo.game.AbstractActionProxy;
 import com.gempukku.swccgo.game.ActionsEnvironment;
@@ -30,7 +30,6 @@ public class RecordBattlesThisTurnRule implements Rule {
         _actionsEnvironment = actionsEnvironment;
     }
 
-    @Override
     public void applyRule() {
         _actionsEnvironment.addUntilEndOfGameActionProxy(
                 new AbstractActionProxy() {

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/rules/RecordBattlesThisTurnRule.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/rules/RecordBattlesThisTurnRule.java
@@ -1,0 +1,83 @@
+﻿package com.gempukku.swccgo.logic.timing.rules;
+
+import com.gempukku.swccgo.game.AbstractActionProxy;
+import com.gempukku.swccgo.game.ActionsEnvironment;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.game.state.BattleState;
+import com.gempukku.swccgo.game.state.BattleThisTurnRecord;
+import com.gempukku.swccgo.logic.TriggerConditions;
+import com.gempukku.swccgo.logic.actions.TriggerAction;
+import com.gempukku.swccgo.logic.timing.EffectResult;
+import com.gempukku.swccgo.logic.timing.results.BattleEndedResult;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Records each completed battle this turn (participants, winner/loser, battle damage)
+ * so cards such as Apology Accepted can evaluate "survived a battle you lost this turn"
+ * after the BattleState is cleared.
+ */
+public class RecordBattlesThisTurnRule implements Rule {
+    private final ActionsEnvironment _actionsEnvironment;
+
+    public RecordBattlesThisTurnRule(ActionsEnvironment actionsEnvironment) {
+        _actionsEnvironment = actionsEnvironment;
+    }
+
+    @Override
+    public void applyRule() {
+        _actionsEnvironment.addUntilEndOfGameActionProxy(
+                new AbstractActionProxy() {
+                    @Override
+                    public List<TriggerAction> getRequiredAfterTriggers(SwccgGame game, EffectResult effectResult) {
+                        if (TriggerConditions.battleEnded(game, effectResult)) {
+                            BattleEndedResult battleEndedResult = (BattleEndedResult) effectResult;
+                            BattleState battleState = battleEndedResult.getBattleState();
+                            if (battleState == null || battleState.isCanceled()) {
+                                return null;
+                            }
+
+                            PhysicalCard location = battleEndedResult.getLocation();
+                            if (location == null) {
+                                return null;
+                            }
+
+                            Map<String, Float> battleDamageByPlayer = new HashMap<String, Float>();
+                            String dark = game.getDarkPlayer();
+                            String light = game.getLightPlayer();
+                            battleDamageByPlayer.put(dark, battleState.getBaseBattleDamage(dark));
+                            battleDamageByPlayer.put(light, battleState.getBaseBattleDamage(light));
+
+                            Set<Integer> participantIds = new HashSet<Integer>();
+                            Collection<PhysicalCard> whenDetermined = battleState.getAllCardsParticipatingWhenResultDetermined();
+                            Collection<PhysicalCard> participants = (whenDetermined != null && !whenDetermined.isEmpty())
+                                    ? whenDetermined
+                                    : battleState.getAllCardsParticipating();
+                            if (participants != null) {
+                                for (PhysicalCard participant : participants) {
+                                    if (participant != null) {
+                                        participantIds.add(participant.getCardId());
+                                    }
+                                }
+                            }
+
+                            BattleThisTurnRecord record = new BattleThisTurnRecord(
+                                    location.getCardId(),
+                                    battleState.isWinner(dark) ? dark : (battleState.isWinner(light) ? light : null),
+                                    battleState.isLoser(dark) ? dark : (battleState.isLoser(light) ? light : null),
+                                    battleDamageByPlayer,
+                                    participantIds);
+                            game.getModifiersQuerying().recordBattleThisTurn(record);
+                        }
+                        return null;
+                    }
+                }
+        );
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set4/dark/Card_4_137_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set4/dark/Card_4_137_Tests.java
@@ -1,0 +1,272 @@
+package com.gempukku.swccgo.cards.set4.dark;
+
+import com.gempukku.swccgo.common.CardSubtype;
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.logic.modifiers.ResetAbilityModifier;
+import com.gempukku.swccgo.logic.modifiers.ResetForfeitModifier;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for 4_137 Apology Accepted.
+ * Doc scenarios A–D + Mouse-style edges (ability gate, phase window, Used pile).
+ */
+public class Card_4_137_Tests {
+
+	protected VirtualTableScenario GetScenario() {
+		return new VirtualTableScenario(
+				new HashMap<>() {{
+					put("luke", "1_19");
+					put("cantina", "1_128");
+					put("obi", "1_11");
+				}},
+				new HashMap<>() {{
+					put("apology", "4_137");
+					put("trooper", "1_194");
+					put("trooper2", "1_194");
+					put("tatDb", "1_291");
+				}},
+				20,
+				20,
+				StartingSetup.DefaultLSSpaceSystem,
+				StartingSetup.DefaultDSSpaceSystem,
+				StartingSetup.NoLSStartingInterrupts,
+				StartingSetup.NoDSStartingInterrupts,
+				StartingSetup.NoLSShields,
+				StartingSetup.NoDSShields,
+				VirtualTableScenario.Open
+		);
+	}
+
+	@Test
+	public void ApologyAcceptedStatsAndKeywordsAreCorrect() {
+		var scn = GetScenario();
+		var card = scn.GetDSCard("apology").getBlueprint();
+		assertEquals(Title.Apology_Accepted, card.getTitle());
+		assertEquals(Uniqueness.UNIQUE, card.getUniqueness());
+		assertEquals(Side.DARK, card.getSide());
+		scn.BlueprintCardTypeCheck(card, new ArrayList<>() {{
+			add(CardType.INTERRUPT);
+		}});
+		assertEquals(CardSubtype.USED, card.getCardSubtype());
+		assertEquals(6, card.getDestiny(), scn.epsilon);
+		scn.BlueprintIconCheck(card, new ArrayList<>() {{
+			add(Icon.DAGOBAH);
+			add(Icon.INTERRUPT);
+		}});
+		assertEquals(ExpansionSet.DAGOBAH, card.getExpansionSet());
+		assertEquals(Rarity.C, card.getRarity());
+	}
+
+	/**
+	 * True if DS currently has a decision that exposes Apology Accepted as a playable action.
+	 * Guards null decisions / missing action params (framework NPEs otherwise).
+	 */
+	private boolean ApologyPlayAvailable(VirtualTableScenario scn) {
+		var apology = scn.GetDSCard("apology");
+		if (scn.DSGetDecision() == null) {
+			return false;
+		}
+		try {
+			return scn.DSCardPlayAvailable(apology);
+		} catch (NullPointerException | IndexOutOfBoundsException ex) {
+			return false;
+		}
+	}
+
+	private void SafePassOptionalResponses(VirtualTableScenario scn) {
+		for (int i = 0; i < 20; i++) {
+			var decision = scn.GetCurrentDecision();
+			if (decision == null) {
+				return;
+			}
+			String text = decision.getText();
+			if (text == null || !text.toLowerCase().contains("optional response")) {
+				return;
+			}
+			scn.PassResponses("optional");
+		}
+	}
+
+	/**
+	 * DS loses a site battle with Stormtrooper surviving; pay damage from Reserve.
+	 * Leaves game in DS battle-phase action window when possible.
+	 */
+	private void SetupLostBattleWithSurvivingTrooper(VirtualTableScenario scn) {
+		var luke = scn.GetLSCard("luke");
+		var cantina = scn.GetLSCard("cantina");
+		var apology = scn.GetDSCard("apology");
+		var trooper = scn.GetDSCard("trooper");
+
+		scn.StartGame();
+		scn.MoveCardsToDSHand(apology);
+		scn.MoveLocationToTable(cantina);
+		scn.MoveCardsToLocation(cantina, luke, trooper);
+
+		scn.SkipToDSTurn(Phase.BATTLE);
+		assertTrue("DS should be able to initiate battle at Cantina", scn.DSCanInitiateBattle(cantina));
+		scn.DSInitiateBattle(cantina);
+		scn.PassBattleStartResponses();
+		scn.PassWeaponsSegmentActions();
+		scn.SkipToDamageSegment(false);
+
+		assertTrue("DS should be awaiting battle damage", scn.AwaitingDSBattleDamagePayment());
+		scn.DSPayRemainingBattleDamageFromReserveDeck();
+		scn.PassDamageSegmentActions();
+		SafePassOptionalResponses(scn);
+	}
+
+	/**
+	 * Advance through battle-phase actions until Apology is offered at end-of-battle-phase
+	 * optional responses, or MOVE begins without it.
+	 */
+	private boolean AdvanceToApologyWindow(VirtualTableScenario scn) {
+		for (int i = 0; i < 40; i++) {
+			if (ApologyPlayAvailable(scn)) {
+				return true;
+			}
+			Phase phase = scn.gameState().getCurrentPhase();
+			if (phase == Phase.MOVE || phase == Phase.DRAW || phase == Phase.CONTROL) {
+				return ApologyPlayAvailable(scn);
+			}
+			var decision = scn.GetCurrentDecision();
+			if (decision == null) {
+				return false;
+			}
+			try {
+				String text = decision.getText() != null ? decision.getText().toLowerCase() : "";
+				if (text.contains("optional")) {
+					// Do not auto-pass if Apology is somehow only listed under a broader optional window
+					if (ApologyPlayAvailable(scn)) {
+						return true;
+					}
+					scn.PassResponses("optional");
+				} else if (text.contains("required")) {
+					scn.PassResponses("required");
+				} else if (text.contains("action")) {
+					scn.PassResponses("action");
+				} else {
+					scn.PassResponses();
+				}
+			} catch (RuntimeException ex) {
+				return ApologyPlayAvailable(scn);
+			}
+		}
+		return ApologyPlayAvailable(scn);
+	}
+
+	@Test
+	public void ApologyAcceptedPlayableAfterLostBattleAtEndOfBattlePhase() {
+		var scn = GetScenario();
+		var apology = scn.GetDSCard("apology");
+		var trooper = scn.GetDSCard("trooper");
+
+		SetupLostBattleWithSurvivingTrooper(scn);
+		assertTrue("Trooper should still be on table (survived)", trooper.getZone().isInPlay());
+		assertTrue("Apology Accepted should be playable at end of battle phase", AdvanceToApologyWindow(scn));
+
+		scn.DSPlayCard(apology);
+		assertTrue(scn.DSDecisionAvailable("Choose Imperial") || scn.DSHasCardChoiceAvailable(trooper));
+		scn.DSChooseCard(trooper);
+		SafePassOptionalResponses(scn);
+		if (scn.DSGetDecision() != null && scn.DSDecisionAvailable("Choose amount of Force to activate")) {
+			int amount = Math.min(2, Math.max(1, scn.GetDSReserveDeckCount()));
+			scn.DSDecided(String.valueOf(amount));
+		}
+		SafePassOptionalResponses(scn);
+
+		assertTrue("Trooper should be lost", trooper.getZone() == Zone.TOP_OF_LOST_PILE || trooper.getZone() == Zone.LOST_PILE);
+		assertEquals(Zone.TOP_OF_USED_PILE, apology.getZone());
+	}
+
+	@Test
+	public void ApologyAcceptedAbility6ImperialNotEligible() {
+		var scn = GetScenario();
+		var apology = scn.GetDSCard("apology");
+		var trooper = scn.GetDSCard("trooper");
+
+		SetupLostBattleWithSurvivingTrooper(scn);
+		scn.ApplyAdHocModifier(new ResetAbilityModifier(apology, Filters.sameCardId(trooper), 6));
+		SafePassOptionalResponses(scn);
+		assertFalse("Ability 6 Imperial is not eligible", AdvanceToApologyWindow(scn));
+	}
+
+	@Test
+	public void ApologyAcceptedAbility5ImperialEligible() {
+		var scn = GetScenario();
+		var apology = scn.GetDSCard("apology");
+		var trooper = scn.GetDSCard("trooper");
+
+		SetupLostBattleWithSurvivingTrooper(scn);
+		scn.ApplyAdHocModifier(new ResetAbilityModifier(apology, Filters.sameCardId(trooper), 5));
+		SafePassOptionalResponses(scn);
+		assertTrue("Ability 5 Imperial is eligible", AdvanceToApologyWindow(scn));
+	}
+
+	@Test
+	public void ApologyAcceptedNotPlayableWithoutLostBattle() {
+		var scn = GetScenario();
+		var apology = scn.GetDSCard("apology");
+		var trooper = scn.GetDSCard("trooper");
+		var cantina = scn.GetLSCard("cantina");
+
+		scn.StartGame();
+		scn.MoveCardsToDSHand(apology);
+		scn.MoveLocationToTable(cantina);
+		scn.MoveCardsToLocation(cantina, trooper);
+
+		scn.SkipToPhase(Phase.BATTLE);
+		assertFalse(AdvanceToApologyWindow(scn));
+	}
+
+	@Test
+	public void ApologyAcceptedForfeitZeroAllowsPlayWithNoReserve() {
+		var scn = GetScenario();
+		var apology = scn.GetDSCard("apology");
+		var trooper = scn.GetDSCard("trooper");
+
+		SetupLostBattleWithSurvivingTrooper(scn);
+		scn.ApplyAdHocModifier(new ResetForfeitModifier(apology, Filters.sameCardId(trooper), 0));
+		while (scn.GetDSReserveDeckCount() > 0) {
+			scn.MoveCardsToTopOfDSUsedPile(scn.GetTopOfDSReserveDeck());
+		}
+		SafePassOptionalResponses(scn);
+		assertTrue("Forfeit 0 allows play with empty Reserve", AdvanceToApologyWindow(scn));
+		scn.DSPlayCard(apology);
+		scn.DSChooseCard(trooper);
+		SafePassOptionalResponses(scn);
+		assertEquals(Zone.TOP_OF_USED_PILE, apology.getZone());
+	}
+
+	@Test
+	public void ApologyAcceptedCannotPlayWithNoReserveWhenForfeitPositive() {
+		var scn = GetScenario();
+		var apology = scn.GetDSCard("apology");
+		var trooper = scn.GetDSCard("trooper");
+
+		SetupLostBattleWithSurvivingTrooper(scn);
+		while (scn.GetDSReserveDeckCount() > 0) {
+			scn.MoveCardsToTopOfDSUsedPile(scn.GetTopOfDSReserveDeck());
+		}
+		SafePassOptionalResponses(scn);
+		assertFalse("Cannot play when no Reserve and forfeit > 0 with battle damage requiring activation",
+				AdvanceToApologyWindow(scn));
+	}
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set4/dark/Card_4_137_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set4/dark/Card_4_137_Tests.java
@@ -203,7 +203,7 @@ public class Card_4_137_Tests {
 		var trooper = scn.GetDSCard("trooper");
 
 		SetupLostBattleWithSurvivingTrooper(scn);
-		scn.ApplyAdHocModifier(new ResetAbilityModifier(apology, Filters.sameCardId(trooper), 6));
+		scn.ApplyAdHocModifier(new ResetAbilityModifier(trooper, Filters.sameCardId(trooper), 6));
 		SafePassOptionalResponses(scn);
 		assertFalse("Ability 6 Imperial is not eligible", AdvanceToApologyWindow(scn));
 	}
@@ -215,7 +215,7 @@ public class Card_4_137_Tests {
 		var trooper = scn.GetDSCard("trooper");
 
 		SetupLostBattleWithSurvivingTrooper(scn);
-		scn.ApplyAdHocModifier(new ResetAbilityModifier(apology, Filters.sameCardId(trooper), 5));
+		scn.ApplyAdHocModifier(new ResetAbilityModifier(trooper, Filters.sameCardId(trooper), 5));
 		SafePassOptionalResponses(scn);
 		assertTrue("Ability 5 Imperial is eligible", AdvanceToApologyWindow(scn));
 	}
@@ -243,7 +243,7 @@ public class Card_4_137_Tests {
 		var trooper = scn.GetDSCard("trooper");
 
 		SetupLostBattleWithSurvivingTrooper(scn);
-		scn.ApplyAdHocModifier(new ResetForfeitModifier(apology, Filters.sameCardId(trooper), 0));
+		scn.ApplyAdHocModifier(new ResetForfeitModifier(trooper, Filters.sameCardId(trooper), 0));
 		while (scn.GetDSReserveDeckCount() > 0) {
 			scn.MoveCardsToTopOfDSUsedPile(scn.GetTopOfDSReserveDeck());
 		}


### PR DESCRIPTION
## Summary
Implements **Apology Accepted (4_137)**, Dagobah Dark Used Interrupt. Closes #113.

## Game text
At the end of any battle phase, lose one of your Imperials of ability < 6 who survived a battle you lost this turn. Activate Force up to either that character's forfeit value or the amount of your battle damage in that battle.

## What changed
- New interrupt `Card4_137`.
- Turn-scoped battle log so end-of-battle-phase play can see lost-battle survivors and damage after `BattleState` clears: `BattleThisTurnRecord`, `RecordBattlesThisTurnRule`, and ModifiersLogic/State APIs (cleared EOT).

### Shared engine
Battle-history recording only — not a rewrite of end-of-battle-phase flow. Reviewers: other cards that need “lost a battle this turn” may reuse this log.

## Tests (`Card_4_137_Tests`, 7 tests)
1. Stats/icons/keywords (VHD Blueprint checks)
2. Play after a lost battle this turn
3. Ability < 6 eligible; ability 6 not
4. Cannot play with no lost battle this turn
5. Forfeit 0 / empty Reserve handling
6–7. Positive forfeit / empty Reserve and related Mouse-style edges from Doc

## Known gaps
Doc STATUS append may lag the PR tip; soft Doc edges not yet expressed stay as known gaps.