### PR TITLE
5_52 Impressive, Most Impressive

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/dark/Card5_114.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/dark/Card5_114.java
@@ -31,7 +31,7 @@ import com.gempukku.swccgo.logic.effects.FreezeCharacterEffect;
 import com.gempukku.swccgo.logic.effects.LoseCardFromTableEffect;
 import com.gempukku.swccgo.logic.effects.LoseForceEffect;
 import com.gempukku.swccgo.logic.effects.TargetCardOnTableEffect;
-import com.gempukku.swccgo.logic.effects.UnrespondableEffect;
+import com.gempukku.swccgo.logic.effects.RespondableEffect;
 import com.gempukku.swccgo.logic.timing.Action;
 import com.gempukku.swccgo.logic.timing.EffectResult;
 import com.gempukku.swccgo.logic.timing.GuiUtils;
@@ -82,7 +82,7 @@ public class Card5_114 extends AbstractNormalEffect {
                             action.addAnimationGroup(captive);
                             // Allow response(s)
                             action.allowResponses("Perform Carbon-Freezing on " + GameUtils.getCardLink(captive),
-                                    new UnrespondableEffect(action) {
+                                    new RespondableEffect(action) {
                                         @Override
                                         protected void performActionResults(Action targetingAction) {
                                             // Perform result(s)

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/light/Card5_052.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/light/Card5_052.java
@@ -19,7 +19,7 @@ import com.gempukku.swccgo.logic.TriggerConditions;
 import com.gempukku.swccgo.logic.actions.PlayInterruptAction;
 import com.gempukku.swccgo.logic.effects.CancelCardBeingPlayedEffect;
 import com.gempukku.swccgo.logic.effects.DrawDestinyEffect;
-import com.gempukku.swccgo.logic.effects.MayNotBattleUntilEndOfTurnEffect;
+import com.gempukku.swccgo.logic.effects.HideUntilEndOfTurnEffect;
 import com.gempukku.swccgo.logic.effects.ReleaseCaptiveEffect;
 import com.gempukku.swccgo.logic.effects.RespondablePlayCardEffect;
 import com.gempukku.swccgo.logic.effects.RespondablePlayingCardEffect;
@@ -171,7 +171,7 @@ public class Card5_052 extends AbstractLostInterrupt {
                         new ReleaseCaptiveEffect(action, character));
             }
             action.appendEffect(
-                    new MayNotBattleUntilEndOfTurnEffect(action, character));
+                    new HideUntilEndOfTurnEffect(action, character));
         }
         else {
             gameState.sendMessage("Result: Failed");

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/light/Card5_052.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/light/Card5_052.java
@@ -1,0 +1,180 @@
+package com.gempukku.swccgo.cards.set5.light;
+
+import com.gempukku.swccgo.cards.AbstractLostInterrupt;
+import com.gempukku.swccgo.cards.GameConditions;
+import com.gempukku.swccgo.cards.effects.CancelCardResultEffect;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.TargetingReason;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.game.state.GameState;
+import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.TriggerConditions;
+import com.gempukku.swccgo.logic.actions.PlayInterruptAction;
+import com.gempukku.swccgo.logic.effects.CancelCardBeingPlayedEffect;
+import com.gempukku.swccgo.logic.effects.DrawDestinyEffect;
+import com.gempukku.swccgo.logic.effects.MayNotBattleUntilEndOfTurnEffect;
+import com.gempukku.swccgo.logic.effects.ReleaseCaptiveEffect;
+import com.gempukku.swccgo.logic.effects.RespondablePlayCardEffect;
+import com.gempukku.swccgo.logic.effects.RespondablePlayingCardEffect;
+import com.gempukku.swccgo.logic.timing.Action;
+import com.gempukku.swccgo.logic.timing.Effect;
+import com.gempukku.swccgo.logic.timing.GuiUtils;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Set: Cloud City
+ * Type: Interrupt
+ * Subtype: Lost
+ * Title: Impressive, Most Impressive
+ */
+public class Card5_052 extends AbstractLostInterrupt {
+    public Card5_052() {
+        super(Side.LIGHT, 6, Title.Impressive_Most_Impressive, Uniqueness.UNIQUE, ExpansionSet.CLOUD_CITY, Rarity.R);
+        setLore("'Obi-Wan has taught you well.'");
+        setGameText("If opponent just attempted to 'freeze' a character using Carbon-Freezing or All Too Easy, draw destiny. Add character's ability. If total destiny > 7, effect canceled. Character released (if captive) and 'hides' (may not participate in battle) for remainder of turn.");
+        addIcons(Icon.CLOUD_CITY);
+    }
+
+    @Override
+    protected List<PlayInterruptAction> getGameTextOptionalBeforeActions(final String playerId, final SwccgGame game, final Effect effect, final PhysicalCard self) {
+        List<PlayInterruptAction> actions = new LinkedList<PlayInterruptAction>();
+
+        // All Too Easy being played (freeze attempt via Immediate Effect)
+        if (TriggerConditions.isPlayingCard(game, effect, Filters.All_Too_Easy)
+                && GameConditions.canCancelCardBeingPlayed(game, self, effect)) {
+            final PhysicalCard character = ImpressiveMostImpressiveGetTargetCharacter(game, effect);
+            if (character != null) {
+                actions.add(ImpressiveMostImpressiveBuildCancelFreezeAttemptAction(playerId, game, effect, self, character, true));
+            }
+        }
+
+        // Carbon-Freezing control-phase freeze attempt (RespondableEffect after targeting)
+        if (TriggerConditions.isPerformingGameTextAction(game, effect, Filters.Carbon_Freezing)) {
+            final PhysicalCard character = ImpressiveMostImpressiveGetTargetCharacter(game, effect);
+            if (character != null) {
+                actions.add(ImpressiveMostImpressiveBuildCancelFreezeAttemptAction(playerId, game, effect, self, character, false));
+            }
+        }
+
+        return actions.isEmpty() ? null : actions;
+    }
+
+    /**
+     * Resolve the character targeted by the freeze attempt (ATE attach target or CF captive target).
+     */
+    static PhysicalCard ImpressiveMostImpressiveGetTargetCharacter(SwccgGame game, Effect effect) {
+        Action targetingAction = null;
+        if (effect instanceof RespondablePlayingCardEffect) {
+            targetingAction = ((RespondablePlayingCardEffect) effect).getTargetingAction();
+        }
+        else if (effect.getType() == Effect.Type.RESPONDABLE_EFFECT) {
+            targetingAction = effect.getAction();
+            if (effect instanceof com.gempukku.swccgo.logic.effects.RespondableEffect) {
+                Action fromEffect = ((com.gempukku.swccgo.logic.effects.RespondableEffect) effect).getTargetingAction();
+                if (fromEffect != null) {
+                    targetingAction = fromEffect;
+                }
+            }
+        }
+        if (targetingAction == null) {
+            return null;
+        }
+
+        Map<Integer, Map<PhysicalCard, Set<TargetingReason>>> primaryTargets = targetingAction.getAllPrimaryTargetCards();
+        if (primaryTargets == null || primaryTargets.isEmpty()) {
+            return null;
+        }
+        for (Map<PhysicalCard, Set<TargetingReason>> map : primaryTargets.values()) {
+            for (PhysicalCard card : map.keySet()) {
+                if (Filters.character.accepts(game, card)) {
+                    return card;
+                }
+            }
+        }
+        // Fallback: any primary target
+        for (Map<PhysicalCard, Set<TargetingReason>> map : primaryTargets.values()) {
+            if (!map.isEmpty()) {
+                return map.keySet().iterator().next();
+            }
+        }
+        return null;
+    }
+
+    static PlayInterruptAction ImpressiveMostImpressiveBuildCancelFreezeAttemptAction(
+            final String playerId, final SwccgGame game, final Effect effectToCancel, final PhysicalCard self,
+            final PhysicalCard character, final boolean cancelCardBeingPlayed) {
+
+        final PlayInterruptAction action = new PlayInterruptAction(game, self);
+        action.setText("Cancel freeze attempt on " + GameUtils.getFullName(character));
+        action.addAnimationGroup(character);
+        // Allow response(s)
+        action.allowResponses("Draw destiny to cancel freeze attempt on " + GameUtils.getCardLink(character),
+                new RespondablePlayCardEffect(action) {
+                    @Override
+                    protected void performActionResults(Action targetingAction) {
+                        action.appendEffect(
+                                new DrawDestinyEffect(action, playerId) {
+                                    @Override
+                                    protected void destinyDraws(SwccgGame game, List<PhysicalCard> destinyCardDraws, List<Float> destinyDrawValues, Float totalDestiny) {
+                                        ImpressiveMostImpressiveResolveDestinyDraw(action, game, effectToCancel, character, cancelCardBeingPlayed, totalDestiny);
+                                    }
+                                }
+                        );
+                    }
+                }
+        );
+        return action;
+    }
+
+    static void ImpressiveMostImpressiveResolveDestinyDraw(
+            final PlayInterruptAction action, final SwccgGame game, final Effect effectToCancel,
+            final PhysicalCard character, final boolean cancelCardBeingPlayed, final Float totalDestiny) {
+
+        final GameState gameState = game.getGameState();
+        if (totalDestiny == null) {
+            gameState.sendMessage("Result: Failed due to failed destiny draw");
+            return;
+        }
+
+        // SpotOverride so ability still resolves if character is captive/inactive
+        float ability = game.getModifiersQuerying().getAbility(gameState, character);
+        float total = totalDestiny + ability;
+        gameState.sendMessage("Destiny: " + GuiUtils.formatAsString(totalDestiny));
+        gameState.sendMessage("Ability: " + GuiUtils.formatAsString(ability));
+        gameState.sendMessage("Total: " + GuiUtils.formatAsString(total));
+
+        if (total > 7) {
+            gameState.sendMessage("Result: Succeeded");
+            if (cancelCardBeingPlayed) {
+                action.appendEffect(
+                        new CancelCardBeingPlayedEffect(action, (RespondablePlayingCardEffect) effectToCancel));
+            }
+            else {
+                action.appendEffect(
+                        new CancelCardResultEffect(action, effectToCancel));
+            }
+            // Release if captive (include inactive/captive spotting for CF targets)
+            if (character.isCaptive()) {
+                action.appendEffect(
+                        new ReleaseCaptiveEffect(action, character));
+            }
+            action.appendEffect(
+                    new MayNotBattleUntilEndOfTurnEffect(action, character));
+        }
+        else {
+            gameState.sendMessage("Result: Failed");
+        }
+    }
+}

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
@@ -104393,6 +104393,34 @@
     ]
   },
   {
+    "cardId": "5_52",
+    "title": "Impressive, Most Impressive",
+    "slug": "impressive-most-impressive",
+    "slugWithSetName": "impressive-most-impressive-cloud-city",
+    "side": "LIGHT",
+    "uniqueness": "UNIQUE",
+    "expansionSet": "CLOUD_CITY",
+    "rarity": "R",
+    "cardCategory": "INTERRUPT",
+    "cardTypes": [
+      "INTERRUPT"
+    ],
+    "cardSubtype": "LOST",
+    "lore": "'Obi-Wan has taught you well.'",
+    "gameText": "If opponent just attempted to 'freeze' a character using Carbon-Freezing or All Too Easy, draw destiny. Add character's ability. If total destiny > 7, effect canceled. Character released (if captive) and 'hides' (may not participate in battle) for remainder of turn.",
+    "destiny": 6,
+    "icons": [
+      {
+        "icon": "CLOUD_CITY",
+        "count": 1
+      },
+      {
+        "icon": "INTERRUPT",
+        "count": 1
+      }
+    ]
+  },
+  {
     "cardId": "5_54",
     "title": "Into The Ventilation Shaft, Lefty",
     "slug": "into-the-ventilation-shaft-lefty",

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_light.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_light.json
@@ -53107,6 +53107,34 @@
     ]
   },
   {
+    "cardId": "5_52",
+    "title": "Impressive, Most Impressive",
+    "slug": "impressive-most-impressive",
+    "slugWithSetName": "impressive-most-impressive-cloud-city",
+    "side": "LIGHT",
+    "uniqueness": "UNIQUE",
+    "expansionSet": "CLOUD_CITY",
+    "rarity": "R",
+    "cardCategory": "INTERRUPT",
+    "cardTypes": [
+      "INTERRUPT"
+    ],
+    "cardSubtype": "LOST",
+    "lore": "'Obi-Wan has taught you well.'",
+    "gameText": "If opponent just attempted to 'freeze' a character using Carbon-Freezing or All Too Easy, draw destiny. Add character's ability. If total destiny > 7, effect canceled. Character released (if captive) and 'hides' (may not participate in battle) for remainder of turn.",
+    "destiny": 6,
+    "icons": [
+      {
+        "icon": "CLOUD_CITY",
+        "count": 1
+      },
+      {
+        "icon": "INTERRUPT",
+        "count": 1
+      }
+    ]
+  },
+  {
     "cardId": "5_54",
     "title": "Into The Ventilation Shaft, Lefty",
     "slug": "into-the-ventilation-shaft-lefty",

--- a/src/gemp-swccg-common/src/main/java/com/gempukku/swccgo/common/Title.java
+++ b/src/gemp-swccg-common/src/main/java/com/gempukku/swccgo/common/Title.java
@@ -572,6 +572,7 @@ public interface Title {
     String Im_On_The_Leader = "I'm On The Leader";
     String Im_Sorry = "I'm Sorry";
     String Im_With_You_Too = "I'm With You Too";
+    String Impressive_Most_Impressive = "Impressive, Most Impressive";
     String Imperial_Arrest_Order = "Imperial Arrest Order";
     String Imperial_Artillery = "Imperial Artillery";
     String Imperial_Atrocity = "Imperial Atrocity";

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
@@ -18575,6 +18575,7 @@ public class Filters {
     public static final Filter Imperial_Arrest_Order = Filters.title(Title.Imperial_Arrest_Order);
     public static final Filter Imperial_Artillery = Filters.title(Title.Imperial_Artillery);
     public static final Filter Imperial_Atrocity = Filters.title(Title.Imperial_Atrocity);
+    public static final Filter Impressive_Most_Impressive = Filters.title(Title.Impressive_Most_Impressive);
     public static final Filter Imperial_Barrier = Filters.title(Title.Imperial_Barrier);
     public static final Filter Imperial_City = Filters.title(Title.Imperial_City);
     public static final Filter Imperial_class_Star_Destroyer = Filters.modelType(ModelType.IMPERIAL_CLASS_STAR_DESTROYER);

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/TriggerConditions.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/TriggerConditions.java
@@ -2756,6 +2756,8 @@ public class TriggerConditions {
 
     /**
      * Determines if a card accepted by the filter is about to 'hide' from battle.
+     * Covers in-battle {@code HideFromBattleEffect} and shared hide-until-end-of-turn
+     * (e.g. Impressive, Most Impressive) so Nice Of You Guys To Drop By can cancel either.
      * @param game the game
      * @param effectResult the effect result
      * @param filter the filter
@@ -2765,10 +2767,8 @@ public class TriggerConditions {
         if (effectResult.getType() == EffectResult.Type.ABOUT_TO_HIDE_FROM_BATTLE) {
             AboutToHideFromBattleResult aboutToHideFromBattleResult = (AboutToHideFromBattleResult) effectResult;
             PhysicalCard card = aboutToHideFromBattleResult.getCardToHideFromBattle();
-            BattleState battleState = game.getGameState().getBattleState();
 
-            return battleState != null && battleState.isCardParticipatingInBattle(card)
-                    && !aboutToHideFromBattleResult.getPreventableCardEffect().isEffectOnCardPrevented(card)
+            return !aboutToHideFromBattleResult.getPreventableCardEffect().isEffectOnCardPrevented(card)
                     && Filters.and(filter).accepts(game.getGameState(), game.getModifiersQuerying(), card);
         }
         return false;

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/HideUntilEndOfTurnEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/HideUntilEndOfTurnEffect.java
@@ -1,0 +1,118 @@
+package com.gempukku.swccgo.logic.effects;
+
+import com.gempukku.swccgo.filters.Filter;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.game.state.BattleState;
+import com.gempukku.swccgo.game.state.GameState;
+import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.actions.SubAction;
+import com.gempukku.swccgo.logic.modifiers.ExcludedFromBattleModifier;
+import com.gempukku.swccgo.logic.modifiers.MayNotParticipateInBattleModifier;
+import com.gempukku.swccgo.logic.timing.AbstractSubActionEffect;
+import com.gempukku.swccgo.logic.timing.Action;
+import com.gempukku.swccgo.logic.timing.PassthruEffect;
+import com.gempukku.swccgo.logic.timing.results.AboutToHideFromBattleResult;
+import com.gempukku.swccgo.logic.timing.results.ExcludedFromBattleResult;
+import com.gempukku.swccgo.logic.timing.results.ResetOrModifyCardAttributeResult;
+
+import java.util.Collections;
+
+/**
+ * An effect that causes a card to 'hide' (may not participate in battle) until end of the turn.
+ * Uses the same AboutToHideFromBattle path as {@link HideFromBattleEffect} so cards such as
+ * Nice Of You Guys To Drop By can cancel the hide attempt.
+ */
+public class HideUntilEndOfTurnEffect extends AbstractSubActionEffect implements PreventableCardEffect {
+    private PhysicalCard _cardToHide;
+    private PhysicalCard _preventedCard;
+    private HideUntilEndOfTurnEffect _that;
+
+    /**
+     * Creates an effect that causes the specified card to 'hide' until end of the turn.
+     * @param action the action performing this effect
+     * @param cardToHide the card to 'hide'
+     */
+    public HideUntilEndOfTurnEffect(Action action, PhysicalCard cardToHide) {
+        super(action);
+        _cardToHide = cardToHide;
+        _that = this;
+    }
+
+    @Override
+    public boolean isPlayableInFull(SwccgGame game) {
+        return true;
+    }
+
+    @Override
+    protected SubAction getSubAction(final SwccgGame game) {
+        final GameState gameState = game.getGameState();
+
+        final SubAction subAction = new SubAction(_action);
+
+        // 1) Trigger "about to hide from battle" for card (same family as HideFromBattleEffect).
+        // When responding to the trigger, the preventEffectOnCard method can be called to prevent the hide.
+        subAction.appendEffect(new TriggeringResultEffect(subAction,
+                new AboutToHideFromBattleResult(subAction, _action.getPerformingPlayer(), _cardToHide, _that)));
+
+        // 2) Apply hide until end of turn if not prevented
+        subAction.appendEffect(
+                new PassthruEffect(subAction) {
+                    @Override
+                    protected void doPlayEffect(SwccgGame game) {
+                        if (_cardToHide.equals(_preventedCard))
+                            return;
+
+                        PhysicalCard source = subAction.getActionSource();
+                        gameState.sendMessage(GameUtils.getCardLink(_cardToHide) + " 'hides' (may not participate in battle) until end of the turn");
+                        gameState.cardAffectsCards(_action.getPerformingPlayer(), source, Collections.singleton(_cardToHide));
+
+                        // If currently in a battle, exclude from that battle (same as HideFromBattleEffect)
+                        BattleState battleState = gameState.getBattleState();
+                        if (battleState != null && battleState.isCardParticipatingInBattle(_cardToHide)) {
+                            game.getModifiersEnvironment().addUntilEndOfBattleModifier(
+                                    new ExcludedFromBattleModifier(source, _cardToHide));
+                            battleState.updateParticipants(game);
+                            game.getActionsEnvironment().emitEffectResult(
+                                    new ExcludedFromBattleResult(subAction.getPerformingPlayer(), source,
+                                            Collections.singletonList(_cardToHide), null, null));
+                        }
+
+                        // Remainder of turn: may not participate in battle
+                        Filter cardFilter = Filters.and(Filters.sameCardId(_cardToHide), Filters.in_play);
+                        game.getModifiersEnvironment().addUntilEndOfTurnModifier(
+                                new MayNotParticipateInBattleModifier(source, cardFilter));
+
+                        game.getActionsEnvironment().emitEffectResult(
+                                new ResetOrModifyCardAttributeResult(_action.getPerformingPlayer(), _cardToHide));
+                    }
+                }
+        );
+        return subAction;
+    }
+
+    @Override
+    protected boolean wasActionCarriedOut() {
+        return _preventedCard == null;
+    }
+
+    /**
+     * Prevents the specified card from being affected by the effect.
+     * @param card the card
+     */
+    @Override
+    public void preventEffectOnCard(PhysicalCard card) {
+        _preventedCard = card;
+    }
+
+    /**
+     * Determines if the specified card was prevented from being affected by the effect.
+     * @param card the card
+     * @return true or false
+     */
+    @Override
+    public boolean isEffectOnCardPrevented(PhysicalCard card) {
+        return card.equals(_preventedCard);
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_052_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_052_Tests.java
@@ -24,6 +24,8 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests for 5_52 Impressive, Most Impressive.
  * Doc scenarios + Mouse-style edges (threshold, CF window, hide, release, non-window).
+ * Luke Skywalker (1_19) ability = 4.
+ * Reuses existing MayNotBattleUntilEndOfTurnEffect hide; no seeker-ignore path.
  */
 public class Card_5_052_Tests {
 
@@ -89,6 +91,52 @@ public class Card_5_052_Tests {
 		}
 	}
 
+	private boolean WaitForImpressiveResponse(VirtualTableScenario scn) {
+		for (int i = 0; i < 30; i++) {
+			if (ImpressivePlayAvailable(scn)) {
+				return true;
+			}
+			var decision = scn.GetCurrentDecision();
+			if (decision == null) {
+				return false;
+			}
+			String text = decision.getText() != null ? decision.getText().toLowerCase() : "";
+			if (text.contains("optional")) {
+				scn.PassResponses("optional");
+			} else if (text.contains("required")) {
+				scn.PassResponses("required");
+			} else {
+				return ImpressivePlayAvailable(scn);
+			}
+		}
+		return ImpressivePlayAvailable(scn);
+	}
+
+	private void StartCarbonFreezingOnLuke(VirtualTableScenario scn) {
+		var luke = scn.GetLSCard("luke");
+		var carbonFreezing = scn.GetDSCard("carbonFreezing");
+		try {
+			scn.DSUseCardAction(carbonFreezing, "Perform Carbon-Freezing");
+		} catch (RuntimeException ex) {
+			scn.DSUseCardAction(carbonFreezing);
+		}
+		if (scn.DSHasCardChoiceAvailable(luke)) {
+			scn.DSChooseCard(luke);
+		}
+	}
+
+	private void FinishImpressivePlay(VirtualTableScenario scn) {
+		scn.PassCardPlayResponses();
+		scn.PassDestinyDrawResponses();
+		SafePassOptionalResponses(scn);
+		scn.PassAllResponses();
+		if (scn.LSReleaseDecisionAvailable()) {
+			scn.LSChooseRally();
+			scn.PassAllResponses();
+			SafePassOptionalResponses(scn);
+		}
+	}
+
 	@Test
 	public void ImpressiveMostImpressiveStatsAndKeywordsAreCorrect() {
 		var scn = GetScenario();
@@ -126,7 +174,7 @@ public class Card_5_052_Tests {
 
 	/**
 	 * Carbon-Freezing attempt: destiny+ability > 7 cancels, releases captive, hides rest of turn.
-	 * Luke ability 6 + destiny 2 = 8 > 7.
+	 * Luke ability 4 + destiny 4 = 8 > 7.
 	 */
 	@Test
 	public void ImpressiveMostImpressiveCancelsCarbonFreezingOnSuccessReleasesAndHides() {
@@ -144,66 +192,31 @@ public class Card_5_052_Tests {
 		scn.CaptureCardWith(boba, luke);
 		assertTrue(luke.isCaptive());
 
-		// Attach Carbon-Freezing to chamber
-		scn.MoveCardsToDSHand(carbonFreezing);
-		scn.SkipToDSTurn(Phase.DEPLOY);
-		assertTrue(scn.DSDeployAvailable(carbonFreezing) || scn.DSCardPlayAvailable(carbonFreezing));
-		scn.DSDeployCard(carbonFreezing);
-		if (scn.DSHasCardChoiceAvailable(chamber)) {
-			scn.DSChooseCard(chamber);
-		}
-		SafePassOptionalResponses(scn);
+		scn.AttachCardsTo(chamber, carbonFreezing);
 
-		scn.SkipToPhase(Phase.CONTROL);
-		assertTrue("Carbon-Freezing perform action should be available",
-				scn.DSCardActionAvailable(carbonFreezing, "Perform Carbon-Freezing")
-						|| scn.DSCardActionAvailable(carbonFreezing));
-
-		scn.DSUseCardAction(carbonFreezing, "Perform Carbon-Freezing");
-		if (!scn.DSDecisionAvailable("Perform Carbon-Freezing") && scn.DSGetDecision() != null) {
-			// fallback if action text differs
-			scn.DSUseCardAction(carbonFreezing);
+		scn.SkipToDSTurn(Phase.CONTROL);
+		boolean cfAction = false;
+		try {
+			cfAction = scn.DSCardActionAvailable(carbonFreezing, "Perform Carbon-Freezing")
+					|| scn.DSCardActionAvailable(carbonFreezing);
+		} catch (NullPointerException | IndexOutOfBoundsException ex) {
+			cfAction = false;
 		}
-		if (scn.DSHasCardChoiceAvailable(luke)) {
-			scn.DSChooseCard(luke);
-		}
-		SafePassOptionalResponses(scn);
+		assertTrue("Carbon-Freezing perform action should be available", cfAction);
 
-		// LS optional response to CF attempt
-		boolean found = false;
-		for (int i = 0; i < 30; i++) {
-			if (ImpressivePlayAvailable(scn)) {
-				found = true;
-				break;
-			}
-			var decision = scn.GetCurrentDecision();
-			if (decision == null) {
-				break;
-			}
-			String text = decision.getText() != null ? decision.getText().toLowerCase() : "";
-			if (text.contains("optional")) {
-				// do not auto-pass if Impressive is available under broader window
-				if (ImpressivePlayAvailable(scn)) {
-					found = true;
-					break;
-				}
-				scn.PassResponses("optional");
-			} else if (text.contains("required")) {
-				scn.PassResponses("required");
-			} else {
-				break;
-			}
-		}
-		assertTrue("Impressive should be offered in response to Carbon-Freezing attempt", found);
+		StartCarbonFreezingOnLuke(scn);
 
-		scn.PrepareLSDestiny(2); // + Luke ability 6 = 8 > 7
+		assertTrue("Impressive should be offered in response to Carbon-Freezing attempt",
+				WaitForImpressiveResponse(scn));
+
+		scn.PrepareLSDestiny(4); // + Luke ability 4 = 8 > 7
 		scn.LSPlayCard(impressive);
-		SafePassOptionalResponses(scn);
+		FinishImpressivePlay(scn);
 
 		assertTrue("Impressive is Lost Interrupt",
 				impressive.getZone() == Zone.TOP_OF_LOST_PILE || impressive.getZone() == Zone.LOST_PILE);
 		assertFalse("Luke should be released", luke.isCaptive());
-		assertTrue("Luke should remain in play after release", luke.getZone().isInPlay());
+		assertTrue("Luke should remain in play after rally", luke.getZone().isInPlay());
 	}
 
 	@Test
@@ -221,42 +234,23 @@ public class Card_5_052_Tests {
 		scn.MoveCardsToLocation(chamber, boba, luke);
 		scn.CaptureCardWith(boba, luke);
 
-		scn.MoveCardsToDSHand(carbonFreezing);
-		scn.SkipToDSTurn(Phase.DEPLOY);
-		scn.DSDeployCard(carbonFreezing);
-		if (scn.DSHasCardChoiceAvailable(chamber)) {
-			scn.DSChooseCard(chamber);
-		}
-		SafePassOptionalResponses(scn);
+		scn.AttachCardsTo(chamber, carbonFreezing);
 
-		scn.SkipToPhase(Phase.CONTROL);
-		scn.DSUseCardAction(carbonFreezing);
-		if (scn.DSHasCardChoiceAvailable(luke)) {
-			scn.DSChooseCard(luke);
-		}
+		scn.SkipToDSTurn(Phase.CONTROL);
+		StartCarbonFreezingOnLuke(scn);
 
-		boolean found = false;
-		for (int i = 0; i < 30; i++) {
-			if (ImpressivePlayAvailable(scn)) {
-				found = true;
-				break;
-			}
-			var decision = scn.GetCurrentDecision();
-			if (decision == null) break;
-			String text = decision.getText() != null ? decision.getText().toLowerCase() : "";
-			if (text.contains("optional")) {
-				if (ImpressivePlayAvailable(scn)) { found = true; break; }
-				scn.PassResponses("optional");
-			} else if (text.contains("required")) {
-				scn.PassResponses("required");
-			} else break;
-		}
-		assertTrue(found);
+		assertTrue("Impressive should be offered", WaitForImpressiveResponse(scn));
 
-		scn.PrepareLSDestiny(0); // + ability 6 = 6 <= 7 fail
+		scn.PrepareLSDestiny(3); // + ability 4 = 7 not > 7
+		scn.PrepareDSDestiny(7); // CF no-result band after Impressive fails
 		scn.LSPlayCard(impressive);
+		scn.PassCardPlayResponses();
+		scn.PassDestinyDrawResponses();
+		SafePassOptionalResponses(scn);
+		scn.PassAllResponses();
+		scn.PassDestinyDrawResponses();
 		SafePassOptionalResponses(scn);
 
-		assertTrue(luke.isCaptive());
+		assertTrue("Luke should remain captive when Impressive fails", luke.isCaptive());
 	}
 }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_052_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_052_Tests.java
@@ -1,0 +1,262 @@
+package com.gempukku.swccgo.cards.set5.light;
+
+import com.gempukku.swccgo.common.CardSubtype;
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for 5_52 Impressive, Most Impressive.
+ * Doc scenarios + Mouse-style edges (threshold, CF window, hide, release, non-window).
+ */
+public class Card_5_052_Tests {
+
+	protected VirtualTableScenario GetScenario() {
+		return new VirtualTableScenario(
+				new HashMap<>() {{
+					put("impressive", "5_52");
+					put("luke", "1_19");
+					put("obi", "1_11");
+					put("chamberLS", "5_78");
+				}},
+				new HashMap<>() {{
+					put("carbonFreezing", "5_114");
+					put("chamber", "5_166");
+					put("trooper", "1_194");
+					put("boba", "5_91");
+					put("ate", "5_112");
+					put("saber", "1_302");
+					put("vader", "1_168");
+				}},
+				20,
+				20,
+				StartingSetup.DefaultLSSpaceSystem,
+				StartingSetup.DefaultDSSpaceSystem,
+				StartingSetup.NoLSStartingInterrupts,
+				StartingSetup.NoDSStartingInterrupts,
+				StartingSetup.NoLSShields,
+				StartingSetup.NoDSShields,
+				VirtualTableScenario.Open
+		);
+	}
+
+	private void SafePassOptionalResponses(VirtualTableScenario scn) {
+		for (int i = 0; i < 25; i++) {
+			var decision = scn.GetCurrentDecision();
+			if (decision == null) {
+				return;
+			}
+			String text = decision.getText();
+			if (text == null) {
+				return;
+			}
+			String lower = text.toLowerCase();
+			if (lower.contains("optional")) {
+				scn.PassResponses("optional");
+			} else if (lower.contains("required")) {
+				scn.PassResponses("required");
+			} else {
+				return;
+			}
+		}
+	}
+
+	private boolean ImpressivePlayAvailable(VirtualTableScenario scn) {
+		var impressive = scn.GetLSCard("impressive");
+		if (scn.LSGetDecision() == null) {
+			return false;
+		}
+		try {
+			return scn.LSCardPlayAvailable(impressive);
+		} catch (NullPointerException | IndexOutOfBoundsException ex) {
+			return false;
+		}
+	}
+
+	@Test
+	public void ImpressiveMostImpressiveStatsAndKeywordsAreCorrect() {
+		var scn = GetScenario();
+		var card = scn.GetLSCard("impressive").getBlueprint();
+		assertEquals(Title.Impressive_Most_Impressive, card.getTitle());
+		assertEquals(Uniqueness.UNIQUE, card.getUniqueness());
+		assertEquals(Side.LIGHT, card.getSide());
+		scn.BlueprintCardTypeCheck(card, new ArrayList<>() {{
+			add(CardType.INTERRUPT);
+		}});
+		assertEquals(CardSubtype.LOST, card.getCardSubtype());
+		assertEquals(6, card.getDestiny(), scn.epsilon);
+		scn.BlueprintIconCheck(card, new ArrayList<>() {{
+			add(Icon.CLOUD_CITY);
+			add(Icon.INTERRUPT);
+		}});
+		assertEquals(ExpansionSet.CLOUD_CITY, card.getExpansionSet());
+		assertEquals(Rarity.R, card.getRarity());
+	}
+
+	@Test
+	public void ImpressiveMostImpressiveNotPlayableWithoutFreezeAttempt() {
+		var scn = GetScenario();
+		var impressive = scn.GetLSCard("impressive");
+		var luke = scn.GetLSCard("luke");
+		var site = scn.GetLSStartingLocation();
+
+		scn.StartGame();
+		scn.MoveCardsToLSHand(impressive);
+		scn.MoveCardsToLocation(site, luke);
+
+		scn.SkipToLSTurn(Phase.CONTROL);
+		assertFalse("Impressive should not be playable without freeze attempt", ImpressivePlayAvailable(scn));
+	}
+
+	/**
+	 * Carbon-Freezing attempt: destiny+ability > 7 cancels, releases captive, hides rest of turn.
+	 * Luke ability 6 + destiny 2 = 8 > 7.
+	 */
+	@Test
+	public void ImpressiveMostImpressiveCancelsCarbonFreezingOnSuccessReleasesAndHides() {
+		var scn = GetScenario();
+		var impressive = scn.GetLSCard("impressive");
+		var luke = scn.GetLSCard("luke");
+		var carbonFreezing = scn.GetDSCard("carbonFreezing");
+		var chamber = scn.GetDSCard("chamber");
+		var boba = scn.GetDSCard("boba");
+
+		scn.StartGame();
+		scn.MoveCardsToLSHand(impressive);
+		scn.MoveLocationToTable(chamber);
+		scn.MoveCardsToLocation(chamber, boba, luke);
+		scn.CaptureCardWith(boba, luke);
+		assertTrue(luke.isCaptive());
+
+		// Attach Carbon-Freezing to chamber
+		scn.MoveCardsToDSHand(carbonFreezing);
+		scn.SkipToDSTurn(Phase.DEPLOY);
+		assertTrue(scn.DSDeployAvailable(carbonFreezing) || scn.DSCardPlayAvailable(carbonFreezing));
+		scn.DSDeployCard(carbonFreezing);
+		if (scn.DSHasCardChoiceAvailable(chamber)) {
+			scn.DSChooseCard(chamber);
+		}
+		SafePassOptionalResponses(scn);
+
+		scn.SkipToPhase(Phase.CONTROL);
+		assertTrue("Carbon-Freezing perform action should be available",
+				scn.DSCardActionAvailable(carbonFreezing, "Perform Carbon-Freezing")
+						|| scn.DSCardActionAvailable(carbonFreezing));
+
+		scn.DSUseCardAction(carbonFreezing, "Perform Carbon-Freezing");
+		if (!scn.DSDecisionAvailable("Perform Carbon-Freezing") && scn.DSGetDecision() != null) {
+			// fallback if action text differs
+			scn.DSUseCardAction(carbonFreezing);
+		}
+		if (scn.DSHasCardChoiceAvailable(luke)) {
+			scn.DSChooseCard(luke);
+		}
+		SafePassOptionalResponses(scn);
+
+		// LS optional response to CF attempt
+		boolean found = false;
+		for (int i = 0; i < 30; i++) {
+			if (ImpressivePlayAvailable(scn)) {
+				found = true;
+				break;
+			}
+			var decision = scn.GetCurrentDecision();
+			if (decision == null) {
+				break;
+			}
+			String text = decision.getText() != null ? decision.getText().toLowerCase() : "";
+			if (text.contains("optional")) {
+				// do not auto-pass if Impressive is available under broader window
+				if (ImpressivePlayAvailable(scn)) {
+					found = true;
+					break;
+				}
+				scn.PassResponses("optional");
+			} else if (text.contains("required")) {
+				scn.PassResponses("required");
+			} else {
+				break;
+			}
+		}
+		assertTrue("Impressive should be offered in response to Carbon-Freezing attempt", found);
+
+		scn.PrepareLSDestiny(2); // + Luke ability 6 = 8 > 7
+		scn.LSPlayCard(impressive);
+		SafePassOptionalResponses(scn);
+
+		assertTrue("Impressive is Lost Interrupt",
+				impressive.getZone() == Zone.TOP_OF_LOST_PILE || impressive.getZone() == Zone.LOST_PILE);
+		assertFalse("Luke should be released", luke.isCaptive());
+		assertTrue("Luke should remain in play after release", luke.getZone().isInPlay());
+	}
+
+	@Test
+	public void ImpressiveMostImpressiveFailsWhenTotalNotGreaterThanSeven() {
+		var scn = GetScenario();
+		var impressive = scn.GetLSCard("impressive");
+		var luke = scn.GetLSCard("luke");
+		var carbonFreezing = scn.GetDSCard("carbonFreezing");
+		var chamber = scn.GetDSCard("chamber");
+		var boba = scn.GetDSCard("boba");
+
+		scn.StartGame();
+		scn.MoveCardsToLSHand(impressive);
+		scn.MoveLocationToTable(chamber);
+		scn.MoveCardsToLocation(chamber, boba, luke);
+		scn.CaptureCardWith(boba, luke);
+
+		scn.MoveCardsToDSHand(carbonFreezing);
+		scn.SkipToDSTurn(Phase.DEPLOY);
+		scn.DSDeployCard(carbonFreezing);
+		if (scn.DSHasCardChoiceAvailable(chamber)) {
+			scn.DSChooseCard(chamber);
+		}
+		SafePassOptionalResponses(scn);
+
+		scn.SkipToPhase(Phase.CONTROL);
+		scn.DSUseCardAction(carbonFreezing);
+		if (scn.DSHasCardChoiceAvailable(luke)) {
+			scn.DSChooseCard(luke);
+		}
+
+		boolean found = false;
+		for (int i = 0; i < 30; i++) {
+			if (ImpressivePlayAvailable(scn)) {
+				found = true;
+				break;
+			}
+			var decision = scn.GetCurrentDecision();
+			if (decision == null) break;
+			String text = decision.getText() != null ? decision.getText().toLowerCase() : "";
+			if (text.contains("optional")) {
+				if (ImpressivePlayAvailable(scn)) { found = true; break; }
+				scn.PassResponses("optional");
+			} else if (text.contains("required")) {
+				scn.PassResponses("required");
+			} else break;
+		}
+		assertTrue(found);
+
+		scn.PrepareLSDestiny(0); // + ability 6 = 6 <= 7 fail
+		scn.LSPlayCard(impressive);
+		SafePassOptionalResponses(scn);
+
+		assertTrue(luke.isCaptive());
+	}
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_052_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_052_Tests.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertTrue;
  * Tests for 5_52 Impressive, Most Impressive.
  * Doc scenarios + Mouse-style edges (threshold, CF window, hide, release, non-window).
  * Luke Skywalker (1_19) ability = 4.
- * Reuses existing MayNotBattleUntilEndOfTurnEffect hide; no seeker-ignore path.
+ * Uses shared HideUntilEndOfTurnEffect (AboutToHide family; Nice Of You Guys can cancel).
  */
 public class Card_5_052_Tests {
 
@@ -33,6 +33,7 @@ public class Card_5_052_Tests {
 		return new VirtualTableScenario(
 				new HashMap<>() {{
 					put("impressive", "5_52");
+					put("nice", "3_46");
 					put("luke", "1_19");
 					put("obi", "1_11");
 					put("chamberLS", "5_78");
@@ -217,6 +218,9 @@ public class Card_5_052_Tests {
 				impressive.getZone() == Zone.TOP_OF_LOST_PILE || impressive.getZone() == Zone.LOST_PILE);
 		assertFalse("Luke should be released", luke.isCaptive());
 		assertTrue("Luke should remain in play after rally", luke.getZone().isInPlay());
+		assertTrue("Luke should be hidden (may not participate in battle) for remainder of turn",
+				scn.game().getModifiersQuerying().isProhibitedFromParticipatingInBattle(
+						scn.gameState(), luke, scn.DS));
 	}
 
 	@Test
@@ -252,5 +256,133 @@ public class Card_5_052_Tests {
 		SafePassOptionalResponses(scn);
 
 		assertTrue("Luke should remain captive when Impressive fails", luke.isCaptive());
+	}
+
+	/**
+	 * Hide-until-EOT clears after turn ends (duration = remainder of turn).
+	 */
+	@Test
+	public void ImpressiveMostImpressiveHideClearsAfterTurnEnds() {
+		var scn = GetScenario();
+		var impressive = scn.GetLSCard("impressive");
+		var luke = scn.GetLSCard("luke");
+		var carbonFreezing = scn.GetDSCard("carbonFreezing");
+		var chamber = scn.GetDSCard("chamber");
+		var boba = scn.GetDSCard("boba");
+
+		scn.StartGame();
+		scn.MoveCardsToLSHand(impressive);
+		scn.MoveLocationToTable(chamber);
+		scn.MoveCardsToLocation(chamber, boba, luke);
+		scn.CaptureCardWith(boba, luke);
+		scn.AttachCardsTo(chamber, carbonFreezing);
+
+		scn.SkipToDSTurn(Phase.CONTROL);
+		StartCarbonFreezingOnLuke(scn);
+		assertTrue("Impressive should be offered", WaitForImpressiveResponse(scn));
+
+		scn.PrepareLSDestiny(4);
+		scn.LSPlayCard(impressive);
+		FinishImpressivePlay(scn);
+
+		assertTrue("Luke hidden for remainder of turn",
+				scn.game().getModifiersQuerying().isProhibitedFromParticipatingInBattle(
+						scn.gameState(), luke, scn.DS));
+
+		scn.SkipToLSTurn(Phase.CONTROL);
+		assertFalse("Hide-until-EOT should clear after the turn ends",
+				scn.game().getModifiersQuerying().isProhibitedFromParticipatingInBattle(
+						scn.gameState(), luke, scn.DS));
+	}
+
+	/**
+	 * Nice Of You Guys To Drop By cancels Impressive's AboutToHide hide-until-EOT.
+	 */
+	@Test
+	public void ImpressiveMostImpressiveHideCanceledByNiceOfYouGuysToDropBy() {
+		var scn = GetScenario();
+		var impressive = scn.GetLSCard("impressive");
+		var nice = scn.GetLSCard("nice");
+		var luke = scn.GetLSCard("luke");
+		var carbonFreezing = scn.GetDSCard("carbonFreezing");
+		var chamber = scn.GetDSCard("chamber");
+		var boba = scn.GetDSCard("boba");
+
+		scn.StartGame();
+		scn.MoveCardsToLSHand(impressive, nice);
+		scn.MoveLocationToTable(chamber);
+		scn.MoveCardsToLocation(chamber, boba, luke);
+		scn.CaptureCardWith(boba, luke);
+		scn.AttachCardsTo(chamber, carbonFreezing);
+
+		scn.SkipToDSTurn(Phase.CONTROL);
+		StartCarbonFreezingOnLuke(scn);
+		assertTrue("Impressive should be offered", WaitForImpressiveResponse(scn));
+
+		scn.PrepareLSDestiny(4);
+		scn.LSPlayCard(impressive);
+		scn.PassCardPlayResponses();
+		scn.PassDestinyDrawResponses();
+
+		boolean niceOffered = false;
+		for (int i = 0; i < 50; i++) {
+			if (scn.LSReleaseDecisionAvailable()) {
+				scn.LSChooseRally();
+				continue;
+			}
+
+			var lsDec = scn.LSGetDecision();
+			var dsDec = scn.DSGetDecision();
+			var lsActions = scn.GetLSAvailableActions();
+
+			boolean niceInActions = false;
+			if (lsActions != null) {
+				for (String a : lsActions) {
+					if (a == null) continue;
+					String lower = a.toLowerCase();
+					if (lower.contains("nice") || lower.contains("hide")) {
+						niceInActions = true;
+						break;
+					}
+				}
+			}
+			// Only query LS card actions when LS actually has a decision (avoids framework NPE)
+			if (lsDec != null && (niceInActions || scn.LSCardActionAvailable(nice) || scn.LSActionAvailable("hide"))) {
+				niceOffered = true;
+				break;
+			}
+
+			if (dsDec != null) {
+				String dsText = dsDec.getText() != null ? dsDec.getText().toLowerCase() : "";
+				if (dsText.contains("about_to_hide") || dsText.contains("optional") || dsText.contains("required")) {
+					scn.DSPass();
+					continue;
+				}
+			}
+			if (lsDec != null) {
+				String lsText = lsDec.getText() != null ? lsDec.getText().toLowerCase() : "";
+				if (lsText.contains("about_to_hide")) {
+					// LS has AboutToHide but Nice not listed — fail later
+					break;
+				}
+				if (lsText.contains("optional") || lsText.contains("required")) {
+					scn.LSPass();
+					continue;
+				}
+			}
+			break;
+		}
+
+		assertTrue("Nice Of You Guys should be offered to cancel AboutToHide", niceOffered);
+		scn.LSUseCardAction(nice);
+		scn.PassCardPlayResponses();
+		scn.PassAllResponses();
+		SafePassOptionalResponses(scn);
+		scn.PassAllResponses();
+
+		assertFalse("Luke should be released", luke.isCaptive());
+		assertFalse("Nice Of You Guys should cancel hide-until-EOT",
+				scn.game().getModifiersQuerying().isProhibitedFromParticipatingInBattle(
+						scn.gameState(), luke, scn.DS));
 	}
 }


### PR DESCRIPTION
## Summary
Implements **Impressive, Most Impressive (5_52)**, Cloud City Light Lost Interrupt. Closes #120.

## Game text
If opponent just attempted to freeze a character using Carbon-Freezing or All Too Easy, draw destiny; add character ability; if total > 7, cancel effect, release if captive, and the character **'hides' (may not participate in battle) for remainder of turn**.

## What changed
- New interrupt `Card5_052`.
- Opens Carbon-Freezing attempt response window by switching `Card5_114` from `UnrespondableEffect` to `RespondableEffect` (targeting already performed; required for interrupt responses).
- **Chief (C):** replaces `MayNotBattleUntilEndOfTurnEffect` with new shared **`HideUntilEndOfTurnEffect`** in the same AboutToHide / hide family as `HideFromBattleEffect` (emits `AboutToHideFromBattleResult`, then applies may-not-participate until end of turn; if currently in battle, also excludes from that battle).
- Narrow hook: `TriggerConditions.isAboutToHideFromBattle` no longer requires the card to already be participating in the current battle, so **Nice Of You Guys To Drop By** can cancel out-of-battle hide-until-EOT (e.g. Impressive during Carbon-Freezing control). `Card3_046` itself unchanged — it already listens to AboutToHide.
- No seeker-ignore path (coordinate with Attark/Velken seeker-ignore work if related).

### Shared engine
- New: `HideUntilEndOfTurnEffect` (AboutToHide-cancelable hide lasting remainder of TURN — not battle-only `HideFromBattleEffect`).
- `TriggerConditions.isAboutToHideFromBattle` broadened slightly for hide-until-EOT outside an active battle.
- Narrow Carbon-Freezing response enablement on `Card5_114`. Reviewers: other cards that respond to Carbon-Freezing / All Too Easy freezes depend on that window.

## Tests (`Card_5_052_Tests`, 6 tests)
1. Stats / keywords
2. Not playable without freeze attempt
3. Success: destiny+ability >7 cancels Carbon-Freezing, releases captive, hide-until-EOT applied
4. Fail ≤7 leaves captive
5. Hide-until-EOT clears after the turn ends
6. Nice Of You Guys To Drop By cancels Impressive's AboutToHide hide-until-EOT

Maven: `Card_5_052_Tests` — Tests run: 6, Failures: 0, Errors: 0.

## Known gaps
All Too Easy success path not separately asserted in suite (CF path covers cancel/release/hide). Doc soft edges may still be open.
