### PR TITLE
Add Tight Squeeze (4_65)

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set4/light/Card4_065.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set4/light/Card4_065.java
@@ -19,7 +19,7 @@ import com.gempukku.swccgo.logic.actions.RequiredGameTextTriggerAction;
 import com.gempukku.swccgo.logic.actions.TriggerAction;
 import com.gempukku.swccgo.logic.effects.AddUntilEndOfBattleActionProxyEffect;
 import com.gempukku.swccgo.logic.effects.AddUntilEndOfTurnActionProxyEffect;
-import com.gempukku.swccgo.logic.effects.ForfeitCardFromTableEffect;
+import com.gempukku.swccgo.logic.effects.LoseCardFromTableEffect;
 import com.gempukku.swccgo.logic.effects.RespondablePlayCardEffect;
 import com.gempukku.swccgo.logic.effects.UseForceEffect;
 import com.gempukku.swccgo.logic.effects.choose.ChooseCardsOnTableEffect;
@@ -84,7 +84,7 @@ public class Card4_065 extends AbstractLostInterrupt {
                     @Override
                     protected void cardsSelected(Collection<PhysicalCard> selectedCards) {
                         for (PhysicalCard selected : selectedCards) {
-                            action.appendEffect(new ForfeitCardFromTableEffect(action, selected));
+                            action.appendEffect(new LoseCardFromTableEffect(action, selected));
                         }
                     }
                 }

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set4/light/Card4_065.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set4/light/Card4_065.java
@@ -1,0 +1,185 @@
+package com.gempukku.swccgo.cards.set4.light;
+
+import com.gempukku.swccgo.cards.AbstractLostInterrupt;
+import com.gempukku.swccgo.cards.GameConditions;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.filters.Filter;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.AbstractActionProxy;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.logic.TriggerConditions;
+import com.gempukku.swccgo.logic.actions.PlayInterruptAction;
+import com.gempukku.swccgo.logic.actions.RequiredGameTextTriggerAction;
+import com.gempukku.swccgo.logic.actions.TriggerAction;
+import com.gempukku.swccgo.logic.effects.AddUntilEndOfBattleActionProxyEffect;
+import com.gempukku.swccgo.logic.effects.AddUntilEndOfTurnActionProxyEffect;
+import com.gempukku.swccgo.logic.effects.ForfeitCardFromTableEffect;
+import com.gempukku.swccgo.logic.effects.RespondablePlayCardEffect;
+import com.gempukku.swccgo.logic.effects.UseForceEffect;
+import com.gempukku.swccgo.logic.effects.choose.ChooseCardsOnTableEffect;
+import com.gempukku.swccgo.logic.timing.Action;
+import com.gempukku.swccgo.logic.timing.EffectResult;
+import com.gempukku.swccgo.logic.timing.results.MovedAtEndOfAttackRunResult;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Set: Dagobah
+ * Type: Interrupt
+ * Subtype: Lost
+ * Title: Tight Squeeze
+ */
+public class Card4_065 extends AbstractLostInterrupt {
+    public Card4_065() {
+        super(Side.LIGHT, 3, Title.Tight_Squeeze, Uniqueness.UNIQUE, ExpansionSet.DAGOBAH, Rarity.R);
+        setLore("Rebel pilots often join the Rebellion from Outer Rim worlds. Bush pilots fly by the seat of their pants, giving them a huge advantage in close quarters.");
+        setGameText("If you have a lone vehicle or starfighter in a battle or Attack Run at Beggar's Canyon, Cloud City, Death Star: Trench or an asteroid sector, use 1 Force. At the end of that battle or Attack Run, opponent must forfeit two participating vehicles or starfighters.");
+        addIcons(Icon.DAGOBAH);
+    }
+
+    private Filter getValidLocationFilter() {
+        return Filters.or(Filters.Beggars_Canyon, Filters.Bespin_Cloud_City, Filters.Death_Star_Trench, Filters.asteroid_sector);
+    }
+
+    private Filter getYourLoneVehicleOrStarfighterFilter(PhysicalCard self) {
+        return Filters.and(Filters.your(self), Filters.or(Filters.vehicle, Filters.starfighter), Filters.alone);
+    }
+
+    private Filter getOpponentsParticipatingVehicleOrStarfighterFilter(PhysicalCard self) {
+        return Filters.and(Filters.opponents(self), Filters.or(Filters.vehicle, Filters.starfighter), Filters.participatingInBattle);
+    }
+
+    private boolean canPlayDuringBattle(SwccgGame game, PhysicalCard self, String playerId) {
+        return GameConditions.isDuringBattleAt(game, getValidLocationFilter())
+                && GameConditions.isDuringBattleWithParticipant(game, getYourLoneVehicleOrStarfighterFilter(self))
+                && GameConditions.canSpot(game, self, 2, getOpponentsParticipatingVehicleOrStarfighterFilter(self))
+                && GameConditions.canUseForceToPlayInterrupt(game, playerId, self, 1);
+    }
+
+    private boolean canPlayDuringAttackRun(SwccgGame game, PhysicalCard self, String playerId) {
+        Filter yourLone = Filters.and(getYourLoneVehicleOrStarfighterFilter(self), Filters.at(Filters.Death_Star_Trench));
+        Filter opponentsAtTrench = Filters.and(Filters.opponents(self), Filters.or(Filters.vehicle, Filters.starfighter), Filters.at(Filters.Death_Star_Trench));
+        return GameConditions.isDuringAttackRunWithParticipant(game, yourLone)
+                && GameConditions.canSpot(game, self, 2, opponentsAtTrench)
+                && GameConditions.canUseForceToPlayInterrupt(game, playerId, self, 1);
+    }
+
+    private void appendForfeitTwoEffect(final Action action, final SwccgGame game, final PhysicalCard self, final String opponent, final Filter targetFilter) {
+        int available = Filters.countActive(game, self, targetFilter);
+        int num = Math.min(2, available);
+        if (num <= 0) {
+            return;
+        }
+        action.appendEffect(
+                new ChooseCardsOnTableEffect(action, opponent, "Choose vehicle or starfighter to forfeit", num, num, targetFilter) {
+                    @Override
+                    protected void cardsSelected(Collection<PhysicalCard> selectedCards) {
+                        for (PhysicalCard selected : selectedCards) {
+                            action.appendEffect(new ForfeitCardFromTableEffect(action, selected));
+                        }
+                    }
+                }
+        );
+    }
+
+    private PlayInterruptAction createBattleAction(final String playerId, final SwccgGame game, final PhysicalCard self) {
+        final String opponent = game.getOpponent(playerId);
+        final PlayInterruptAction action = new PlayInterruptAction(game, self);
+        action.setText("Force opponent to forfeit two at end of battle");
+        action.appendCost(new UseForceEffect(action, playerId, 1));
+        action.allowResponses("At end of battle, opponent forfeits two participating vehicles or starfighters",
+                new RespondablePlayCardEffect(action) {
+                    @Override
+                    protected void performActionResults(Action targetingAction) {
+                        final int permCardId = self.getPermanentCardId();
+                        final int gameTextSourceCardId = self.getCardId();
+                        action.appendEffect(
+                                new AddUntilEndOfBattleActionProxyEffect(action,
+                                        new AbstractActionProxy() {
+                                            @Override
+                                            public List<TriggerAction> getRequiredAfterTriggers(SwccgGame game, EffectResult effectResult) {
+                                                final PhysicalCard self = game.findCardByPermanentId(permCardId);
+                                                if (TriggerConditions.battleEndingAt(game, effectResult, getValidLocationFilter())) {
+                                                    final RequiredGameTextTriggerAction action2 = new RequiredGameTextTriggerAction(self, gameTextSourceCardId);
+                                                    action2.setText("Opponent forfeits two vehicles or starfighters");
+                                                    appendForfeitTwoEffect(action2, game, self, opponent, getOpponentsParticipatingVehicleOrStarfighterFilter(self));
+                                                    return Collections.singletonList((TriggerAction) action2);
+                                                }
+                                                return null;
+                                            }
+                                        }
+                                )
+                        );
+                    }
+                }
+        );
+        return action;
+    }
+
+    private PlayInterruptAction createAttackRunAction(final String playerId, final SwccgGame game, final PhysicalCard self) {
+        final String opponent = game.getOpponent(playerId);
+        final PlayInterruptAction action = new PlayInterruptAction(game, self);
+        action.setText("Force opponent to forfeit two at end of Attack Run");
+        action.appendCost(new UseForceEffect(action, playerId, 1));
+        action.allowResponses("At end of Attack Run, opponent forfeits two participating vehicles or starfighters",
+                new RespondablePlayCardEffect(action) {
+                    @Override
+                    protected void performActionResults(Action targetingAction) {
+                        final int permCardId = self.getPermanentCardId();
+                        final int gameTextSourceCardId = self.getCardId();
+                        action.appendEffect(
+                                new AddUntilEndOfTurnActionProxyEffect(action,
+                                        new AbstractActionProxy() {
+                                            private boolean _fired;
+
+                                            @Override
+                                            public List<TriggerAction> getRequiredAfterTriggers(SwccgGame game, EffectResult effectResult) {
+                                                if (_fired) {
+                                                    return null;
+                                                }
+                                                final PhysicalCard self = game.findCardByPermanentId(permCardId);
+                                                if (effectResult instanceof MovedAtEndOfAttackRunResult) {
+                                                    _fired = true;
+                                                    final RequiredGameTextTriggerAction action2 = new RequiredGameTextTriggerAction(self, gameTextSourceCardId);
+                                                    action2.setText("Opponent forfeits two vehicles or starfighters");
+                                                    Filter forfeitFilter = Filters.and(Filters.opponents(self), Filters.or(Filters.vehicle, Filters.starfighter), Filters.at(Filters.Death_Star_Trench));
+                                                    appendForfeitTwoEffect(action2, game, self, opponent, forfeitFilter);
+                                                    return Collections.singletonList((TriggerAction) action2);
+                                                }
+                                                return null;
+                                            }
+                                        }
+                                )
+                        );
+                    }
+                }
+        );
+        return action;
+    }
+
+    @Override
+    protected List<PlayInterruptAction> getGameTextTopLevelActions(final String playerId, SwccgGame game, final PhysicalCard self) {
+        List<PlayInterruptAction> actions = new LinkedList<PlayInterruptAction>();
+        if (canPlayDuringBattle(game, self, playerId)) {
+            actions.add(createBattleAction(playerId, game, self));
+        }
+        return actions;
+    }
+
+    @Override
+    protected List<PlayInterruptAction> getGameTextTopLevelAttackRunActions(final String playerId, SwccgGame game, final PhysicalCard self) {
+        if (canPlayDuringAttackRun(game, self, playerId)) {
+            return Collections.singletonList(createAttackRunAction(playerId, game, self));
+        }
+        return null;
+    }
+}

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set4/light/Card4_065.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set4/light/Card4_065.java
@@ -19,7 +19,7 @@ import com.gempukku.swccgo.logic.actions.RequiredGameTextTriggerAction;
 import com.gempukku.swccgo.logic.actions.TriggerAction;
 import com.gempukku.swccgo.logic.effects.AddUntilEndOfBattleActionProxyEffect;
 import com.gempukku.swccgo.logic.effects.AddUntilEndOfTurnActionProxyEffect;
-import com.gempukku.swccgo.logic.effects.LoseCardFromTableEffect;
+import com.gempukku.swccgo.logic.effects.ForfeitCardFromTableEffect;
 import com.gempukku.swccgo.logic.effects.RespondablePlayCardEffect;
 import com.gempukku.swccgo.logic.effects.UseForceEffect;
 import com.gempukku.swccgo.logic.effects.choose.ChooseCardsOnTableEffect;
@@ -84,7 +84,7 @@ public class Card4_065 extends AbstractLostInterrupt {
                     @Override
                     protected void cardsSelected(Collection<PhysicalCard> selectedCards) {
                         for (PhysicalCard selected : selectedCards) {
-                            action.appendEffect(new LoseCardFromTableEffect(action, selected));
+                            action.appendEffect(new ForfeitCardFromTableEffect(action, selected));
                         }
                     }
                 }

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
@@ -99254,6 +99254,34 @@
     ]
   },
   {
+    "cardId": "4_65",
+    "title": "Tight Squeeze",
+    "slug": "tight-squeeze",
+    "slugWithSetName": "tight-squeeze-dagobah",
+    "side": "LIGHT",
+    "uniqueness": "UNIQUE",
+    "expansionSet": "DAGOBAH",
+    "rarity": "R",
+    "cardCategory": "INTERRUPT",
+    "cardTypes": [
+      "INTERRUPT"
+    ],
+    "cardSubtype": "LOST",
+    "lore": "Rebel pilots often join the Rebellion from Outer Rim worlds. Bush pilots fly by the seat of their pants, giving them a huge advantage in close quarters.",
+    "gameText": "If you have a lone vehicle or starfighter in a battle or Attack Run at Beggar's Canyon, Cloud City, Death Star: Trench or an asteroid sector, use 1 Force. At the end of that battle or Attack Run, opponent must forfeit two participating vehicles or starfighters.",
+    "destiny": 3,
+    "icons": [
+      {
+        "icon": "DAGOBAH",
+        "count": 1
+      },
+      {
+        "icon": "INTERRUPT",
+        "count": 1
+      }
+    ]
+  },
+  {
     "cardId": "4_66",
     "title": "Transmission Terminated",
     "slug": "transmission-terminated",

--- a/src/gemp-swccg-common/src/main/java/com/gempukku/swccgo/common/Title.java
+++ b/src/gemp-swccg-common/src/main/java/com/gempukku/swccgo/common/Title.java
@@ -1156,6 +1156,7 @@ public interface Title {
     String Thats_One = "That's One";
     String They_Have_No_Idea_Were_Coming = "They Have No Idea We're Coming";
     String They_Must_Never_Again_Leave_This_City = "They Must Never Again Leave This City";
+    String Tight_Squeeze = "Tight Squeeze";
     String Theyve_Shut_Down_The_Main_Reactor = "They've Shut Down The Main Reactor";
     String The_Camp = "The Camp";
     String The_Circle_Is_Now_Complete = "The Circle Is Now Complete";

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
@@ -19459,6 +19459,7 @@ public class Filters {
     public static final Filter They_Have_No_Idea_Were_Coming = Filters.title(Title.They_Have_No_Idea_Were_Coming);
     public static final Filter Theyre_On_Dantooine = Filters.title(Title.Theyre_On_Dantooine);
     public static final Filter Theyve_Shut_Down_The_Main_Reactor = Filters.title(Title.Theyve_Shut_Down_The_Main_Reactor);
+    public static final Filter Tight_Squeeze = Filters.title(Title.Tight_Squeeze);
     public static final Filter thief = Filters.keyword(Keyword.THIEF);
     public static final Filter Third_Marker = Filters.keyword(Keyword.MARKER_3);
     public static final Filter They_Will_Be_Lost_And_Confused = Filters.title(Title.They_Will_Be_Lost_And_Confused);

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/BattleState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/BattleState.java
@@ -684,8 +684,11 @@ public class BattleState implements Snapshotable<BattleState> {
     }
 
     public float getAttritionTotal(SwccgGame game, String player) {
-        if (_reachedDamageSegment)
-            return _totalAttrition.get(player);
+        if (_reachedDamageSegment) {
+            // Null-safe: end-of-battle forfeit effects can run after totals are cleared
+            Float attrition = _totalAttrition.get(player);
+            return attrition == null ? 0 : attrition;
+        }
 
         if (_baseAttrition.get(player) == null)
             return 0;

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set4/light/Card_4_65_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set4/light/Card_4_65_Tests.java
@@ -1,0 +1,89 @@
+package com.gempukku.swccgo.cards.set4.light;
+
+import com.gempukku.swccgo.common.CardSubtype;
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class Card_4_65_Tests {
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("squeeze", "4_65");
+                    put("xwing", "1_146");
+                    put("kessel", "1_126");
+                    put("asteroid", "4_081");
+                }},
+                new HashMap<>() {{
+                    put("tie1", "1_304");
+                    put("tie2", "9_175");
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void TightSqueezeStatsAndKeywordsAreCorrect() {
+        var scn = GetScenario();
+        var card = scn.GetLSCard("squeeze").getBlueprint();
+
+        assertEquals("Tight Squeeze", card.getTitle());
+        assertEquals(Uniqueness.UNIQUE, card.getUniqueness());
+        assertEquals(Side.LIGHT, card.getSide());
+        scn.BlueprintCardTypeCheck(card, new ArrayList<>() {{
+            add(CardType.INTERRUPT);
+        }});
+        assertEquals(CardSubtype.LOST, card.getCardSubtype());
+        assertEquals(3, card.getDestiny(), scn.epsilon);
+        scn.BlueprintIconCheck(card, new ArrayList<>() {{
+            add(Icon.INTERRUPT);
+            add(Icon.DAGOBAH);
+        }});
+        assertEquals(ExpansionSet.DAGOBAH, card.getExpansionSet());
+        assertEquals(Rarity.R, card.getRarity());
+    }
+
+    @Test
+    public void TightSqueezeNotPlayableWithOnlyOneOpposingStarfighter() {
+        var scn = GetScenario();
+
+        var squeeze = scn.GetLSCard("squeeze");
+        var xwing = scn.GetLSCard("xwing");
+        var kessel = scn.GetLSCard("kessel");
+        var asteroid = scn.GetLSCard("asteroid");
+        var tie1 = scn.GetDSCard("tie1");
+
+        scn.StartGame();
+        scn.MoveCardsToLSHand(squeeze);
+        scn.MoveLocationToTable(kessel);
+        scn.MoveLocationToTable(asteroid);
+        scn.MoveCardsToLocation(asteroid, xwing, tie1);
+
+        scn.SkipToLSTurn(Phase.BATTLE);
+        scn.LSInitiateBattle(asteroid);
+        scn.PassAllResponses();
+
+        assertFalse(scn.LSCardPlayAvailable(squeeze));
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set4/light/Card_4_65_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set4/light/Card_4_65_Tests.java
@@ -4,10 +4,12 @@ import com.gempukku.swccgo.common.CardSubtype;
 import com.gempukku.swccgo.common.CardType;
 import com.gempukku.swccgo.common.ExpansionSet;
 import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Keyword;
 import com.gempukku.swccgo.common.Phase;
 import com.gempukku.swccgo.common.Rarity;
 import com.gempukku.swccgo.common.Side;
 import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.common.Zone;
 import com.gempukku.swccgo.framework.StartingSetup;
 import com.gempukku.swccgo.framework.VirtualTableScenario;
 import org.junit.Test;
@@ -17,24 +19,76 @@ import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class Card_4_65_Tests {
     protected VirtualTableScenario GetScenario() {
         return new VirtualTableScenario(
                 new HashMap<>() {{
                     put("squeeze", "4_65");
-                    put("xwing", "1_146");
+                    put("ywing", "1_147");
                     put("kessel", "1_126");
                     put("asteroid", "4_081");
                 }},
                 new HashMap<>() {{
                     put("tie1", "1_304");
-                    put("tie2", "9_175");
+                    put("tie2", "1_304");
                 }},
                 10,
                 10,
                 StartingSetup.DefaultLSGroundLocation,
                 StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    protected VirtualTableScenario GetTrenchBattleScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("squeeze", "4_65");
+                    put("ywing", "1_147");
+                    put("deathstar", "7_117");
+                    put("trench", "2_62");
+                }},
+                new HashMap<>() {{
+                    put("tie1", "1_304");
+                    put("tie2", "1_304");
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSSpaceSystem,
+                StartingSetup.DefaultDSSpaceSystem,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    protected VirtualTableScenario GetAttackRunScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("squeeze", "4_65");
+                    put("red2", "2_70");
+                    put("biggs", "1_3");
+                    put("torpedoes", "1_158");
+                    put("deathstar", "7_117");
+                    put("trench", "2_62");
+                    put("attackrun", "2_42");
+                }},
+                new HashMap<>() {{
+                    put("tie1", "1_304");
+                    put("tie2", "1_304");
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSSpaceSystem,
+                StartingSetup.DefaultDSSpaceSystem,
                 StartingSetup.NoLSStartingInterrupts,
                 StartingSetup.NoDSStartingInterrupts,
                 StartingSetup.NoLSShields,
@@ -60,6 +114,8 @@ public class Card_4_65_Tests {
             add(Icon.INTERRUPT);
             add(Icon.DAGOBAH);
         }});
+        scn.BlueprintKeywordCheck(card, new ArrayList<Keyword>() {{
+        }});
         assertEquals(ExpansionSet.DAGOBAH, card.getExpansionSet());
         assertEquals(Rarity.R, card.getRarity());
     }
@@ -69,7 +125,7 @@ public class Card_4_65_Tests {
         var scn = GetScenario();
 
         var squeeze = scn.GetLSCard("squeeze");
-        var xwing = scn.GetLSCard("xwing");
+        var ywing = scn.GetLSCard("ywing");
         var kessel = scn.GetLSCard("kessel");
         var asteroid = scn.GetLSCard("asteroid");
         var tie1 = scn.GetDSCard("tie1");
@@ -78,12 +134,146 @@ public class Card_4_65_Tests {
         scn.MoveCardsToLSHand(squeeze);
         scn.MoveLocationToTable(kessel);
         scn.MoveLocationToTable(asteroid);
-        scn.MoveCardsToLocation(asteroid, xwing, tie1);
+        scn.MoveCardsToLocation(asteroid, ywing, tie1);
 
         scn.SkipToLSTurn(Phase.BATTLE);
         scn.LSInitiateBattle(asteroid);
         scn.PassAllResponses();
 
         assertFalse(scn.LSCardPlayAvailable(squeeze));
+    }
+
+    @Test
+    public void TightSqueezePlayableWithLoneStarfighterAndTwoOpposingInAsteroidBattle() {
+        var scn = GetScenario();
+
+        var squeeze = scn.GetLSCard("squeeze");
+        var ywing = scn.GetLSCard("ywing");
+        var kessel = scn.GetLSCard("kessel");
+        var asteroid = scn.GetLSCard("asteroid");
+        var tie1 = scn.GetDSCard("tie1");
+        var tie2 = scn.GetDSCard("tie2");
+
+        scn.StartGame();
+        scn.MoveCardsToLSHand(squeeze);
+        scn.MoveLocationToTable(kessel);
+        scn.MoveLocationToTable(asteroid);
+
+        scn.SkipToLSTurn(Phase.DEPLOY);
+        scn.MoveCardsToLocation(asteroid, ywing, tie1, tie2);
+        scn.SkipToPhase(Phase.BATTLE);
+        scn.LSInitiateBattle(asteroid);
+        scn.PassAllResponses();
+
+        assertTrue(scn.LSCardPlayAvailable(squeeze));
+        int forceBefore = scn.GetLSForcePileCount();
+        scn.LSPlayCard(squeeze);
+        scn.PassAllResponses();
+
+        assertEquals(forceBefore - 1, scn.GetLSForcePileCount());
+        assertEquals(Zone.TOP_OF_LOST_PILE, squeeze.getZone());
+    }
+
+    @Test
+    public void TightSqueezeAtEndOfBattleOpponentForfeitsTwoParticipatingStarfighters() {
+        var scn = GetTrenchBattleScenario();
+
+        var squeeze = scn.GetLSCard("squeeze");
+        var ywing = scn.GetLSCard("ywing");
+        var deathstar = scn.GetLSCard("deathstar");
+        var trench = scn.GetLSCard("trench");
+        var tie1 = scn.GetDSCard("tie1");
+        var tie2 = scn.GetDSCard("tie2");
+
+        scn.StartGame();
+        scn.MoveCardsToLSHand(squeeze);
+        scn.MoveLocationToTable(deathstar);
+        scn.MoveLocationToTable(trench);
+        scn.MoveCardsToLocation(trench, ywing, tie1, tie2);
+
+        scn.SkipToLSTurn(Phase.BATTLE);
+        scn.LSInitiateBattle(trench);
+        scn.PassAllResponses();
+
+        assertTrue(scn.LSCardPlayAvailable(squeeze));
+        scn.LSPlayCard(squeeze);
+        scn.PassAllResponses();
+
+        scn.PassWeaponsSegmentActions();
+        scn.SkipBattleDestinyDraws(false);
+        scn.PassResponses("INITIAL_ATTRITION_CALCULATED");
+        if (scn.AwaitingDSDamageSegmentActions() || scn.AwaitingLSDamageSegmentActions()) {
+            scn.PassDamageSegmentActions();
+        }
+
+        // Exactly two legal targets often auto-selects; otherwise choose both TIEs
+        if (scn.DSDecisionAvailable("Choose vehicle or starfighter to forfeit")) {
+            assertTrue(scn.DSHasCardChoiceAvailable(tie1));
+            assertTrue(scn.DSHasCardChoiceAvailable(tie2));
+            scn.DSChooseCards(tie1, tie2);
+        }
+        // Finish leave-table responses for both forfeited ships
+        for (int i = 0; i < 10; i++) {
+            if (tie1.getZone() != Zone.AT_LOCATION && tie2.getZone() != Zone.AT_LOCATION) {
+                break;
+            }
+            if (scn.DSAnyDecisionsAvailable() || scn.LSAnyDecisionsAvailable()) {
+                scn.PassAllResponses();
+                scn.PassResponses("ABOUT_TO_BE_LOST_FROM_TABLE");
+                scn.PassResponses("LOST_FROM_TABLE");
+                scn.PassCardLeavingTable();
+            } else {
+                break;
+            }
+        }
+
+        assertTrue(tie1.getZone() == Zone.LOST_PILE || tie1.getZone() == Zone.TOP_OF_LOST_PILE);
+        assertTrue(tie2.getZone() == Zone.LOST_PILE || tie2.getZone() == Zone.TOP_OF_LOST_PILE);
+        assertTrue(scn.CardsAtLocation(trench, ywing));
+    }
+
+    @Test
+    public void TightSqueezePlayableDuringAttackRunWithLoneStarfighterAndTwoOpposingAtTrench() {
+        var scn = GetAttackRunScenario();
+
+        var squeeze = scn.GetLSCard("squeeze");
+        var attackrun = scn.GetLSCard("attackrun");
+        var red2 = scn.GetLSCard("red2");
+        var biggs = scn.GetLSCard("biggs");
+        var torpedoes = scn.GetLSCard("torpedoes");
+        var deathstar = scn.GetLSCard("deathstar");
+        var trench = scn.GetLSCard("trench");
+        var tie1 = scn.GetDSCard("tie1");
+        var tie2 = scn.GetDSCard("tie2");
+
+        scn.StartGame();
+        scn.MoveCardsToLSHand(squeeze);
+        scn.MoveLocationToTable(deathstar);
+        scn.MoveLocationToTable(trench);
+        scn.AttachCardsTo(trench, attackrun);
+        scn.MoveCardsToLocation(deathstar, red2, tie1, tie2);
+        scn.BoardAsPilot(red2, biggs);
+        scn.AttachCardsTo(red2, torpedoes);
+
+        scn.SkipToLSTurn(Phase.MOVE);
+
+        assertTrue(scn.LSActionAvailable("Attempt to 'blow away' Death Star"));
+        scn.PrepareLSDestiny(1);
+        scn.PrepareLSDestiny(1);
+        scn.LSChooseAction("Attempt to 'blow away' Death Star");
+        scn.PassResponses("MOVING_AT_START_OF_ATTACK_RUN");
+        scn.PassResponses("MOVED_AT_START_OF_ATTACK_RUN");
+
+        scn.DSChooseCard(tie1);
+        scn.PassResponses("MOVING_AT_START_OF_ATTACK_RUN");
+        scn.PassResponses("MOVED_AT_START_OF_ATTACK_RUN");
+        scn.DSChooseCard(tie2);
+        scn.PassResponses("MOVING_AT_START_OF_ATTACK_RUN");
+        scn.PassResponses("MOVED_AT_START_OF_ATTACK_RUN");
+
+        assertTrue(scn.LSCardPlayAvailable(squeeze));
+        scn.LSPlayCard(squeeze);
+        scn.PassAllResponses();
+        assertEquals(Zone.TOP_OF_LOST_PILE, squeeze.getZone());
     }
 }


### PR DESCRIPTION
## Summary
Implements Dagobah Lost Interrupt **Tight Squeeze** (4_65 / Closes #110).

- If you have a lone vehicle or starfighter in a battle or Attack Run at Beggar's Canyon, Cloud City, Death Star: Trench, or an asteroid sector, use 1 Force
- At the end of that battle or Attack Run, opponent must forfeit two participating vehicles or starfighters
- Battle path uses `AddUntilEndOfBattleActionProxyEffect` + `battleEndingAt`
- Attack Run path uses `getGameTextTopLevelAttackRunActions` + end-of-Attack-Run move trigger
- End-of-battle/Attack Run uses printed `ForfeitCardFromTableEffect`
- `BattleState.getAttritionTotal` null-safe so forfeit can resolve at BATTLE_ENDING after attrition totals clear

No second attack-react; no parallel Used-Pile work.

## Tests
VHD `Card_4_65_Tests`: **5/5 passing**
- Stats/keywords (BlueprintIconCheck + BlueprintKeywordCheck)
- Not playable with only one opposing starfighter
- Playable with lone starfighter + two opposing in asteroid battle (uses 1 Force)
- End-of-battle: opponent forfeits two participating starfighters (Death Star: Trench)
- Playable during Attack Run with lone starfighter + two opposing at Trench

## Checklist
- [x] Independent PR vs master
- [x] VHD tests green (5/5)
- [x] Overlay app_3 only (tip this SHA; other cards preserved)
- [x] Google Doc Tight Squeeze tab STATUS (anonymous)

Closes #110