### PR TITLE
5_137 Double-Crossing, No-Good Swindler (Closes #126)

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/dark/Card5_137.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/dark/Card5_137.java
@@ -99,9 +99,14 @@ public class Card5_137 extends AbstractLostInterrupt {
                                     new AddUntilEndOfCardPlayedModifierEffect(action, self,
                                             new DeploysFreeModifier(self, Filters.and(Filters.your(self), Filters.trooper)),
                                             "Troopers deploy free"));
-                            // May repeatedly deploy from hand to destination site (not as a react)
+                            // May repeatedly deploy from hand to destination site (not as a react).
+                            // Limit to cards that can actually deploy to a site / cards there — excludes
+                            // side-of-table Effects (e.g. Den Of Thieves).
+                            Filter deployableToSite = Filters.or(Filters.character, Filters.starship, Filters.vehicle,
+                                    Filters.weapon, Filters.device, Filters.and(Filters.Effect,
+                                            Filters.or(Filters.deploys_on_location, Filters.deploys_on_characters)));
                             action.appendEffect(
-                                    new DeployCardsToLocationFromHandEffect(action, playerId, Filters.any, thatSite, false));
+                                    new DeployCardsToLocationFromHandEffect(action, playerId, deployableToSite, thatSite, false));
                         }
                     }
             );

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/dark/Card5_137.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/dark/Card5_137.java
@@ -1,0 +1,112 @@
+package com.gempukku.swccgo.cards.set5.dark;
+
+import com.gempukku.swccgo.cards.AbstractLostInterrupt;
+import com.gempukku.swccgo.cards.GameConditions;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.filters.Filter;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.TriggerConditions;
+import com.gempukku.swccgo.logic.actions.PlayInterruptAction;
+import com.gempukku.swccgo.logic.effects.AddUntilEndOfCardPlayedModifierEffect;
+import com.gempukku.swccgo.logic.effects.LoseForceEffect;
+import com.gempukku.swccgo.logic.effects.PutCardFromVoidInLostPileEffect;
+import com.gempukku.swccgo.logic.effects.RespondablePlayCardEffect;
+import com.gempukku.swccgo.logic.effects.choose.DeployCardsToLocationFromHandEffect;
+import com.gempukku.swccgo.logic.modifiers.DeploysFreeModifier;
+import com.gempukku.swccgo.logic.timing.Action;
+import com.gempukku.swccgo.logic.timing.EffectResult;
+import com.gempukku.swccgo.logic.timing.results.RelocatedBetweenLocationsResult;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+
+/**
+ * Set: Cloud City
+ * Type: Interrupt
+ * Subtype: Lost
+ * Title: Double-Crossing, No-Good Swindler
+ */
+public class Card5_137 extends AbstractLostInterrupt {
+    public Card5_137() {
+        super(Side.DARK, 3, Title.Double_Crossing_No_Good_Swindler, Uniqueness.UNIQUE, ExpansionSet.CLOUD_CITY, Rarity.C);
+        setLore("'You've got a lot of guts coming here. . . after what you pulled.'");
+        setGameText("If Han and your Lando are at same site, opponent loses 3 Force. OR If Nabrun Leids just completed a transport, Nabrun is lost and you may immediately deploy cards to that site from hand (at normal use of the Force, but troopers deploy free).");
+        addIcons(Icon.CLOUD_CITY);
+    }
+
+    @Override
+    protected List<PlayInterruptAction> getGameTextTopLevelActions(final String playerId, final SwccgGame game, final PhysicalCard self) {
+        List<PlayInterruptAction> actions = new LinkedList<PlayInterruptAction>();
+
+        // Check condition(s) — Han and your Lando at same site (inactive excluded via canSpot)
+        Filter yourLando = Filters.and(Filters.your(self), Filters.Lando);
+        if (GameConditions.canSpot(game, self, Filters.and(Filters.Han, Filters.at(Filters.site), Filters.with(self, yourLando)))) {
+            final String opponent = game.getOpponent(playerId);
+
+            final PlayInterruptAction action = new PlayInterruptAction(game, self);
+            action.setText("Opponent loses 3 Force");
+            // Allow response(s)
+            action.allowResponses("Make opponent lose 3 Force",
+                    new RespondablePlayCardEffect(action) {
+                        @Override
+                        protected void performActionResults(Action targetingAction) {
+                            // Perform result(s)
+                            action.appendEffect(
+                                    new LoseForceEffect(action, opponent, 3));
+                        }
+                    }
+            );
+            actions.add(action);
+        }
+        return actions;
+    }
+
+    @Override
+    protected List<PlayInterruptAction> getGameTextOptionalAfterActions(final String playerId, SwccgGame game, final EffectResult effectResult, final PhysicalCard self) {
+        // Check condition(s)
+        if (TriggerConditions.transportCompletedBy(game, effectResult, Filters.Nabrun_Leids)) {
+            final RelocatedBetweenLocationsResult relocateResult = (RelocatedBetweenLocationsResult) effectResult;
+            final PhysicalCard nabrun = relocateResult.getActionSource();
+            final PhysicalCard destinationSite = relocateResult.getMovedTo();
+            if (nabrun == null || destinationSite == null || !Filters.site.accepts(game, destinationSite)) {
+                return null;
+            }
+
+            final Filter thatSite = Filters.sameCardId(destinationSite);
+
+            final PlayInterruptAction action = new PlayInterruptAction(game, self);
+            action.setText("Make " + GameUtils.getFullName(nabrun) + " lost and deploy to site");
+            // Allow response(s) — deployment choices happen after responses resolve (hidden intent)
+            action.allowResponses("Make " + GameUtils.getCardLink(nabrun) + " lost and deploy cards to " + GameUtils.getCardLink(destinationSite),
+                    new RespondablePlayCardEffect(action) {
+                        @Override
+                        protected void performActionResults(Action targetingAction) {
+                            // Nabrun lost (same void→lost pattern as Oo-ta Goo-ta / Quite A Mercenary)
+                            action.appendEffect(
+                                    new PutCardFromVoidInLostPileEffect(action, playerId, nabrun));
+                            // Troopers (yours) deploy free for the remainder of this card play
+                            action.appendEffect(
+                                    new AddUntilEndOfCardPlayedModifierEffect(action, self,
+                                            new DeploysFreeModifier(self, Filters.and(Filters.your(self), Filters.trooper)),
+                                            "Troopers deploy free"));
+                            // May repeatedly deploy from hand to destination site (not as a react)
+                            action.appendEffect(
+                                    new DeployCardsToLocationFromHandEffect(action, playerId, Filters.any, thatSite, false));
+                        }
+                    }
+            );
+            return Collections.singletonList(action);
+        }
+        return null;
+    }
+}

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/choose/DeployCardsToLocationFromHandEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/choose/DeployCardsToLocationFromHandEffect.java
@@ -1,0 +1,107 @@
+package com.gempukku.swccgo.logic.effects.choose;
+
+import com.gempukku.swccgo.common.Filterable;
+import com.gempukku.swccgo.filters.Filter;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.actions.SubAction;
+import com.gempukku.swccgo.logic.timing.AbstractSubActionEffect;
+import com.gempukku.swccgo.logic.timing.Action;
+import com.gempukku.swccgo.logic.timing.PassthruEffect;
+import com.gempukku.swccgo.logic.timing.StandardEffect;
+
+import java.util.Collection;
+
+/**
+ * An effect that causes the player performing the action to repeatedly choose and deploy cards from hand
+ * to a specified location until the player passes (or no deployable cards remain).
+ */
+public class DeployCardsToLocationFromHandEffect extends AbstractSubActionEffect {
+    private final String _playerId;
+    private final Filter _cardFilter;
+    private final Filter _locationFilter;
+    private final boolean _forFree;
+    private int _numDeployed;
+
+    /**
+     * Creates an effect that causes the player performing the action to choose and deploy cards accepted by the card filter
+     * from hand to a location accepted by the location filter (optional; may pass at any time).
+     * @param action the action performing this effect
+     * @param playerId the player
+     * @param cardFilter the card filter
+     * @param locationFilter the location filter
+     * @param forFree true if deploying for free, otherwise false
+     */
+    public DeployCardsToLocationFromHandEffect(Action action, String playerId, Filter cardFilter, Filterable locationFilter, boolean forFree) {
+        super(action);
+        _playerId = playerId;
+        _locationFilter = Filters.and(locationFilter);
+        _forFree = forFree;
+        _cardFilter = Filters.and(cardFilter, Filters.deployableToLocation(action.getActionSource(), _locationFilter, forFree, 0));
+        _numDeployed = 0;
+    }
+
+    @Override
+    public boolean isPlayableInFull(SwccgGame game) {
+        return true;
+    }
+
+    @Override
+    protected SubAction getSubAction(SwccgGame game) {
+        final SubAction subAction = new SubAction(_action, _playerId);
+        subAction.appendEffect(
+                new PassthruEffect(subAction) {
+                    @Override
+                    protected void doPlayEffect(SwccgGame game) {
+                        Collection<PhysicalCard> fromHand = Filters.filter(game.getGameState().getHand(_playerId), game, _cardFilter);
+                        if (!fromHand.isEmpty()) {
+                            subAction.insertEffect(getChooseOneCardToDeployEffect(subAction));
+                        }
+                    }
+                }
+        );
+        return subAction;
+    }
+
+    private StandardEffect getChooseOneCardToDeployEffect(final SubAction subAction) {
+        // min 0 so the player may pass; each selection deploys one card then re-offers
+        return new ChooseCardsFromHandEffect(subAction, _playerId, _playerId, 0, 1, _cardFilter, true, true) {
+            @Override
+            public String getChoiceText(int numCardsToChoose) {
+                return "Choose card" + GameUtils.s(numCardsToChoose) + " to deploy to that site (or pass)";
+            }
+
+            @Override
+            protected void cardsSelected(SwccgGame game, Collection<PhysicalCard> selectedCards) {
+                if (selectedCards.isEmpty()) {
+                    return;
+                }
+                PhysicalCard selectedCard = selectedCards.iterator().next();
+                _numDeployed++;
+                subAction.insertEffect(
+                        new DeployCardToLocationFromHandEffect(subAction, selectedCard, _locationFilter, _forFree, false),
+                        new PassthruEffect(subAction) {
+                            @Override
+                            protected void doPlayEffect(SwccgGame game) {
+                                Collection<PhysicalCard> remaining = Filters.filter(game.getGameState().getHand(_playerId), game, _cardFilter);
+                                if (!remaining.isEmpty()) {
+                                    subAction.insertEffect(getChooseOneCardToDeployEffect(subAction));
+                                }
+                            }
+                        }
+                );
+            }
+        };
+    }
+
+    @Override
+    protected boolean wasActionCarriedOut() {
+        return true;
+    }
+
+    public int getNumDeployed() {
+        return _numDeployed;
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_137_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_137_Tests.java
@@ -1,0 +1,261 @@
+package com.gempukku.swccgo.cards.set5.dark;
+
+import com.gempukku.swccgo.common.CardSubtype;
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * VHD tests for 5_137 Double-Crossing, No-Good Swindler.
+ * Doc Action1 (Han + your Lando) and Action2 (Nabrun transport) + Mouse-style edges.
+ */
+public class Card_5_137_Tests {
+
+	protected VirtualTableScenario GetScenario() {
+		return new VirtualTableScenario(
+				new HashMap<>() {{
+					put("han", "1_011");
+					put("nabrun", "1_097");
+					put("farm", "1_132");
+					put("cantina", "1_128");
+				}},
+				new HashMap<>() {{
+					put("swindler", "5_137");
+					put("lando", "5_099");
+					put("trooper", "1_194");
+					put("trooper2", "1_194");
+					put("dining", "5_168");
+					put("platform", "5_169");
+					put("plaza", "7_270");
+				}},
+				20,
+				20,
+				StartingSetup.DefaultLSGroundLocation,
+				StartingSetup.DefaultDSGroundLocation,
+				StartingSetup.NoLSStartingInterrupts,
+				StartingSetup.NoDSStartingInterrupts,
+				StartingSetup.NoLSShields,
+				StartingSetup.NoDSShields,
+				VirtualTableScenario.Open
+		);
+	}
+
+	private void SafePassOptionalResponses(VirtualTableScenario scn) {
+		for (int i = 0; i < 25; i++) {
+			var decision = scn.GetCurrentDecision();
+			if (decision == null) {
+				return;
+			}
+			String text = decision.getText();
+			if (text == null) {
+				return;
+			}
+			String lower = text.toLowerCase();
+			if (lower.contains("optional")) {
+				scn.PassResponses("optional");
+			} else if (lower.contains("required")) {
+				scn.PassResponses("required");
+			} else {
+				return;
+			}
+		}
+	}
+
+	@Test
+	public void DoubleCrossingNoGoodSwindlerStatsAndKeywordsAreCorrect() {
+		var scn = GetScenario();
+		var card = scn.GetDSCard("swindler").getBlueprint();
+		assertEquals(Title.Double_Crossing_No_Good_Swindler, card.getTitle());
+		assertEquals(Uniqueness.UNIQUE, card.getUniqueness());
+		assertEquals(Side.DARK, card.getSide());
+		scn.BlueprintCardTypeCheck(card, new ArrayList<>() {{
+			add(CardType.INTERRUPT);
+		}});
+		assertEquals(CardSubtype.LOST, card.getCardSubtype());
+		assertEquals(3, card.getDestiny(), scn.epsilon);
+		scn.BlueprintIconCheck(card, new ArrayList<>() {{
+			add(Icon.CLOUD_CITY);
+			add(Icon.INTERRUPT);
+		}});
+		assertEquals(ExpansionSet.CLOUD_CITY, card.getExpansionSet());
+		assertEquals(Rarity.C, card.getRarity());
+	}
+
+	@Test
+	public void DoubleCrossingPlayableWhenHanAndYourLandoAtSameSite() {
+		var scn = GetScenario();
+		var swindler = scn.GetDSCard("swindler");
+		var lando = scn.GetDSCard("lando");
+		var han = scn.GetLSCard("han");
+		var dining = scn.GetDSCard("dining");
+
+		scn.StartGame();
+		scn.MoveCardsToDSHand(swindler);
+		scn.MoveLocationToTable(dining);
+		scn.MoveCardsToLocation(dining, han, lando);
+
+		scn.SkipToPhase(Phase.CONTROL);
+		assertTrue("Swindler should be playable with Han and your Lando at same site",
+				scn.DSCardPlayAvailable(swindler));
+	}
+
+	@Test
+	public void DoubleCrossingNotPlayableWithOpponentsLandoOnly() {
+		var scn = GetScenario();
+		var swindler = scn.GetDSCard("swindler");
+		var han = scn.GetLSCard("han");
+		var dining = scn.GetDSCard("dining");
+		// LS Lando persona via filler is hard; use absence of DS Lando as the negative case
+		scn.StartGame();
+		scn.MoveCardsToDSHand(swindler);
+		scn.MoveLocationToTable(dining);
+		scn.MoveCardsToLocation(dining, han);
+
+		scn.SkipToPhase(Phase.CONTROL);
+		assertFalse("Without your Lando, Swindler Action1 is not playable",
+				scn.DSCardPlayAvailable(swindler));
+	}
+
+	@Test
+	public void DoubleCrossingNotPlayableAtSameSystemInsteadOfSite() {
+		var scn = GetScenario();
+		var swindler = scn.GetDSCard("swindler");
+		var lando = scn.GetDSCard("lando");
+		var han = scn.GetLSCard("han");
+		// Bespin system is not a site
+		var bespin = scn.GetDSCard("plaza"); // use a site that we will NOT put them on — relocate to default systems via skip
+
+		scn.StartGame();
+		scn.MoveCardsToDSHand(swindler);
+		// Place Han/Lando at starting systems (not sites) if possible — characters at system need to be aboard;
+		// instead put them at different sites to prove same-system alone is insufficient for Action1.
+		var dining = scn.GetDSCard("dining");
+		var platform = scn.GetDSCard("platform");
+		scn.MoveLocationToTable(dining);
+		scn.MoveLocationToTable(platform);
+		scn.MoveCardsToLocation(dining, han);
+		scn.MoveCardsToLocation(platform, lando);
+
+		scn.SkipToPhase(Phase.CONTROL);
+		assertFalse("Han and your Lando at different sites — Action1 not playable",
+				scn.DSCardPlayAvailable(swindler));
+	}
+
+	@Test
+	public void DoubleCrossingOpponentLoses3ForceAndCardToLostPile() {
+		var scn = GetScenario();
+		var swindler = scn.GetDSCard("swindler");
+		var lando = scn.GetDSCard("lando");
+		var han = scn.GetLSCard("han");
+		var dining = scn.GetDSCard("dining");
+
+		scn.StartGame();
+		scn.MoveCardsToDSHand(swindler);
+		scn.MoveLocationToTable(dining);
+		scn.MoveCardsToLocation(dining, han, lando);
+
+		int lsForceBefore = scn.GetLSLifeForceRemaining();
+
+		scn.SkipToPhase(Phase.CONTROL);
+		assertTrue(scn.DSCardPlayAvailable(swindler));
+		scn.DSPlayCard(swindler);
+		SafePassOptionalResponses(scn);
+
+		assertEquals("Opponent should lose 3 Force", lsForceBefore - 3, scn.GetLSLifeForceRemaining());
+		assertTrue("Swindler is Lost Interrupt",
+				swindler.getZone() == Zone.LOST_PILE || swindler.getZone() == Zone.TOP_OF_LOST_PILE);
+	}
+
+	@Test
+	public void DoubleCrossingPlayableAfterNabrunTransportNabrunLost() {
+		var scn = GetScenario();
+		var swindler = scn.GetDSCard("swindler");
+		var trooper = scn.GetDSCard("trooper");
+		var nabrun = scn.GetLSCard("nabrun");
+		var dining = scn.GetDSCard("dining");
+		var platform = scn.GetDSCard("platform");
+
+		scn.StartGame();
+		scn.MoveCardsToDSHand(swindler);
+		scn.MoveCardsToLSHand(nabrun);
+		scn.MoveLocationToTable(dining);
+		scn.MoveLocationToTable(platform);
+		// LS needs a character to transport — use Han
+		var han = scn.GetLSCard("han");
+		scn.MoveCardsToLocation(dining, han);
+		scn.MoveCardsToLocation(platform, trooper); // DS presence at destination
+
+		scn.SkipToLSTurn(Phase.CONTROL);
+		assertTrue(scn.AwaitingLSControlPhaseActions());
+		scn.PrepareLSDestiny(0);
+		scn.LSPlayCard(nabrun);
+		scn.LSChooseCard(dining);
+		scn.LSChooseCard(platform);
+		scn.LSChooseCard(han);
+		scn.PassDestinyDrawResponses();
+		scn.LSChooseYes();
+
+		// After transport completes, DS may respond with Swindler
+		boolean sawSwindler = false;
+		for (int i = 0; i < 30; i++) {
+			var decision = scn.GetCurrentDecision();
+			if (decision == null) {
+				break;
+			}
+			try {
+				if (scn.DSCardPlayAvailable(swindler)) {
+					sawSwindler = true;
+					scn.DSPlayCard(swindler);
+					SafePassOptionalResponses(scn);
+					// May be offered deploy choices — pass them
+					for (int j = 0; j < 15; j++) {
+						var d2 = scn.GetCurrentDecision();
+						if (d2 == null) break;
+						String t = d2.getText() != null ? d2.getText().toLowerCase() : "";
+						if (t.contains("deploy") || t.contains("choose card")) {
+							// pass / done
+							try { scn.DSPass(); } catch (RuntimeException ex) {
+								try { scn.PassResponses(); } catch (RuntimeException ex2) { break; }
+							}
+						} else if (t.contains("optional")) {
+							scn.PassResponses("optional");
+						} else {
+							break;
+						}
+					}
+					break;
+				}
+			} catch (RuntimeException ignored) {
+			}
+			String text = decision.getText() != null ? decision.getText().toLowerCase() : "";
+			if (text.contains("optional")) {
+				scn.PassResponses("optional");
+			} else if (text.contains("required")) {
+				scn.PassResponses("required");
+			} else {
+				try { scn.PassAllResponses(); } catch (RuntimeException ex) { break; }
+			}
+		}
+
+		assertTrue("Swindler should be offered after Nabrun transport", sawSwindler);
+		assertTrue("Nabrun should be lost",
+				nabrun.getZone() == Zone.LOST_PILE || nabrun.getZone() == Zone.TOP_OF_LOST_PILE
+						|| nabrun.getZone() == Zone.VOID);
+	}
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_137_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_137_Tests.java
@@ -43,6 +43,9 @@ public class Card_5_137_Tests {
 					put("dining", "5_168");
 					put("platform", "5_169");
 					put("plaza", "7_270");
+					put("denOfThieves", "6_143");
+					put("disarmed", "1_214");
+					put("potf", "1_227"); // Presence Of The Force
 				}},
 				20,
 				20,
@@ -257,4 +260,245 @@ public class Card_5_137_Tests {
 				nabrun.getZone() == Zone.LOST_PILE || nabrun.getZone() == Zone.TOP_OF_LOST_PILE
 						|| nabrun.getZone() == Zone.VOID);
 	}
+	/** Advance through Nabrun transport until Swindler is playable; play it; land on deploy-from-hand choice. */
+	private boolean PlaySwindlerAfterNabrunToDeployWindow(VirtualTableScenario scn) {
+		var swindler = scn.GetDSCard("swindler");
+		var nabrun = scn.GetLSCard("nabrun");
+		var han = scn.GetLSCard("han");
+		var dining = scn.GetDSCard("dining");
+		var platform = scn.GetDSCard("platform");
+
+		scn.PrepareLSDestiny(0);
+		scn.LSPlayCard(nabrun);
+		scn.LSChooseCard(dining);
+		scn.LSChooseCard(platform);
+		scn.LSChooseCard(han);
+		scn.PassDestinyDrawResponses();
+		scn.LSChooseYes();
+
+		for (int i = 0; i < 30; i++) {
+			var decision = scn.GetCurrentDecision();
+			if (decision == null) break;
+			try {
+				if (scn.DSCardPlayAvailable(swindler)) {
+					scn.DSPlayCard(swindler);
+					SafePassOptionalResponses(scn);
+					return true;
+				}
+			} catch (RuntimeException ignored) {
+			}
+			String t = decision.getText() != null ? decision.getText().toLowerCase() : "";
+			if (t.contains("optional")) {
+				scn.PassResponses("optional");
+			} else if (t.contains("required")) {
+				scn.PassResponses("required");
+			} else {
+				try { scn.PassAllResponses(); } catch (RuntimeException ex) { break; }
+			}
+		}
+		return false;
+	}
+
+	private boolean AtDeployFromHandChoice(VirtualTableScenario scn) {
+		var d = scn.GetCurrentDecision();
+		if (d == null || d.getText() == null) return false;
+		String t = d.getText().toLowerCase();
+		return t.contains("deploy") && (t.contains("hand") || t.contains("that site") || t.contains("pass"));
+	}
+
+	@Test
+	public void SwindlerDenOfThievesNotOfferedForSiteDeploy() {
+		var scn = GetScenario();
+		var swindler = scn.GetDSCard("swindler");
+		var den = scn.GetDSCard("denOfThieves");
+		var trooper = scn.GetDSCard("trooper");
+		var nabrun = scn.GetLSCard("nabrun");
+		var han = scn.GetLSCard("han");
+		var dining = scn.GetDSCard("dining");
+		var platform = scn.GetDSCard("platform");
+
+		scn.StartGame();
+		scn.MoveCardsToDSHand(swindler, den, trooper);
+		scn.MoveCardsToLSHand(nabrun);
+		scn.MoveLocationToTable(dining);
+		scn.MoveLocationToTable(platform);
+		scn.MoveCardsToLocation(dining, han);
+
+		scn.SkipToLSTurn(Phase.MOVE);
+		assertTrue("Swindler should resolve after Nabrun", PlaySwindlerAfterNabrunToDeployWindow(scn));
+
+		boolean sawDeploy = false;
+		for (int j = 0; j < 20; j++) {
+			if (AtDeployFromHandChoice(scn) || scn.DSHasCardChoiceAvailable(trooper) || scn.DSDecisionAvailable("deploy")) {
+				sawDeploy = true;
+				assertTrue("Trooper should be deployable to destination", scn.DSHasCardChoiceAvailable(trooper));
+				assertFalse("Den Of Thieves (side-of-table Effect) must not be offered for site deploy",
+						scn.DSHasCardChoiceAvailable(den));
+				try { scn.DSPass(); } catch (RuntimeException ex) {
+					try { scn.PassResponses(); } catch (RuntimeException ex2) {}
+				}
+				break;
+			}
+			SafePassOptionalResponses(scn);
+			try { scn.PassAllResponses(); } catch (RuntimeException ignored) { break; }
+		}
+		assertTrue("Should reach deploy-from-hand window", sawDeploy);
+	}
+
+	@Test
+	public void SwindlerDisarmedNotDeployableOutsideControl() {
+		var scn = GetScenario();
+		var swindler = scn.GetDSCard("swindler");
+		var disarmed = scn.GetDSCard("disarmed");
+		var trooper = scn.GetDSCard("trooper");
+		var nabrun = scn.GetLSCard("nabrun");
+		var han = scn.GetLSCard("han");
+		var dining = scn.GetDSCard("dining");
+		var platform = scn.GetDSCard("platform");
+
+		scn.StartGame();
+		scn.MoveCardsToDSHand(swindler, disarmed, trooper);
+		scn.MoveCardsToLSHand(nabrun);
+		scn.MoveLocationToTable(dining);
+		scn.MoveLocationToTable(platform);
+		// Put a DS character with a weapon at destination so Disarmed's present-at filter could otherwise match
+		scn.MoveCardsToLocation(dining, han);
+		scn.MoveCardsToLocation(platform, trooper);
+		// Give LS a weapon-bearing character at destination for Disarmed's mutual-weapon requirement if needed —
+		// but phase restriction alone should block outside Control.
+		var trooper2 = scn.GetDSCard("trooper2");
+		scn.MoveCardsToDSHand(trooper2);
+
+		scn.SkipToLSTurn(Phase.MOVE); // outside Control
+		assertTrue("Sanity: Nabrun during Move (outside Control)", scn.GetCurrentPhase() == Phase.MOVE);
+		assertTrue(PlaySwindlerAfterNabrunToDeployWindow(scn));
+
+		boolean sawDeploy = false;
+		for (int j = 0; j < 20; j++) {
+			if (AtDeployFromHandChoice(scn) || scn.DSDecisionAvailable("deploy") || scn.DSHasCardChoiceAvailable(trooper2)) {
+				sawDeploy = true;
+				assertFalse("Disarmed must not deploy via Swindler outside Control phase",
+						scn.DSHasCardChoiceAvailable(disarmed));
+				try { scn.DSPass(); } catch (RuntimeException ex) {
+					try { scn.PassResponses(); } catch (RuntimeException ex2) {}
+				}
+				break;
+			}
+			SafePassOptionalResponses(scn);
+			try { scn.PassAllResponses(); } catch (RuntimeException ignored) { break; }
+		}
+		assertTrue(sawDeploy);
+	}
+
+	@Test
+	public void SwindlerPresenceOfTheForceMayDeployToDestinationNotBlocked() {
+		// "not POTF" fold note: Presence Of The Force is a normal location Effect and SHOULD be offered
+		// (unlike Den Of Thieves). Verifies deploy-to-site path accepts DEPLOYS_ON_LOCATION Effects.
+		var scn = GetScenario();
+		var swindler = scn.GetDSCard("swindler");
+		var potf = scn.GetDSCard("potf");
+		var nabrun = scn.GetLSCard("nabrun");
+		var han = scn.GetLSCard("han");
+		var dining = scn.GetDSCard("dining");
+		var platform = scn.GetDSCard("platform");
+		var trooper = scn.GetDSCard("trooper");
+
+		scn.StartGame();
+		scn.MoveCardsToDSHand(swindler, potf);
+		scn.MoveCardsToLSHand(nabrun);
+		scn.MoveLocationToTable(dining);
+		scn.MoveLocationToTable(platform);
+		scn.MoveCardsToLocation(dining, han);
+		scn.MoveCardsToLocation(platform, trooper);
+
+		scn.SkipToLSTurn(Phase.CONTROL);
+		assertTrue(PlaySwindlerAfterNabrunToDeployWindow(scn));
+
+		boolean saw = false;
+		for (int j = 0; j < 25; j++) {
+			if (scn.DSHasCardChoiceAvailable(potf) || AtDeployFromHandChoice(scn) || scn.DSDecisionAvailable("deploy")) {
+				if (scn.DSHasCardChoiceAvailable(potf)) {
+					saw = true;
+					scn.DSChooseCard(potf);
+					// May need to confirm target location
+					try {
+						if (scn.DSHasCardChoiceAvailable(platform)) {
+							scn.DSChooseCard(platform);
+						}
+					} catch (RuntimeException ignored) {}
+					SafePassOptionalResponses(scn);
+					assertTrue("POTF should leave hand onto destination",
+							potf.getZone() != Zone.HAND && (potf.getAttachedTo() == platform
+									|| (potf.getAttachedTo() != null && potf.getAttachedTo().getCardId() == platform.getCardId())
+									|| potf.getZone() == Zone.ATTACHED));
+					try { scn.DSPass(); } catch (RuntimeException ex) {
+						try { scn.PassResponses(); } catch (RuntimeException ex2) {}
+					}
+					break;
+				}
+			}
+			SafePassOptionalResponses(scn);
+			try { scn.PassAllResponses(); } catch (RuntimeException ignored) { break; }
+		}
+		assertTrue("Presence Of The Force should be offered for deploy-to-site", saw);
+	}
+
+	@Test
+	public void SwindlerSimultaneousSequentialDeployMultipleFromHand() {
+		// Repeated deploy-from-hand (not starship+pilot simultaneous): two troopers in one Swindler resolution.
+		var scn = GetScenario();
+		var swindler = scn.GetDSCard("swindler");
+		var trooper = scn.GetDSCard("trooper");
+		var trooper2 = scn.GetDSCard("trooper2");
+		var nabrun = scn.GetLSCard("nabrun");
+		var han = scn.GetLSCard("han");
+		var dining = scn.GetDSCard("dining");
+		var platform = scn.GetDSCard("platform");
+
+		scn.StartGame();
+		scn.MoveCardsToDSHand(swindler, trooper, trooper2);
+		scn.MoveCardsToLSHand(nabrun);
+		scn.MoveLocationToTable(dining);
+		scn.MoveLocationToTable(platform);
+		scn.MoveCardsToLocation(dining, han);
+
+		scn.SkipToLSTurn(Phase.CONTROL);
+		assertTrue(PlaySwindlerAfterNabrunToDeployWindow(scn));
+
+		int deployed = 0;
+		for (int j = 0; j < 30; j++) {
+			boolean can1 = false, can2 = false;
+			try { can1 = scn.DSHasCardChoiceAvailable(trooper); } catch (RuntimeException ignored) {}
+			try { can2 = scn.DSHasCardChoiceAvailable(trooper2); } catch (RuntimeException ignored) {}
+			if (can1 || can2) {
+				if (can1 && trooper.getZone() == Zone.HAND) {
+					scn.DSChooseCard(trooper);
+					SafePassOptionalResponses(scn);
+					deployed++;
+					continue;
+				}
+				if (can2 && trooper2.getZone() == Zone.HAND) {
+					scn.DSChooseCard(trooper2);
+					SafePassOptionalResponses(scn);
+					deployed++;
+					continue;
+				}
+			}
+			if (deployed >= 2) break;
+			String t = scn.GetCurrentDecision() != null && scn.GetCurrentDecision().getText() != null
+					? scn.GetCurrentDecision().getText().toLowerCase() : "";
+			if (t.contains("optional")) {
+				scn.PassResponses("optional");
+			} else if (AtDeployFromHandChoice(scn) && deployed > 0 && !can1 && !can2) {
+				try { scn.DSPass(); } catch (RuntimeException ex) { break; }
+			} else {
+				try { scn.PassAllResponses(); } catch (RuntimeException ex) { break; }
+			}
+		}
+		assertTrue("First trooper should leave hand", trooper.getZone() != Zone.HAND);
+		assertTrue("Second trooper should leave hand (sequential multi-deploy)", trooper2.getZone() != Zone.HAND);
+		assertTrue("First trooper at destination", trooper.getAtLocation() == platform);
+		assertTrue("Second trooper at destination", trooper2.getAtLocation() == platform);
+	}
+
 }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_137_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_137_Tests.java
@@ -139,11 +139,11 @@ public class Card_5_137_Tests {
 		var lando = scn.GetDSCard("lando");
 		var han = scn.GetLSCard("han");
 		// Bespin system is not a site
-		var bespin = scn.GetDSCard("plaza"); // use a site that we will NOT put them on — relocate to default systems via skip
+		var bespin = scn.GetDSCard("plaza"); // use a site that we will NOT put them on â€” relocate to default systems via skip
 
 		scn.StartGame();
 		scn.MoveCardsToDSHand(swindler);
-		// Place Han/Lando at starting systems (not sites) if possible — characters at system need to be aboard;
+		// Place Han/Lando at starting systems (not sites) if possible â€” characters at system need to be aboard;
 		// instead put them at different sites to prove same-system alone is insufficient for Action1.
 		var dining = scn.GetDSCard("dining");
 		var platform = scn.GetDSCard("platform");
@@ -153,7 +153,7 @@ public class Card_5_137_Tests {
 		scn.MoveCardsToLocation(platform, lando);
 
 		scn.SkipToPhase(Phase.CONTROL);
-		assertFalse("Han and your Lando at different sites — Action1 not playable",
+		assertFalse("Han and your Lando at different sites â€” Action1 not playable",
 				scn.DSCardPlayAvailable(swindler));
 	}
 
@@ -170,12 +170,11 @@ public class Card_5_137_Tests {
 		scn.MoveLocationToTable(dining);
 		scn.MoveCardsToLocation(dining, han, lando);
 
-		int lsForceBefore = scn.GetLSLifeForceRemaining();
-
 		scn.SkipToPhase(Phase.CONTROL);
 		assertTrue(scn.DSCardPlayAvailable(swindler));
-		scn.DSPlayCard(swindler);
-		SafePassOptionalResponses(scn);
+		int lsForceBefore = scn.GetLSLifeForceRemaining();
+		scn.DSPlayCardAndPassResponses(swindler);
+		scn.LSPayRemainingForceLossFromReserveDeck();
 
 		assertEquals("Opponent should lose 3 Force", lsForceBefore - 3, scn.GetLSLifeForceRemaining());
 		assertTrue("Swindler is Lost Interrupt",
@@ -196,7 +195,7 @@ public class Card_5_137_Tests {
 		scn.MoveCardsToLSHand(nabrun);
 		scn.MoveLocationToTable(dining);
 		scn.MoveLocationToTable(platform);
-		// LS needs a character to transport — use Han
+		// LS needs a character to transport â€” use Han
 		var han = scn.GetLSCard("han");
 		scn.MoveCardsToLocation(dining, han);
 		scn.MoveCardsToLocation(platform, trooper); // DS presence at destination
@@ -223,7 +222,7 @@ public class Card_5_137_Tests {
 					sawSwindler = true;
 					scn.DSPlayCard(swindler);
 					SafePassOptionalResponses(scn);
-					// May be offered deploy choices — pass them
+					// May be offered deploy choices â€” pass them
 					for (int j = 0; j < 15; j++) {
 						var d2 = scn.GetCurrentDecision();
 						if (d2 == null) break;


### PR DESCRIPTION
## Summary
- Implements Cloud City Lost Interrupt **Double-Crossing, No-Good Swindler** (`5_137`).
- **Action 1:** If Han and your Lando are at the same site, opponent loses 3 Force.
- **Action 2:** If Nabrun Leids just completed a transport, Nabrun is lost and you may immediately deploy cards from hand to that destination site (normal Force cost; troopers deploy free via until-end-of-card-played modifier).
- Adds `DeployCardsToLocationFromHandEffect` for optional repeating hand→location deploy (not as a react).
- Action2 hand filter limited to site-capable cards (characters/ships/vehicles/weapons/devices + Effects that deploy on location/characters) so side-of-table Effects like **Den Of Thieves** are not offered.

Closes #126

## Tests (`Card_5_137_Tests` 10/0/0)
1. Blueprint stats / keywords
2. Action1 playable with Han + your Lando at same site
3. Action1 not playable without your Lando
4. Action1 not playable at different sites
5. Action1 opponent loses 3 Force; card to Lost Pile
6. Action2 playable after Nabrun; Nabrun lost
7. **NEW:** Den Of Thieves not offered for site deploy
8. **NEW:** Disarmed not deployable via Swindler outside Control
9. **NEW:** Presence Of The Force may deploy to destination (normal location Effect)
10. **NEW:** Sequential multi-deploy (two troopers) in one Swindler resolution

## Test plan
- [x] `Card_5_137_Tests` 10/0/0 green locally
- [ ] Manual: Han + DS Lando at Cloud City site → play Swindler → LS loses 3
- [ ] Manual: after Nabrun transport → Swindler response → Nabrun lost → optional deploy to destination (trooper free)
- [ ] Confirm Sense response window does not reveal intended deploys
