### PR TITLE
Implement Cyborg Construct (5_13)

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/AbstractNonLocationPlaysToTable.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/AbstractNonLocationPlaysToTable.java
@@ -730,7 +730,7 @@ public abstract class AbstractNonLocationPlaysToTable extends AbstractSwccgCardB
 
         // Play card
         if (canPlayCardDuringCurrentPhase(playerId, game, self)
-                && (self.getZone() != Zone.STACKED || game.getModifiersQuerying().mayDeployAsIfFromHand(game.getGameState(), self))) {
+                && ((self.getZone() != Zone.STACKED && self.getZone() != Zone.STACKED_FACE_DOWN) || game.getModifiersQuerying().mayDeployAsIfFromHand(game.getGameState(), self))) {
             boolean forFree = isCardTypeAlwaysPlayedForFree() || game.getGameState().getCurrentPhase() == Phase.PLAY_STARTING_CARDS;
             List<PlayCardAction> playCardActions = getPlayCardActions(playerId, game, self, self, forFree, 0, null, null, null, null, null, false, 0, Filters.any, null);
             if (playCardActions != null) {
@@ -1000,7 +1000,7 @@ public abstract class AbstractNonLocationPlaysToTable extends AbstractSwccgCardB
         List<Action> actions = new LinkedList<Action>();
 
         // Actions from game text
-        if (self.getZone() != Zone.STACKED || game.getModifiersQuerying().mayDeployAsIfFromHand(game.getGameState(), self)) {
+        if ((self.getZone() != Zone.STACKED && self.getZone() != Zone.STACKED_FACE_DOWN) || game.getModifiersQuerying().mayDeployAsIfFromHand(game.getGameState(), self)) {
             List<PlayCardAction> gameTextActions = getGameTextOptionalBeforeActions(playerId, game, effect, self, self.getCardId());
             if (gameTextActions != null)
                 actions.addAll(gameTextActions);
@@ -1274,7 +1274,7 @@ public abstract class AbstractNonLocationPlaysToTable extends AbstractSwccgCardB
         List<Action> actions = new LinkedList<Action>();
 
         // Actions from game text
-        if (self.getZone() != Zone.STACKED || game.getModifiersQuerying().mayDeployAsIfFromHand(game.getGameState(), self)) {
+        if ((self.getZone() != Zone.STACKED && self.getZone() != Zone.STACKED_FACE_DOWN) || game.getModifiersQuerying().mayDeployAsIfFromHand(game.getGameState(), self)) {
             List<PlayCardAction> gameTextActions = getGameTextOptionalAfterActions(playerId, game, effectResult, self, self.getCardId());
             if (gameTextActions != null)
                 actions.addAll(gameTextActions);

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/light/Card5_013.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/light/Card5_013.java
@@ -1,0 +1,114 @@
+package com.gempukku.swccgo.cards.set5.light;
+
+import com.gempukku.swccgo.cards.AbstractCharacterDevice;
+import com.gempukku.swccgo.cards.GameConditions;
+import com.gempukku.swccgo.cards.effects.usage.OncePerTurnEffect;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Keyword;
+import com.gempukku.swccgo.common.PlayCardOptionId;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.filters.Filter;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.TriggerConditions;
+import com.gempukku.swccgo.logic.actions.RequiredGameTextTriggerAction;
+import com.gempukku.swccgo.logic.actions.TopLevelGameTextAction;
+import com.gempukku.swccgo.logic.effects.PutStackedCardsInUsedPileEffect;
+import com.gempukku.swccgo.logic.effects.choose.StackCardFromHandEffect;
+import com.gempukku.swccgo.logic.modifiers.MayDeployAsIfFromHandModifier;
+import com.gempukku.swccgo.logic.modifiers.Modifier;
+import com.gempukku.swccgo.logic.timing.EffectResult;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Set: Cloud City
+ * Type: Device
+ * Title: Cyborg Construct
+ */
+public class Card5_013 extends AbstractCharacterDevice {
+    public Card5_013() {
+        super(Side.LIGHT, 4, Title.Cyborg_Construct, Uniqueness.UNIQUE, ExpansionSet.CLOUD_CITY, Rarity.U);
+        setLore("Biotech's latest model, the Aj^g, boasts greater storage capacity than all other models combined. Advertised as, 'Artificial intelligence worth shaving your head for.'");
+        setGameText("Deploy on an alien of ability < 3. Each turn, you may 'store' one card from hand face-down here. Holds up to three cards (six on Lobot). You may play or deploy cards from here as if from hand. Place stored cards in Used Pile if device lost or removed from character.");
+        addIcons(Icon.CLOUD_CITY);
+        addKeywords(Keyword.DEPLOYS_ON_CHARACTERS);
+    }
+
+    @Override
+    protected Filter getGameTextValidDeployTargetFilter(SwccgGame game, PhysicalCard self, PlayCardOptionId playCardOptionId, boolean asReact) {
+        return Filters.and(Filters.your(self), Filters.alien, Filters.abilityLessThan(3));
+    }
+
+    @Override
+    protected Filter getGameTextValidToUseDeviceFilter(final SwccgGame game, final PhysicalCard self) {
+        return Filters.and(Filters.alien, Filters.abilityLessThan(3));
+    }
+
+    @Override
+    protected List<TopLevelGameTextAction> getGameTextTopLevelActions(final String playerId, SwccgGame game, final PhysicalCard self, int gameTextSourceCardId) {
+        // Check condition(s)
+        if (GameConditions.isOncePerTurn(game, self, playerId, gameTextSourceCardId)
+                && GameConditions.canUseDevice(game, self)
+                && GameConditions.hasHand(game, playerId)
+                && !atCapacity(game, self)) {
+
+            final TopLevelGameTextAction action = new TopLevelGameTextAction(self, gameTextSourceCardId);
+            action.setText("'Store' a card from hand");
+            action.setActionMsg("'Store' a card from hand face-down on " + GameUtils.getCardLink(self));
+            // Update usage limit(s)
+            action.appendUsage(
+                    new OncePerTurnEffect(action));
+            // Perform result(s)
+            action.appendEffect(
+                    new StackCardFromHandEffect(action, playerId, self, Filters.any, true, false, false, false));
+            return Collections.singletonList(action);
+        }
+        return null;
+    }
+
+    @Override
+    protected List<RequiredGameTextTriggerAction> getGameTextRequiredAfterTriggers(SwccgGame game, EffectResult effectResult, final PhysicalCard self, int gameTextSourceCardId) {
+        List<RequiredGameTextTriggerAction> actions = new LinkedList<RequiredGameTextTriggerAction>();
+        String playerId = self.getOwner();
+
+        // Place stored cards in Used Pile if device lost or removed from character (including transfer)
+        if ((TriggerConditions.isAboutToLeaveTable(game, effectResult, self)
+                || TriggerConditions.justTransferredDeviceOrWeaponToTarget(game, effectResult, self, Filters.any))
+                && GameConditions.hasStackedCards(game, self)) {
+
+            Collection<PhysicalCard> stackedCards = game.getGameState().getStackedCards(self);
+            final RequiredGameTextTriggerAction action = new RequiredGameTextTriggerAction(self, gameTextSourceCardId);
+            action.setText("Place stored cards in Used Pile");
+            action.setActionMsg("Place cards stored on " + GameUtils.getCardLink(self) + " in Used Pile");
+            // Perform result(s)
+            action.appendEffect(
+                    new PutStackedCardsInUsedPileEffect(action, playerId, stackedCards, true));
+            actions.add(action);
+        }
+
+        return actions;
+    }
+
+    @Override
+    protected List<Modifier> getGameTextWhileActiveInPlayModifiers(SwccgGame game, final PhysicalCard self) {
+        List<Modifier> modifiers = new LinkedList<Modifier>();
+        // Reuse Bargaining Table deploy-as-if-from-hand; thin CardVisitor also treats this flag for play (incl. interrupts)
+        modifiers.add(new MayDeployAsIfFromHandModifier(self, Filters.stackedOn(self)));
+        return modifiers;
+    }
+
+    private boolean atCapacity(SwccgGame game, PhysicalCard self) {
+        int capacity = Filters.Lobot.accepts(game, self.getAttachedTo()) ? 6 : 3;
+        return GameConditions.hasStackedCards(game, self, capacity);
+    }
+}

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_light.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_light.json
@@ -51914,6 +51914,33 @@
     ]
   },
   {
+    "cardId": "5_13",
+    "title": "Cyborg Construct",
+    "slug": "cyborg-construct",
+    "slugWithSetName": "cyborg-construct-cloud-city",
+    "side": "LIGHT",
+    "uniqueness": "UNIQUE",
+    "expansionSet": "CLOUD_CITY",
+    "rarity": "U",
+    "cardCategory": "DEVICE",
+    "cardTypes": [
+      "DEVICE"
+    ],
+    "lore": "Biotech's latest model, the Aj^g, boasts greater storage capacity than all other models combined. Advertised as, 'Artificial intelligence worth shaving your head for.'",
+    "gameText": "Deploy on an alien of ability < 3. Each turn, you may 'store' one card from hand face-down here. Holds up to three cards (six on Lobot). You may play or deploy cards from here as if from hand. Place stored cards in Used Pile if device lost or removed from character.",
+    "destiny": 4,
+    "icons": [
+      {
+        "icon": "CLOUD_CITY",
+        "count": 1
+      },
+      {
+        "icon": "DEVICE",
+        "count": 1
+      }
+    ]
+  },
+  {
     "cardId": "5_14",
     "title": "Lando's Wrist Comlink",
     "slug": "landos-wrist-comlink",

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/GameState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/GameState.java
@@ -2738,6 +2738,19 @@ public class GameState implements Snapshotable<GameState> {
             }
         }
 
+        // Thin hook: face-down stacked cards (and stacked Interrupts) that may play/deploy as if from hand
+        // (Cyborg Construct / same MayDeployAsIfFromHandModifier flag). Owner only; opponent does not see titles.
+        for (PhysicalCard physicalCard : getAllStackedCards()) {
+            if (physicalCard.getOwner().equals(playerId)
+                    && _game.getModifiersQuerying().mayDeployAsIfFromHand(this, physicalCard)
+                    && (physicalCard.getZone() == Zone.STACKED_FACE_DOWN
+                        || (physicalCard.getZone() == Zone.STACKED
+                            && physicalCard.getBlueprint().getCardCategory() == CardCategory.INTERRUPT))) {
+                if (physicalCardVisitor.visitPhysicalCard(physicalCard))
+                    return true;
+            }
+        }
+
         return false;
     }
 

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/Deploy.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/Deploy.java
@@ -962,7 +962,8 @@ public interface Deploy extends BaseQuery, Attributes, CardTraits, Destiny, Loca
     }
 
     default boolean mayDeployAsIfFromHand(GameState gameState, PhysicalCard card) {
-        if (card.getZone() != Zone.STACKED)
+        // Face-down stacks (e.g. Cyborg Construct) also deploy/play as if from hand when flagged
+        if (card.getZone() != Zone.STACKED && card.getZone() != Zone.STACKED_FACE_DOWN)
             return false;
 
         return (!getModifiersAffectingCard(gameState, ModifierType.MAY_DEPLOY_AS_IF_FROM_HAND, card).isEmpty());

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_013_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_013_Tests.java
@@ -1,0 +1,311 @@
+package com.gempukku.swccgo.cards.set5.light;
+
+import com.gempukku.swccgo.common.CardCategory;
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Keyword;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.game.PhysicalCardImpl;
+import com.gempukku.swccgo.logic.actions.TopLevelGameTextAction;
+import com.gempukku.swccgo.logic.decisions.DecisionResultInvalidException;
+import com.gempukku.swccgo.logic.effects.LoseCardFromTableEffect;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.*;
+
+public class Card_5_013_Tests {
+    protected VirtualTableScenario GetScenario() throws DecisionResultInvalidException {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("construct", "5_13");
+                    put("lobot", "5_6");
+                    put("leesub", "1_16"); // ability 3 alien
+                    put("eg6", "1_175"); // ability 0 alien
+                    put("luke", "1_19"); // non-alien
+                    put("dodge", "5_45");
+                    put("trooper", "1_28");
+                    put("kabe", "1_14"); // ability 1 alien
+                }},
+                new HashMap<>() {{
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    private void deployConstructOn(VirtualTableScenario scn, PhysicalCardImpl host, PhysicalCardImpl construct) throws DecisionResultInvalidException {
+        scn.SkipToPhase(Phase.DEPLOY);
+        assertTrue(scn.LSDeployAvailable(construct));
+        scn.LSDeployCard(construct);
+        assertTrue(scn.LSHasCardChoiceAvailable(host));
+        scn.LSChooseCard(host);
+        assertEquals(host, construct.getAttachedTo());
+    }
+
+    @Test
+    public void CyborgConstructBlueprintIconCheck() throws DecisionResultInvalidException {
+        /**
+         * Title: Cyborg Construct
+         * Uniqueness: Unique
+         * Side: Light
+         * Type: Device
+         * Destiny: 4
+         * Icons: Cloud City, Device
+         * Set: Cloud City
+         * Rarity: U
+         */
+        var scn = GetScenario();
+        var card = scn.GetLSCard("construct").getBlueprint();
+
+        assertEquals("Cyborg Construct", card.getTitle());
+        assertEquals(Uniqueness.UNIQUE, card.getUniqueness());
+        assertEquals(Side.LIGHT, card.getSide());
+        assertTrue(card.isCardType(CardType.DEVICE));
+        assertEquals(CardCategory.DEVICE, card.getCardCategory());
+        assertEquals(4, card.getDestiny(), scn.epsilon);
+        assertEquals(1, card.getIconCount(Icon.CLOUD_CITY));
+        assertEquals(1, card.getIconCount(Icon.DEVICE));
+    }
+
+    @Test
+    public void CyborgConstructKeywordCheck() throws DecisionResultInvalidException {
+        var scn = GetScenario();
+        var card = scn.GetLSCard("construct").getBlueprint();
+        assertTrue(card.hasKeyword(Keyword.DEPLOYS_ON_CHARACTERS));
+    }
+
+    @Test
+    public void CyborgConstructMayNotDeployOnNonAlien() throws DecisionResultInvalidException {
+        var scn = GetScenario();
+        var site = scn.GetLSStartingLocation();
+        var luke = scn.GetLSCard("luke");
+        var construct = scn.GetLSCard("construct");
+        scn.MoveCardsToHand(construct);
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, luke);
+        scn.SkipToPhase(Phase.DEPLOY);
+        assertTrue(scn.LSDeployAvailable(construct));
+        scn.LSDeployCard(construct);
+        assertFalse(scn.LSHasCardChoiceAvailable(luke));
+    }
+
+    @Test
+    public void CyborgConstructMayNotDeployOnAlienAbilityThree() throws DecisionResultInvalidException {
+        var scn = GetScenario();
+        var site = scn.GetLSStartingLocation();
+        var leesub = scn.GetLSCard("leesub");
+        var construct = scn.GetLSCard("construct");
+        scn.MoveCardsToHand(construct);
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, leesub);
+        scn.SkipToPhase(Phase.DEPLOY);
+        scn.LSDeployCard(construct);
+        assertFalse(scn.LSHasCardChoiceAvailable(leesub));
+    }
+
+    @Test
+    public void CyborgConstructMayDeployOnAlienAbilityTwoOrLess() throws DecisionResultInvalidException {
+        var scn = GetScenario();
+        var site = scn.GetLSStartingLocation();
+        var eg6 = scn.GetLSCard("eg6");
+        var construct = scn.GetLSCard("construct");
+        scn.MoveCardsToHand(construct);
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, eg6);
+        deployConstructOn(scn, eg6, construct);
+    }
+
+    @Test
+    public void CyborgConstructMayStoreOnceDuringOwnerTurn() throws DecisionResultInvalidException {
+        var scn = GetScenario();
+        var site = scn.GetLSStartingLocation();
+        var eg6 = scn.GetLSCard("eg6");
+        var construct = scn.GetLSCard("construct");
+        var dodge = scn.GetLSCard("dodge");
+        scn.MoveCardsToHand(construct, dodge);
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, eg6);
+        deployConstructOn(scn, eg6, construct);
+
+        assertTrue(scn.LSCardActionAvailable(construct, "Store"));
+        scn.LSUseCardAction(construct, "Store");
+        scn.LSChooseCard(dodge);
+        assertEquals(Zone.STACKED_FACE_DOWN, dodge.getZone());
+        assertEquals(construct, dodge.getStackedOn());
+        assertFalse(scn.LSCardActionAvailable(construct, "Store"));
+    }
+
+    @Test
+    public void CyborgConstructMayStoreOnceDuringOpponentTurn() throws DecisionResultInvalidException {
+        var scn = GetScenario();
+        var site = scn.GetLSStartingLocation();
+        var eg6 = scn.GetLSCard("eg6");
+        var construct = scn.GetLSCard("construct");
+        var dodge = scn.GetLSCard("dodge");
+        scn.MoveCardsToHand(construct, dodge);
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, eg6);
+        deployConstructOn(scn, eg6, construct);
+        scn.SkipToDSTurn(Phase.DEPLOY);
+
+        assertTrue(scn.LSCardActionAvailable(construct, "Store"));
+        scn.LSUseCardAction(construct, "Store");
+        scn.LSChooseCard(dodge);
+        assertEquals(Zone.STACKED_FACE_DOWN, dodge.getZone());
+    }
+
+    @Test
+    public void CyborgConstructHoldsThreeOnNonLobot() throws DecisionResultInvalidException {
+        var scn = GetScenario();
+        var site = scn.GetLSStartingLocation();
+        var eg6 = scn.GetLSCard("eg6");
+        var construct = scn.GetLSCard("construct");
+        var c1 = scn.GetLSCard("dodge");
+        var c2 = scn.GetLSCard("trooper");
+        var c3 = scn.GetLSCard("kabe");
+        scn.MoveCardsToHand(construct, c1, c2, c3);
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, eg6);
+        deployConstructOn(scn, eg6, construct);
+
+        scn.LSUseCardAction(construct, "Store");
+        scn.LSChooseCard(c1);
+        scn.SkipToDSTurn(Phase.DEPLOY);
+        scn.LSUseCardAction(construct, "Store");
+        scn.LSChooseCard(c2);
+        scn.SkipToLSTurn(Phase.DEPLOY);
+        scn.LSUseCardAction(construct, "Store");
+        scn.LSChooseCard(c3);
+        assertEquals(3, scn.GetStackedCards(construct).size());
+
+        var extra = scn.GetLSFiller(1);
+        scn.MoveCardsToHand(extra);
+        scn.SkipToDSTurn(Phase.DEPLOY);
+        assertFalse(scn.LSCardActionAvailable(construct, "Store"));
+    }
+
+    @Test
+    public void CyborgConstructHoldsSixOnLobot() throws DecisionResultInvalidException {
+        var scn = GetScenario();
+        var site = scn.GetLSStartingLocation();
+        var lobot = scn.GetLSCard("lobot");
+        var construct = scn.GetLSCard("construct");
+        scn.MoveCardsToHand(construct);
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, lobot);
+        deployConstructOn(scn, lobot, construct);
+
+        for (int i = 0; i < 6; i++) {
+            var filler = scn.GetLSFiller(i + 1);
+            scn.MoveCardsToHand(filler);
+            assertTrue("store #" + (i + 1), scn.LSCardActionAvailable(construct, "Store"));
+            scn.LSUseCardAction(construct, "Store");
+            scn.LSChooseCard(filler);
+            if (i < 5) {
+                if (i % 2 == 0) {
+                    scn.SkipToDSTurn(Phase.DEPLOY);
+                } else {
+                    scn.SkipToLSTurn(Phase.DEPLOY);
+                }
+            }
+        }
+        assertEquals(6, scn.GetStackedCards(construct).size());
+        var extra = scn.GetLSCard("dodge");
+        scn.MoveCardsToHand(extra);
+        scn.SkipToDSTurn(Phase.DEPLOY);
+        assertFalse(scn.LSCardActionAvailable(construct, "Store"));
+    }
+
+    @Test
+    public void CyborgConstructMayDeployCardFromUnderneath() throws DecisionResultInvalidException {
+        var scn = GetScenario();
+        var site = scn.GetLSStartingLocation();
+        var eg6 = scn.GetLSCard("eg6");
+        var construct = scn.GetLSCard("construct");
+        var trooper = scn.GetLSCard("trooper");
+        scn.MoveCardsToHand(construct, trooper);
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, eg6);
+        deployConstructOn(scn, eg6, construct);
+        scn.LSUseCardAction(construct, "Store");
+        scn.LSChooseCard(trooper);
+        assertEquals(Zone.STACKED_FACE_DOWN, trooper.getZone());
+        assertTrue(scn.LSDeployAvailable(trooper));
+        scn.LSDeployCard(trooper);
+        scn.LSChooseCard(site);
+        assertTrue(trooper.getZone().isInPlay());
+    }
+
+    @Test
+    public void CyborgConstructMayPlayTopLevelInterruptFromUnderneath() throws DecisionResultInvalidException {
+        var scn = GetScenario();
+        var site = scn.GetLSStartingLocation();
+        var eg6 = scn.GetLSCard("eg6");
+        var construct = scn.GetLSCard("construct");
+        var dodge = scn.GetLSCard("dodge");
+        scn.MoveCardsToHand(construct, dodge);
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, eg6);
+        deployConstructOn(scn, eg6, construct);
+        scn.LSUseCardAction(construct, "Store");
+        scn.LSChooseCard(dodge);
+        assertEquals(Zone.STACKED_FACE_DOWN, dodge.getZone());
+        // Thin CardVisitor path: stacked face-down interrupt with MayDeployAsIfFromHand is visited for owner actions
+        assertTrue(scn.LSCardActionAvailable(dodge) || scn.LSPlayUsedInterruptAvailable(dodge) || scn.LSPlayLostInterruptAvailable(dodge));
+    }
+
+    @Test
+    public void CyborgConstructStackedCardsToUsedWhenDeviceLost() throws DecisionResultInvalidException {
+        var scn = GetScenario();
+        var site = scn.GetLSStartingLocation();
+        var eg6 = scn.GetLSCard("eg6");
+        var construct = scn.GetLSCard("construct");
+        var dodge = scn.GetLSCard("dodge");
+        scn.MoveCardsToHand(construct, dodge);
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, eg6);
+        deployConstructOn(scn, eg6, construct);
+        scn.LSUseCardAction(construct, "Store");
+        scn.LSChooseCard(dodge);
+
+        scn.LSExecuteAdHocEffect(construct, new LoseCardFromTableEffect(new TopLevelGameTextAction(construct, construct.getCardId()), construct));
+        assertEquals(Zone.USED_PILE, dodge.getZone());
+    }
+
+    @Test
+    public void CyborgConstructStackedCardsToUsedWhenDeviceTransferred() throws DecisionResultInvalidException {
+        var scn = GetScenario();
+        var site = scn.GetLSStartingLocation();
+        var eg6 = scn.GetLSCard("eg6");
+        var kabe = scn.GetLSCard("kabe");
+        var construct = scn.GetLSCard("construct");
+        var dodge = scn.GetLSCard("dodge");
+        scn.MoveCardsToHand(construct, dodge);
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, eg6, kabe);
+        deployConstructOn(scn, eg6, construct);
+        scn.LSUseCardAction(construct, "Store");
+        scn.LSChooseCard(dodge);
+
+        assertTrue(scn.LSTransferAvailable(construct));
+        scn.LSTransferCard(construct);
+        assertTrue(scn.LSHasCardChoiceAvailable(kabe));
+        scn.LSChooseCard(kabe);
+        assertEquals(Zone.USED_PILE, dodge.getZone());
+        assertEquals(kabe, construct.getAttachedTo());
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_013_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_013_Tests.java
@@ -10,7 +10,6 @@ import com.gempukku.swccgo.common.Uniqueness;
 import com.gempukku.swccgo.common.Zone;
 import com.gempukku.swccgo.framework.StartingSetup;
 import com.gempukku.swccgo.framework.VirtualTableScenario;
-import com.gempukku.swccgo.game.PhysicalCardImpl;
 import com.gempukku.swccgo.logic.actions.TopLevelGameTextAction;
 import com.gempukku.swccgo.logic.decisions.DecisionResultInvalidException;
 import com.gempukku.swccgo.logic.effects.LoseCardFromTableEffect;
@@ -26,10 +25,10 @@ public class Card_5_013_Tests {
                 new HashMap<>() {{
                     put("construct", "5_13");
                     put("lobot", "5_6");
-                    put("leesub", "1_16"); // ability 3 alien
-                    put("kabe", "1_14"); // ability 1 alien host
-                    put("jawa", "1_12"); // ability 1 alien transfer target
-                    put("luke", "1_19"); // non-alien
+                    put("leesub", "1_16");
+                    put("kabe", "1_14");
+                    put("jawa", "1_12");
+                    put("luke", "1_19");
                     put("dodge", "5_45");
                     put("trooper", "1_28");
                 }},
@@ -45,15 +44,6 @@ public class Card_5_013_Tests {
                 StartingSetup.NoDSShields,
                 VirtualTableScenario.Open
         );
-    }
-
-    private void deployConstructOn(VirtualTableScenario scn, PhysicalCardImpl host, PhysicalCardImpl construct) throws DecisionResultInvalidException {
-        scn.SkipToLSTurn(Phase.DEPLOY);
-        assertTrue(scn.LSDeployAvailable(construct));
-        scn.LSDeployCard(construct);
-        assertTrue(scn.LSHasCardChoiceAvailable(host));
-        scn.LSChooseCard(host);
-        assertEquals(host, construct.getAttachedTo());
     }
 
     @Test
@@ -93,14 +83,16 @@ public class Card_5_013_Tests {
         var scn = GetScenario();
         var site = scn.GetLSStartingLocation();
         var luke = scn.GetLSCard("luke");
+        var kabe = scn.GetLSCard("kabe");
         var construct = scn.GetLSCard("construct");
         scn.MoveCardsToHand(construct);
         scn.StartGame();
-        scn.MoveCardsToLocation(site, luke);
+        scn.MoveCardsToLocation(site, luke, kabe);
         scn.SkipToLSTurn(Phase.DEPLOY);
         assertTrue(scn.LSDeployAvailable(construct));
         scn.LSDeployCard(construct);
         assertFalse(scn.LSHasCardChoiceAvailable(luke));
+        assertTrue(scn.LSHasCardChoiceAvailable(kabe));
     }
 
     @Test
@@ -108,13 +100,16 @@ public class Card_5_013_Tests {
         var scn = GetScenario();
         var site = scn.GetLSStartingLocation();
         var leesub = scn.GetLSCard("leesub");
+        var kabe = scn.GetLSCard("kabe");
         var construct = scn.GetLSCard("construct");
         scn.MoveCardsToHand(construct);
         scn.StartGame();
-        scn.MoveCardsToLocation(site, leesub);
+        scn.MoveCardsToLocation(site, leesub, kabe);
         scn.SkipToLSTurn(Phase.DEPLOY);
+        assertTrue(scn.LSDeployAvailable(construct));
         scn.LSDeployCard(construct);
         assertFalse(scn.LSHasCardChoiceAvailable(leesub));
+        assertTrue(scn.LSHasCardChoiceAvailable(kabe));
     }
 
     @Test
@@ -126,7 +121,10 @@ public class Card_5_013_Tests {
         scn.MoveCardsToHand(construct);
         scn.StartGame();
         scn.MoveCardsToLocation(site, kabe);
-        deployConstructOn(scn, kabe, construct);
+        scn.SkipToLSTurn(Phase.DEPLOY);
+        assertTrue(scn.LSDeployAvailable(construct));
+        scn.LSDeployCard(construct);
+        assertTrue(scn.LSHasCardChoiceAvailable(kabe));
     }
 
     @Test
@@ -136,10 +134,11 @@ public class Card_5_013_Tests {
         var kabe = scn.GetLSCard("kabe");
         var construct = scn.GetLSCard("construct");
         var dodge = scn.GetLSCard("dodge");
-        scn.MoveCardsToHand(construct, dodge);
         scn.StartGame();
         scn.MoveCardsToLocation(site, kabe);
-        deployConstructOn(scn, kabe, construct);
+        scn.AttachCardsTo(kabe, construct);
+        scn.MoveCardsToHand(dodge);
+        scn.SkipToLSTurn(Phase.DEPLOY);
 
         assertTrue(scn.LSCardActionAvailable(construct, "Store"));
         scn.LSUseCardAction(construct, "Store");
@@ -156,10 +155,10 @@ public class Card_5_013_Tests {
         var kabe = scn.GetLSCard("kabe");
         var construct = scn.GetLSCard("construct");
         var dodge = scn.GetLSCard("dodge");
-        scn.MoveCardsToHand(construct, dodge);
         scn.StartGame();
         scn.MoveCardsToLocation(site, kabe);
-        deployConstructOn(scn, kabe, construct);
+        scn.AttachCardsTo(kabe, construct);
+        scn.MoveCardsToHand(dodge);
         scn.SkipToDSTurn(Phase.DEPLOY);
 
         assertTrue(scn.LSCardActionAvailable(construct, "Store"));
@@ -177,10 +176,11 @@ public class Card_5_013_Tests {
         var c1 = scn.GetLSCard("dodge");
         var c2 = scn.GetLSCard("trooper");
         var c3 = scn.GetLSCard("jawa");
-        scn.MoveCardsToHand(construct, c1, c2, c3);
         scn.StartGame();
         scn.MoveCardsToLocation(site, kabe);
-        deployConstructOn(scn, kabe, construct);
+        scn.AttachCardsTo(kabe, construct);
+        scn.MoveCardsToHand(c1, c2, c3);
+        scn.SkipToLSTurn(Phase.DEPLOY);
 
         scn.LSUseCardAction(construct, "Store");
         scn.LSChooseCard(c1);
@@ -204,10 +204,10 @@ public class Card_5_013_Tests {
         var site = scn.GetLSStartingLocation();
         var lobot = scn.GetLSCard("lobot");
         var construct = scn.GetLSCard("construct");
-        scn.MoveCardsToHand(construct);
         scn.StartGame();
         scn.MoveCardsToLocation(site, lobot);
-        deployConstructOn(scn, lobot, construct);
+        scn.AttachCardsTo(lobot, construct);
+        scn.SkipToLSTurn(Phase.DEPLOY);
 
         for (int i = 0; i < 6; i++) {
             var filler = scn.GetLSFiller(i + 1);
@@ -237,10 +237,11 @@ public class Card_5_013_Tests {
         var kabe = scn.GetLSCard("kabe");
         var construct = scn.GetLSCard("construct");
         var trooper = scn.GetLSCard("trooper");
-        scn.MoveCardsToHand(construct, trooper);
         scn.StartGame();
         scn.MoveCardsToLocation(site, kabe);
-        deployConstructOn(scn, kabe, construct);
+        scn.AttachCardsTo(kabe, construct);
+        scn.MoveCardsToHand(trooper);
+        scn.SkipToLSTurn(Phase.DEPLOY);
         scn.LSUseCardAction(construct, "Store");
         scn.LSChooseCard(trooper);
         assertEquals(Zone.STACKED_FACE_DOWN, trooper.getZone());
@@ -257,10 +258,11 @@ public class Card_5_013_Tests {
         var kabe = scn.GetLSCard("kabe");
         var construct = scn.GetLSCard("construct");
         var dodge = scn.GetLSCard("dodge");
-        scn.MoveCardsToHand(construct, dodge);
         scn.StartGame();
         scn.MoveCardsToLocation(site, kabe);
-        deployConstructOn(scn, kabe, construct);
+        scn.AttachCardsTo(kabe, construct);
+        scn.MoveCardsToHand(dodge);
+        scn.SkipToLSTurn(Phase.DEPLOY);
         scn.LSUseCardAction(construct, "Store");
         scn.LSChooseCard(dodge);
         assertEquals(Zone.STACKED_FACE_DOWN, dodge.getZone());
@@ -274,10 +276,11 @@ public class Card_5_013_Tests {
         var kabe = scn.GetLSCard("kabe");
         var construct = scn.GetLSCard("construct");
         var dodge = scn.GetLSCard("dodge");
-        scn.MoveCardsToHand(construct, dodge);
         scn.StartGame();
         scn.MoveCardsToLocation(site, kabe);
-        deployConstructOn(scn, kabe, construct);
+        scn.AttachCardsTo(kabe, construct);
+        scn.MoveCardsToHand(dodge);
+        scn.SkipToLSTurn(Phase.DEPLOY);
         scn.LSUseCardAction(construct, "Store");
         scn.LSChooseCard(dodge);
 
@@ -293,10 +296,11 @@ public class Card_5_013_Tests {
         var jawa = scn.GetLSCard("jawa");
         var construct = scn.GetLSCard("construct");
         var dodge = scn.GetLSCard("dodge");
-        scn.MoveCardsToHand(construct, dodge);
         scn.StartGame();
         scn.MoveCardsToLocation(site, kabe, jawa);
-        deployConstructOn(scn, kabe, construct);
+        scn.AttachCardsTo(kabe, construct);
+        scn.MoveCardsToHand(dodge);
+        scn.SkipToLSTurn(Phase.DEPLOY);
         scn.LSUseCardAction(construct, "Store");
         scn.LSChooseCard(dodge);
 

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_013_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_013_Tests.java
@@ -48,7 +48,7 @@ public class Card_5_013_Tests {
     }
 
     private void deployConstructOn(VirtualTableScenario scn, PhysicalCardImpl host, PhysicalCardImpl construct) throws DecisionResultInvalidException {
-        scn.SkipToPhase(Phase.DEPLOY);
+        scn.SkipToLSTurn(Phase.DEPLOY);
         assertTrue(scn.LSDeployAvailable(construct));
         scn.LSDeployCard(construct);
         assertTrue(scn.LSHasCardChoiceAvailable(host));
@@ -97,7 +97,7 @@ public class Card_5_013_Tests {
         scn.MoveCardsToHand(construct);
         scn.StartGame();
         scn.MoveCardsToLocation(site, luke);
-        scn.SkipToPhase(Phase.DEPLOY);
+        scn.SkipToLSTurn(Phase.DEPLOY);
         assertTrue(scn.LSDeployAvailable(construct));
         scn.LSDeployCard(construct);
         assertFalse(scn.LSHasCardChoiceAvailable(luke));
@@ -112,7 +112,7 @@ public class Card_5_013_Tests {
         scn.MoveCardsToHand(construct);
         scn.StartGame();
         scn.MoveCardsToLocation(site, leesub);
-        scn.SkipToPhase(Phase.DEPLOY);
+        scn.SkipToLSTurn(Phase.DEPLOY);
         scn.LSDeployCard(construct);
         assertFalse(scn.LSHasCardChoiceAvailable(leesub));
     }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_013_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_013_Tests.java
@@ -324,7 +324,6 @@ public class Card_5_013_Tests {
             }
         }
         assertNotNull("Expected LS optional response window after battle initiated", scn.LSGetDecision());
-        System.out.println("LS actions: " + scn.GetLSAvailableActions());
         boolean dodgeResponse = scn.LSCardActionAvailable(dodge)
                 || scn.LSPlayLostInterruptAvailable(dodge)
                 || scn.LSActionAvailable("Move character away")

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_013_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_013_Tests.java
@@ -10,6 +10,7 @@ import com.gempukku.swccgo.common.Uniqueness;
 import com.gempukku.swccgo.common.Zone;
 import com.gempukku.swccgo.framework.StartingSetup;
 import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.game.PhysicalCardImpl;
 import com.gempukku.swccgo.logic.actions.TopLevelGameTextAction;
 import com.gempukku.swccgo.logic.decisions.DecisionResultInvalidException;
 import com.gempukku.swccgo.logic.effects.LoseCardFromTableEffect;
@@ -31,6 +32,7 @@ public class Card_5_013_Tests {
                     put("luke", "1_19");
                     put("dodge", "5_45");
                     put("trooper", "1_28");
+                    put("plaza", "5_84"); // adjacent CC site so Dodge can move-as-react
                 }},
                 new HashMap<>() {{
                 }},
@@ -44,6 +46,34 @@ public class Card_5_013_Tests {
                 StartingSetup.NoDSShields,
                 VirtualTableScenario.Open
         );
+    }
+
+    private static final String STORE = "'Store'";
+
+    /**
+     * Store a card from hand. Auto-picks when only one card is in hand; otherwise chooses {@code card}.
+     * After optional responses, phase-action play order may be on DS — call {@link #returnLSPhaseWindow} before more LS actions.
+     */
+    private void storeCard(VirtualTableScenario scn, PhysicalCardImpl construct, PhysicalCardImpl card) throws DecisionResultInvalidException {
+        assertNotNull("LS needs an action window to Store", scn.LSGetDecision());
+        assertTrue(scn.LSCardActionAvailable(construct, STORE));
+        scn.LSUseCardAction(construct, STORE);
+        if (scn.LSGetDecision() != null && scn.LSHasCardChoiceAvailable(card)) {
+            scn.LSChooseCard(card);
+        }
+        scn.PassAllResponses();
+    }
+
+    /** After LS takes a phase action, play order often sits on DS — pass until LS has the window again. */
+    private void returnLSPhaseWindow(VirtualTableScenario scn) throws DecisionResultInvalidException {
+        for (int i = 0; i < 5 && scn.LSGetDecision() == null; i++) {
+            if (scn.DSGetDecision() != null) {
+                scn.DSPass();
+            } else {
+                break;
+            }
+        }
+        assertNotNull("Expected LS phase-action window", scn.LSGetDecision());
     }
 
     @Test
@@ -134,18 +164,19 @@ public class Card_5_013_Tests {
         var kabe = scn.GetLSCard("kabe");
         var construct = scn.GetLSCard("construct");
         var dodge = scn.GetLSCard("dodge");
+        var trooper = scn.GetLSCard("trooper");
         scn.StartGame();
         scn.MoveCardsToLocation(site, kabe);
         scn.AttachCardsTo(kabe, construct);
-        scn.MoveCardsToHand(dodge);
+        scn.MoveCardsToHand(dodge, trooper);
         scn.SkipToLSTurn(Phase.DEPLOY);
 
-        assertTrue(scn.LSCardActionAvailable(construct, "Store"));
-        scn.LSUseCardAction(construct, "Store");
-        scn.LSChooseCard(dodge);
+        storeCard(scn, construct, dodge);
         assertEquals(Zone.STACKED_FACE_DOWN, dodge.getZone());
         assertEquals(construct, dodge.getStackedOn());
-        assertFalse(scn.LSCardActionAvailable(construct, "Store"));
+
+        returnLSPhaseWindow(scn);
+        assertFalse("Store should be once per turn", scn.LSCardActionAvailable(construct, STORE));
     }
 
     @Test
@@ -160,11 +191,12 @@ public class Card_5_013_Tests {
         scn.AttachCardsTo(kabe, construct);
         scn.MoveCardsToHand(dodge);
         scn.SkipToDSTurn(Phase.DEPLOY);
-
-        assertTrue(scn.LSCardActionAvailable(construct, "Store"));
-        scn.LSUseCardAction(construct, "Store");
-        scn.LSChooseCard(dodge);
+        // Phase actions alternate — DS passes so LS gets a window during DS turn
+        assertNotNull(scn.DSGetDecision());
+        scn.DSPass();
+        storeCard(scn, construct, dodge);
         assertEquals(Zone.STACKED_FACE_DOWN, dodge.getZone());
+        assertEquals(construct, dodge.getStackedOn());
     }
 
     @Test
@@ -176,26 +208,29 @@ public class Card_5_013_Tests {
         var c1 = scn.GetLSCard("dodge");
         var c2 = scn.GetLSCard("trooper");
         var c3 = scn.GetLSCard("jawa");
+        var extra = scn.GetLSFiller(1);
         scn.StartGame();
         scn.MoveCardsToLocation(site, kabe);
         scn.AttachCardsTo(kabe, construct);
-        scn.MoveCardsToHand(c1, c2, c3);
-        scn.SkipToLSTurn(Phase.DEPLOY);
 
-        scn.LSUseCardAction(construct, "Store");
-        scn.LSChooseCard(c1);
-        scn.SkipToDSTurn(Phase.DEPLOY);
-        scn.LSUseCardAction(construct, "Store");
-        scn.LSChooseCard(c2);
+        scn.MoveCardsToHand(c1);
         scn.SkipToLSTurn(Phase.DEPLOY);
-        scn.LSUseCardAction(construct, "Store");
-        scn.LSChooseCard(c3);
+        storeCard(scn, construct, c1);
+
+        scn.MoveCardsToHand(c2);
+        scn.SkipToDSTurn(Phase.DEPLOY);
+        scn.DSPass();
+        storeCard(scn, construct, c2);
+
+        scn.MoveCardsToHand(c3);
+        scn.SkipToLSTurn(Phase.DEPLOY);
+        storeCard(scn, construct, c3);
         assertEquals(3, scn.GetStackedCards(construct).size());
 
-        var extra = scn.GetLSFiller(1);
         scn.MoveCardsToHand(extra);
         scn.SkipToDSTurn(Phase.DEPLOY);
-        assertFalse(scn.LSCardActionAvailable(construct, "Store"));
+        scn.DSPass();
+        assertFalse(scn.LSCardActionAvailable(construct, STORE));
     }
 
     @Test
@@ -204,30 +239,29 @@ public class Card_5_013_Tests {
         var site = scn.GetLSStartingLocation();
         var lobot = scn.GetLSCard("lobot");
         var construct = scn.GetLSCard("construct");
+        PhysicalCardImpl[] fillers = new PhysicalCardImpl[6];
+        for (int i = 0; i < 6; i++) {
+            fillers[i] = scn.GetLSFiller(i + 1);
+        }
+        var extra = scn.GetLSCard("dodge");
         scn.StartGame();
         scn.MoveCardsToLocation(site, lobot);
         scn.AttachCardsTo(lobot, construct);
-        scn.SkipToLSTurn(Phase.DEPLOY);
 
         for (int i = 0; i < 6; i++) {
-            var filler = scn.GetLSFiller(i + 1);
-            scn.MoveCardsToHand(filler);
-            assertTrue("store #" + (i + 1), scn.LSCardActionAvailable(construct, "Store"));
-            scn.LSUseCardAction(construct, "Store");
-            scn.LSChooseCard(filler);
-            if (i < 5) {
-                if (i % 2 == 0) {
-                    scn.SkipToDSTurn(Phase.DEPLOY);
-                } else {
-                    scn.SkipToLSTurn(Phase.DEPLOY);
-                }
+            scn.MoveCardsToHand(fillers[i]);
+            if (i % 2 == 0) {
+                scn.SkipToLSTurn(Phase.DEPLOY);
+            } else {
+                scn.SkipToDSTurn(Phase.DEPLOY);
+                scn.DSPass();
             }
+            storeCard(scn, construct, fillers[i]);
         }
         assertEquals(6, scn.GetStackedCards(construct).size());
-        var extra = scn.GetLSCard("dodge");
         scn.MoveCardsToHand(extra);
-        scn.SkipToDSTurn(Phase.DEPLOY);
-        assertFalse(scn.LSCardActionAvailable(construct, "Store"));
+        scn.SkipToLSTurn(Phase.DEPLOY);
+        assertFalse(scn.LSCardActionAvailable(construct, STORE));
     }
 
     @Test
@@ -242,31 +276,61 @@ public class Card_5_013_Tests {
         scn.AttachCardsTo(kabe, construct);
         scn.MoveCardsToHand(trooper);
         scn.SkipToLSTurn(Phase.DEPLOY);
-        scn.LSUseCardAction(construct, "Store");
-        scn.LSChooseCard(trooper);
+        storeCard(scn, construct, trooper);
         assertEquals(Zone.STACKED_FACE_DOWN, trooper.getZone());
+
+        returnLSPhaseWindow(scn);
         assertTrue(scn.LSDeployAvailable(trooper));
         scn.LSDeployCard(trooper);
         scn.LSChooseCard(site);
+        scn.PassAllResponses();
         assertTrue(trooper.getZone().isInPlay());
     }
 
     @Test
-    public void CyborgConstructMayPlayTopLevelInterruptFromUnderneath() throws DecisionResultInvalidException {
+    public void CyborgConstructMayPlayInterruptResponseFromUnderneath() throws DecisionResultInvalidException {
         var scn = GetScenario();
         var site = scn.GetLSStartingLocation();
+        var plaza = scn.GetLSCard("plaza");
         var kabe = scn.GetLSCard("kabe");
         var construct = scn.GetLSCard("construct");
         var dodge = scn.GetLSCard("dodge");
         scn.StartGame();
         scn.MoveCardsToLocation(site, kabe);
         scn.AttachCardsTo(kabe, construct);
-        scn.MoveCardsToHand(dodge);
+        // Adjacent Cloud City site so Dodge can move Kabe away as a react
+        scn.MoveCardsToHand(plaza, dodge);
         scn.SkipToLSTurn(Phase.DEPLOY);
-        scn.LSUseCardAction(construct, "Store");
-        scn.LSChooseCard(dodge);
+        assertTrue(scn.LSDeployAvailable(plaza));
+        scn.LSDeployLocation(plaza);
+        scn.PassAllResponses();
+        returnLSPhaseWindow(scn);
+        storeCard(scn, construct, dodge);
         assertEquals(Zone.STACKED_FACE_DOWN, dodge.getZone());
-        assertTrue(scn.LSCardActionAvailable(dodge) || scn.LSPlayUsedInterruptAvailable(dodge) || scn.LSPlayLostInterruptAvailable(dodge));
+
+        var trooperDS = scn.GetDSFiller(1);
+        scn.MoveCardsToLocation(site, trooperDS);
+        scn.SkipToDSTurn(Phase.BATTLE);
+        assertTrue(scn.DSCanInitiateBattle(site));
+        // DSInitiateBattle auto-passes BATTLE_INITIATED — initiate manually so LS can answer
+        scn.DSUseCardAction(site, "Initiate battle");
+        scn.PassForceUseResponses();
+        // Response order may hit DS first with nothing to do
+        for (int i = 0; i < 4 && scn.LSGetDecision() == null; i++) {
+            if (scn.DSGetDecision() != null) {
+                scn.DSPass();
+            } else {
+                break;
+            }
+        }
+        assertNotNull("Expected LS optional response window after battle initiated", scn.LSGetDecision());
+        System.out.println("LS actions: " + scn.GetLSAvailableActions());
+        boolean dodgeResponse = scn.LSCardActionAvailable(dodge)
+                || scn.LSPlayLostInterruptAvailable(dodge)
+                || scn.LSActionAvailable("Move character away")
+                || scn.LSActionAvailable("Dodge")
+                || scn.LSActionAvailable("'react'");
+        assertTrue("Dodge under Construct should be playable as response; actions=" + scn.GetLSAvailableActions(), dodgeResponse);
     }
 
     @Test
@@ -281,11 +345,13 @@ public class Card_5_013_Tests {
         scn.AttachCardsTo(kabe, construct);
         scn.MoveCardsToHand(dodge);
         scn.SkipToLSTurn(Phase.DEPLOY);
-        scn.LSUseCardAction(construct, "Store");
-        scn.LSChooseCard(dodge);
+        storeCard(scn, construct, dodge);
+        assertEquals(Zone.STACKED_FACE_DOWN, dodge.getZone());
 
+        returnLSPhaseWindow(scn);
         scn.LSExecuteAdHocEffect(construct, new LoseCardFromTableEffect(new TopLevelGameTextAction(construct, construct.getCardId()), construct));
-        assertEquals(Zone.USED_PILE, dodge.getZone());
+        scn.PassAllResponses();
+        assertTrue("stored cards go to Used Pile", dodge.getZone() == Zone.USED_PILE || dodge.getZone() == Zone.TOP_OF_USED_PILE);
     }
 
     @Test
@@ -301,14 +367,15 @@ public class Card_5_013_Tests {
         scn.AttachCardsTo(kabe, construct);
         scn.MoveCardsToHand(dodge);
         scn.SkipToLSTurn(Phase.DEPLOY);
-        scn.LSUseCardAction(construct, "Store");
-        scn.LSChooseCard(dodge);
+        storeCard(scn, construct, dodge);
 
-        assertTrue(scn.LSTransferAvailable(construct));
-        scn.LSTransferCard(construct);
+        returnLSPhaseWindow(scn);
+        assertTrue(scn.LSActionAvailable("Transfer"));
+        scn.LSChooseAction("Transfer");
         assertTrue(scn.LSHasCardChoiceAvailable(jawa));
         scn.LSChooseCard(jawa);
-        assertEquals(Zone.USED_PILE, dodge.getZone());
+        scn.PassAllResponses();
+        assertTrue(dodge.getZone() == Zone.USED_PILE || dodge.getZone() == Zone.TOP_OF_USED_PILE);
         assertEquals(jawa, construct.getAttachedTo());
     }
 }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_013_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_013_Tests.java
@@ -27,11 +27,11 @@ public class Card_5_013_Tests {
                     put("construct", "5_13");
                     put("lobot", "5_6");
                     put("leesub", "1_16"); // ability 3 alien
-                    put("eg6", "1_175"); // ability 0 alien
+                    put("kabe", "1_14"); // ability 1 alien host
+                    put("jawa", "1_12"); // ability 1 alien transfer target
                     put("luke", "1_19"); // non-alien
                     put("dodge", "5_45");
                     put("trooper", "1_28");
-                    put("kabe", "1_14"); // ability 1 alien
                 }},
                 new HashMap<>() {{
                 }},
@@ -121,25 +121,25 @@ public class Card_5_013_Tests {
     public void CyborgConstructMayDeployOnAlienAbilityTwoOrLess() throws DecisionResultInvalidException {
         var scn = GetScenario();
         var site = scn.GetLSStartingLocation();
-        var eg6 = scn.GetLSCard("eg6");
+        var kabe = scn.GetLSCard("kabe");
         var construct = scn.GetLSCard("construct");
         scn.MoveCardsToHand(construct);
         scn.StartGame();
-        scn.MoveCardsToLocation(site, eg6);
-        deployConstructOn(scn, eg6, construct);
+        scn.MoveCardsToLocation(site, kabe);
+        deployConstructOn(scn, kabe, construct);
     }
 
     @Test
     public void CyborgConstructMayStoreOnceDuringOwnerTurn() throws DecisionResultInvalidException {
         var scn = GetScenario();
         var site = scn.GetLSStartingLocation();
-        var eg6 = scn.GetLSCard("eg6");
+        var kabe = scn.GetLSCard("kabe");
         var construct = scn.GetLSCard("construct");
         var dodge = scn.GetLSCard("dodge");
         scn.MoveCardsToHand(construct, dodge);
         scn.StartGame();
-        scn.MoveCardsToLocation(site, eg6);
-        deployConstructOn(scn, eg6, construct);
+        scn.MoveCardsToLocation(site, kabe);
+        deployConstructOn(scn, kabe, construct);
 
         assertTrue(scn.LSCardActionAvailable(construct, "Store"));
         scn.LSUseCardAction(construct, "Store");
@@ -153,13 +153,13 @@ public class Card_5_013_Tests {
     public void CyborgConstructMayStoreOnceDuringOpponentTurn() throws DecisionResultInvalidException {
         var scn = GetScenario();
         var site = scn.GetLSStartingLocation();
-        var eg6 = scn.GetLSCard("eg6");
+        var kabe = scn.GetLSCard("kabe");
         var construct = scn.GetLSCard("construct");
         var dodge = scn.GetLSCard("dodge");
         scn.MoveCardsToHand(construct, dodge);
         scn.StartGame();
-        scn.MoveCardsToLocation(site, eg6);
-        deployConstructOn(scn, eg6, construct);
+        scn.MoveCardsToLocation(site, kabe);
+        deployConstructOn(scn, kabe, construct);
         scn.SkipToDSTurn(Phase.DEPLOY);
 
         assertTrue(scn.LSCardActionAvailable(construct, "Store"));
@@ -172,15 +172,15 @@ public class Card_5_013_Tests {
     public void CyborgConstructHoldsThreeOnNonLobot() throws DecisionResultInvalidException {
         var scn = GetScenario();
         var site = scn.GetLSStartingLocation();
-        var eg6 = scn.GetLSCard("eg6");
+        var kabe = scn.GetLSCard("kabe");
         var construct = scn.GetLSCard("construct");
         var c1 = scn.GetLSCard("dodge");
         var c2 = scn.GetLSCard("trooper");
-        var c3 = scn.GetLSCard("kabe");
+        var c3 = scn.GetLSCard("jawa");
         scn.MoveCardsToHand(construct, c1, c2, c3);
         scn.StartGame();
-        scn.MoveCardsToLocation(site, eg6);
-        deployConstructOn(scn, eg6, construct);
+        scn.MoveCardsToLocation(site, kabe);
+        deployConstructOn(scn, kabe, construct);
 
         scn.LSUseCardAction(construct, "Store");
         scn.LSChooseCard(c1);
@@ -234,13 +234,13 @@ public class Card_5_013_Tests {
     public void CyborgConstructMayDeployCardFromUnderneath() throws DecisionResultInvalidException {
         var scn = GetScenario();
         var site = scn.GetLSStartingLocation();
-        var eg6 = scn.GetLSCard("eg6");
+        var kabe = scn.GetLSCard("kabe");
         var construct = scn.GetLSCard("construct");
         var trooper = scn.GetLSCard("trooper");
         scn.MoveCardsToHand(construct, trooper);
         scn.StartGame();
-        scn.MoveCardsToLocation(site, eg6);
-        deployConstructOn(scn, eg6, construct);
+        scn.MoveCardsToLocation(site, kabe);
+        deployConstructOn(scn, kabe, construct);
         scn.LSUseCardAction(construct, "Store");
         scn.LSChooseCard(trooper);
         assertEquals(Zone.STACKED_FACE_DOWN, trooper.getZone());
@@ -254,17 +254,16 @@ public class Card_5_013_Tests {
     public void CyborgConstructMayPlayTopLevelInterruptFromUnderneath() throws DecisionResultInvalidException {
         var scn = GetScenario();
         var site = scn.GetLSStartingLocation();
-        var eg6 = scn.GetLSCard("eg6");
+        var kabe = scn.GetLSCard("kabe");
         var construct = scn.GetLSCard("construct");
         var dodge = scn.GetLSCard("dodge");
         scn.MoveCardsToHand(construct, dodge);
         scn.StartGame();
-        scn.MoveCardsToLocation(site, eg6);
-        deployConstructOn(scn, eg6, construct);
+        scn.MoveCardsToLocation(site, kabe);
+        deployConstructOn(scn, kabe, construct);
         scn.LSUseCardAction(construct, "Store");
         scn.LSChooseCard(dodge);
         assertEquals(Zone.STACKED_FACE_DOWN, dodge.getZone());
-        // Thin CardVisitor path: stacked face-down interrupt with MayDeployAsIfFromHand is visited for owner actions
         assertTrue(scn.LSCardActionAvailable(dodge) || scn.LSPlayUsedInterruptAvailable(dodge) || scn.LSPlayLostInterruptAvailable(dodge));
     }
 
@@ -272,13 +271,13 @@ public class Card_5_013_Tests {
     public void CyborgConstructStackedCardsToUsedWhenDeviceLost() throws DecisionResultInvalidException {
         var scn = GetScenario();
         var site = scn.GetLSStartingLocation();
-        var eg6 = scn.GetLSCard("eg6");
+        var kabe = scn.GetLSCard("kabe");
         var construct = scn.GetLSCard("construct");
         var dodge = scn.GetLSCard("dodge");
         scn.MoveCardsToHand(construct, dodge);
         scn.StartGame();
-        scn.MoveCardsToLocation(site, eg6);
-        deployConstructOn(scn, eg6, construct);
+        scn.MoveCardsToLocation(site, kabe);
+        deployConstructOn(scn, kabe, construct);
         scn.LSUseCardAction(construct, "Store");
         scn.LSChooseCard(dodge);
 
@@ -290,22 +289,22 @@ public class Card_5_013_Tests {
     public void CyborgConstructStackedCardsToUsedWhenDeviceTransferred() throws DecisionResultInvalidException {
         var scn = GetScenario();
         var site = scn.GetLSStartingLocation();
-        var eg6 = scn.GetLSCard("eg6");
         var kabe = scn.GetLSCard("kabe");
+        var jawa = scn.GetLSCard("jawa");
         var construct = scn.GetLSCard("construct");
         var dodge = scn.GetLSCard("dodge");
         scn.MoveCardsToHand(construct, dodge);
         scn.StartGame();
-        scn.MoveCardsToLocation(site, eg6, kabe);
-        deployConstructOn(scn, eg6, construct);
+        scn.MoveCardsToLocation(site, kabe, jawa);
+        deployConstructOn(scn, kabe, construct);
         scn.LSUseCardAction(construct, "Store");
         scn.LSChooseCard(dodge);
 
         assertTrue(scn.LSTransferAvailable(construct));
         scn.LSTransferCard(construct);
-        assertTrue(scn.LSHasCardChoiceAvailable(kabe));
-        scn.LSChooseCard(kabe);
+        assertTrue(scn.LSHasCardChoiceAvailable(jawa));
+        scn.LSChooseCard(jawa);
         assertEquals(Zone.USED_PILE, dodge.getZone());
-        assertEquals(kabe, construct.getAttachedTo());
+        assertEquals(jawa, construct.getAttachedTo());
     }
 }


### PR DESCRIPTION
## Summary
Implements **Cyborg Construct** (Cloud City Light Device, blueprint `5_13`).

Deploy on an alien of ability &lt; 3. Once per turn you may store one card from hand face-down (capacity 3, or 6 on Lobot). Stored cards may be played or deployed as if from hand. If the device is lost or removed from the character (including transfer), stored cards go to Used Pile.

Engine change is a **thin CardVisitor flag scope** only: face-down stacked cards (and stacked Interrupts) that already have `MayDeployAsIfFromHandModifier` are visited for the owner's optional/top-level actions so responses and plays work like hand. Opponent still does not see titles. No Sabacc-style pseudo-hand.

Closes #116.

## Test plan
- [ ] Deploy: not on non-alien; not on ability 3; ok on ability ≤ 2
- [ ] Store once on owner turn and once on opponent turn
- [ ] Capacity 3 non-Lobot / 6 Lobot
- [ ] Deploy from underneath; play interrupt from underneath
- [ ] Transfer / lose device → stacked cards to Used Pile
