### PR TITLE
6_46 Yarkora

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set6/light/Card6_046.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set6/light/Card6_046.java
@@ -60,20 +60,21 @@ public class Card6_046 extends AbstractAlien {
      * Excludes inactive (e.g. missing) and supporting cards via Filters.filterActive.
      */
     static Collection<PhysicalCard> YarkoraGetActiveOwnedYarkoras(SwccgGame game, String playerId) {
-        return Filters.filterActive(game, null, Filters.and(Filters.owner(playerId), Filters.Yarkora));
+        return Filters.filterActive(game, null, Filters.and(Filters.owner(playerId), Filters.Yarkora, Filters.not(Filters.title("Yarkora"))));
     }
 
     /**
      * Action proxy granting each active owned Yarkora one optional -1 to this specific destiny draw.
-     * Species-based (not gametext), so Saelt-Marae / canceled gametext still eligible.
+     * Species-based for non-title-Yarkora (e.g. Saelt-Marae). Title Yarkora uses getGameTextOptionalAfterTriggers.
      */
     static ActionProxy YarkoraCreateSubtractActionProxy(final String playerId, final DrawDestinyState drawDestinyState) {
         return new AbstractActionProxy() {
             @Override
             public List<TriggerAction> getOptionalAfterTriggers(String playerId2, SwccgGame game, EffectResult effectResult) {
                 List<TriggerAction> actions = new LinkedList<TriggerAction>();
+                // Proxy only lives for this draw; match any non-canceled destiny drawn while active.
                 if (!playerId2.equals(playerId)
-                        || !TriggerConditions.isDestinyJustDrawn(game, effectResult, drawDestinyState)) {
+                        || !TriggerConditions.isDestinyJustDrawn(game, effectResult)) {
                     return actions;
                 }
                 for (PhysicalCard yarkora : YarkoraGetActiveOwnedYarkoras(game, playerId)) {
@@ -159,6 +160,21 @@ public class Card6_046 extends AbstractAlien {
                         }
                     }
             );
+            return Collections.singletonList(action);
+        }
+        return null;
+    }
+
+
+    @Override
+    protected List<OptionalGameTextTriggerAction> getGameTextOptionalAfterTriggers(final String playerId, SwccgGame game, EffectResult effectResult, final PhysicalCard self, int gameTextSourceCardId) {
+        // Each Card6_046 may -1 once per destiny drawn by your Yarkora (The One Rule / once per trigger).
+        if (TriggerConditions.isDestinyJustDrawnFor(game, effectResult, Filters.and(Filters.your(self), Filters.Yarkora))) {
+            final OptionalGameTextTriggerAction action = new OptionalGameTextTriggerAction(self, gameTextSourceCardId);
+            action.setText("Subtract 1 from destiny");
+            action.setActionMsg("Subtract 1 from destiny using " + GameUtils.getCardLink(self));
+            action.appendEffect(
+                    new ModifyDestinyEffect(action, -1, true));
             return Collections.singletonList(action);
         }
         return null;

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set6/light/Card6_046.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set6/light/Card6_046.java
@@ -1,0 +1,166 @@
+package com.gempukku.swccgo.cards.set6.light;
+
+import com.gempukku.swccgo.cards.AbstractAlien;
+import com.gempukku.swccgo.cards.GameConditions;
+import com.gempukku.swccgo.cards.effects.usage.OncePerPhaseEffect;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.InactiveReason;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Species;
+import com.gempukku.swccgo.common.SpotOverride;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.filters.Filter;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.AbstractActionProxy;
+import com.gempukku.swccgo.game.ActionProxy;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.game.state.DrawDestinyState;
+import com.gempukku.swccgo.game.state.GameState;
+import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.TriggerConditions;
+import com.gempukku.swccgo.logic.actions.OptionalGameTextTriggerAction;
+import com.gempukku.swccgo.logic.actions.TopLevelGameTextAction;
+import com.gempukku.swccgo.logic.actions.TriggerAction;
+import com.gempukku.swccgo.logic.effects.BreakCoverEffect;
+import com.gempukku.swccgo.logic.effects.DrawDestinyEffect;
+import com.gempukku.swccgo.logic.effects.ModifyDestinyEffect;
+import com.gempukku.swccgo.logic.effects.TargetCardOnTableEffect;
+import com.gempukku.swccgo.logic.effects.UnrespondableEffect;
+import com.gempukku.swccgo.logic.timing.Action;
+import com.gempukku.swccgo.logic.timing.EffectResult;
+import com.gempukku.swccgo.logic.timing.GuiUtils;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Set: Jabba's Palace
+ * Type: Character
+ * Subtype: Alien
+ * Title: Yarkora
+ */
+public class Card6_046 extends AbstractAlien {
+    public Card6_046() {
+        super(Side.LIGHT, 3, 2, 1, 1, 2, "Yarkora", Uniqueness.UNRESTRICTED, ExpansionSet.JABBAS_PALACE, Rarity.C);
+        setLore("Mysterious, secretive aliens. Tend to be found as couriers, scouts and t'bac farmers. Some have helped the Alliance's efforts at counter-espionage.");
+        setGameText("If at same site as an Undercover spy during your control phase, may draw destiny. Each of your Yarkoras on table may cumulatively subtract one from that destiny. Spy's 'cover is broken' if destiny = spy's ability.");
+        addIcons(Icon.JABBAS_PALACE);
+        setSpecies(Species.YARKORA);
+    }
+
+    /**
+     * Active Yarkoras owned by the player that may optionally subtract from this destiny draw.
+     * Excludes inactive (e.g. missing) and supporting cards via Filters.filterActive.
+     */
+    static Collection<PhysicalCard> YarkoraGetActiveOwnedYarkoras(SwccgGame game, String playerId) {
+        return Filters.filterActive(game, null, Filters.and(Filters.owner(playerId), Filters.Yarkora));
+    }
+
+    /**
+     * Action proxy granting each active owned Yarkora one optional -1 to this specific destiny draw.
+     * Species-based (not gametext), so Saelt-Marae / canceled gametext still eligible.
+     */
+    static ActionProxy YarkoraCreateSubtractActionProxy(final String playerId, final DrawDestinyState drawDestinyState) {
+        return new AbstractActionProxy() {
+            @Override
+            public List<TriggerAction> getOptionalAfterTriggers(String playerId2, SwccgGame game, EffectResult effectResult) {
+                List<TriggerAction> actions = new LinkedList<TriggerAction>();
+                if (!playerId2.equals(playerId)
+                        || !TriggerConditions.isDestinyJustDrawn(game, effectResult, drawDestinyState)) {
+                    return actions;
+                }
+                for (PhysicalCard yarkora : YarkoraGetActiveOwnedYarkoras(game, playerId)) {
+                    final OptionalGameTextTriggerAction subtractAction =
+                            new OptionalGameTextTriggerAction(yarkora, playerId, yarkora.getCardId());
+                    subtractAction.setText("Subtract 1 from destiny (" + GameUtils.getFullName(yarkora) + ")");
+                    subtractAction.setActionMsg("Subtract 1 from destiny using " + GameUtils.getCardLink(yarkora));
+                    // cumulative=true so multiple copies titled Yarkora each stack -1
+                    subtractAction.appendEffect(
+                            new ModifyDestinyEffect(subtractAction, -1, true));
+                    actions.add(subtractAction);
+                }
+                return actions;
+            }
+        };
+    }
+
+    @Override
+    protected List<TopLevelGameTextAction> getGameTextTopLevelActions(final String playerId, SwccgGame game, final PhysicalCard self, int gameTextSourceCardId) {
+        Filter targetFilter = Filters.and(Filters.opponents(self), Filters.undercover_spy, Filters.atSameSite(self));
+        Map<InactiveReason, Boolean> spotOverride = SpotOverride.INCLUDE_UNDERCOVER;
+
+        // Check condition(s)
+        if (GameConditions.isOnceDuringYourPhase(game, self, playerId, gameTextSourceCardId, Phase.CONTROL)
+                && GameConditions.canTarget(game, self, spotOverride, targetFilter)) {
+
+            final TopLevelGameTextAction action = new TopLevelGameTextAction(self, gameTextSourceCardId);
+            action.setText("Break a spy's cover");
+            // Update usage limit(s)
+            action.appendUsage(
+                    new OncePerPhaseEffect(action));
+            // Choose target(s)
+            action.appendTargeting(
+                    new TargetCardOnTableEffect(action, playerId, "Target undercover spy", spotOverride, targetFilter) {
+                        @Override
+                        protected void cardTargeted(final int targetGroupId, final PhysicalCard cardTargeted) {
+                            action.addAnimationGroup(cardTargeted);
+                            // Allow response(s)
+                            action.allowResponses("'Break cover' of " + GameUtils.getCardLink(cardTargeted),
+                                    new UnrespondableEffect(action) {
+                                        @Override
+                                        protected void performActionResults(Action targetingAction) {
+                                            // Perform result(s)
+                                            action.appendEffect(
+                                                    new DrawDestinyEffect(action, playerId) {
+                                                        @Override
+                                                        protected Collection<PhysicalCard> getGameTextAbilityManeuverOrDefenseValueTargeted() {
+                                                            return Collections.singletonList(cardTargeted);
+                                                        }
+
+                                                        @Override
+                                                        protected List<ActionProxy> getDrawDestinyActionProxies(SwccgGame game, final DrawDestinyState drawDestinyState) {
+                                                            return Collections.singletonList(
+                                                                    YarkoraCreateSubtractActionProxy(playerId, drawDestinyState));
+                                                        }
+
+                                                        @Override
+                                                        protected void destinyDraws(SwccgGame game, List<PhysicalCard> destinyCardDraws, List<Float> destinyDrawValues, Float totalDestiny) {
+                                                            GameState gameState = game.getGameState();
+                                                            if (totalDestiny == null) {
+                                                                gameState.sendMessage("Result: Failed due to failed destiny draw");
+                                                                return;
+                                                            }
+
+                                                            float ability = game.getModifiersQuerying().getAbility(game.getGameState(), cardTargeted);
+                                                            gameState.sendMessage("Destiny: " + GuiUtils.formatAsString(totalDestiny));
+                                                            gameState.sendMessage("Ability: " + GuiUtils.formatAsString(ability));
+
+                                                            if (totalDestiny == ability) {
+                                                                gameState.sendMessage("Result: Succeeded");
+                                                                action.appendEffect(
+                                                                        new BreakCoverEffect(action, cardTargeted));
+                                                            }
+                                                            else {
+                                                                gameState.sendMessage("Result: Failed");
+                                                            }
+                                                        }
+                                                    }
+                                            );
+                                        }
+                                    }
+                            );
+                        }
+                    }
+            );
+            return Collections.singletonList(action);
+        }
+        return null;
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set6/light/Card_6_046_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set6/light/Card_6_046_Tests.java
@@ -97,7 +97,7 @@ public class Card_6_046_Tests {
 				scn.PassAllResponses();
 				deployed = garindan.isUndercover();
 			}
-		} catch (RuntimeException | NullPointerException | IndexOutOfBoundsException ex) {
+		} catch (RuntimeException ex) {
 			deployed = false;
 		}
 
@@ -112,6 +112,49 @@ public class Card_6_046_Tests {
 		assertTrue("Garindan should be undercover with Undercover (2_129) involved", garindan.isUndercover());
 	}
 
+
+	/** Pass pre-draw windows, take up to maxSubtracts Yarkora -1 optionals, then finish destiny. */
+	private int YarkoraTakeSubtractsAndFinishDestiny(VirtualTableScenario scn, int maxSubtracts) {
+		scn.PassResponses("COST_TO_DRAW_DESTINY_CARD");
+		scn.PassResponses("ABOUT_TO_DRAW_DESTINY_CARD");
+		int taken = 0;
+		for (int i = 0; i < 40 && taken < maxSubtracts; i++) {
+			// Prefer LS subtract whenever available (even if DS is current decider)
+			if (scn.LSAnyDecisionsAvailable()) {
+				java.util.List<String> actions = scn.LSGetADParamAsList("actionText");
+				boolean hasSubtract = actions != null && actions.stream().anyMatch(
+						a -> a != null && a.toLowerCase().contains("subtract 1"));
+				if (hasSubtract) {
+					scn.LSChooseAction("Subtract 1");
+					taken++;
+					continue;
+				}
+			}
+			var decision = scn.GetCurrentDecision();
+			if (decision == null) {
+				break;
+			}
+			String text = decision.getText() != null ? decision.getText() : "";
+			String lower = text.toLowerCase();
+			// Pass the non-LS (or LS-without-subtract) player one at a time — do not PassResponses both
+			if (lower.contains("destiny_drawn") || lower.contains("optional") || lower.contains("about_to_draw") || lower.contains("cost_to_draw")) {
+				String decider = scn.GetDecidingPlayer();
+				if (decider != null) {
+					scn.PlayerPass(decider);
+				} else {
+					break;
+				}
+				continue;
+			}
+			scn.PassResponses();
+		}
+		scn.PassResponses("DESTINY_DRAWN");
+		scn.PassResponses("COMPLETE_DESTINY_DRAW");
+		scn.PassResponses("DRAWING_DESTINY_COMPLETE");
+		SafePassOptionalResponses(scn);
+		scn.PassAllResponses();
+		return taken;
+	}
 	@Test
 	public void YarkoraStatsAndKeywordsAreCorrect() {
 		var scn = GetScenario();
@@ -230,29 +273,8 @@ public class Card_6_046_Tests {
 		scn.LSUseCardAction(yarkora, "Break a spy's cover");
 		scn.LSChooseCard(garindan);
 
-		// Destiny drawn; take both subtract optionals
-		for (int i = 0; i < 10; i++) {
-			var decision = scn.GetCurrentDecision();
-			if (decision == null) {
-				break;
-			}
-			String text = decision.getText() != null ? decision.getText() : "";
-			if (text.toLowerCase().contains("subtract 1")) {
-				scn.LSChooseAction("Subtract 1");
-			} else if (text.toLowerCase().contains("optional")) {
-				// Prefer subtract if listed in actions; otherwise pass after both used
-				try {
-					scn.LSChooseAction("Subtract 1");
-				} catch (AssertionError | RuntimeException ex) {
-					scn.PassResponses("optional");
-				}
-			} else {
-				break;
-			}
-		}
-		SafePassOptionalResponses(scn);
-		scn.PassAllResponses();
-
+		int taken = YarkoraTakeSubtractsAndFinishDestiny(scn, 2);
+		assertTrue("Expected two Yarkora subtract optionals, took " + taken, taken >= 2);
 		assertFalse("Two Yarkoras -1 each should make destiny 3 become 1 and break cover",
 				garindan.isUndercover());
 	}
@@ -274,32 +296,8 @@ public class Card_6_046_Tests {
 		scn.LSUseCardAction(yarkora, "Break a spy's cover");
 		scn.LSChooseCard(garindan);
 
-		boolean subtracted = false;
-		for (int i = 0; i < 10; i++) {
-			var decision = scn.GetCurrentDecision();
-			if (decision == null) {
-				break;
-			}
-			String text = decision.getText() != null ? decision.getText() : "";
-			if (text.toLowerCase().contains("subtract 1")) {
-				scn.LSChooseAction("Subtract 1");
-				subtracted = true;
-				break;
-			} else if (text.toLowerCase().contains("optional")) {
-				try {
-					scn.LSChooseAction("Subtract 1");
-					subtracted = true;
-					break;
-				} catch (AssertionError | RuntimeException ex) {
-					scn.PassResponses("optional");
-				}
-			} else {
-				break;
-			}
-		}
-		assertTrue("At least one Yarkora species character should offer subtract", subtracted);
-		SafePassOptionalResponses(scn);
-		scn.PassAllResponses();
+		int taken = YarkoraTakeSubtractsAndFinishDestiny(scn, 1);
+		assertTrue("Saelt and/or Yarkora should offer subtract, took " + taken, taken >= 1);
 		assertFalse(garindan.isUndercover());
 	}
 }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set6/light/Card_6_046_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set6/light/Card_6_046_Tests.java
@@ -35,6 +35,8 @@ public class Card_6_046_Tests {
 					put("yarkora", "6_46");
 					put("yarkora2", "6_46");
 					put("saelt", "6_37");
+					put("momaw", "1_20");
+					put("ls_undercover", "2_40");
 				}},
 				new HashMap<>() {{
 					put("garindan", "1_177");
@@ -155,6 +157,45 @@ public class Card_6_046_Tests {
 		scn.PassAllResponses();
 		return taken;
 	}
+
+	/**
+	 * Put LS spy Momaw undercover via LS Undercover (2_40). Spy crosses to DS side but remains LS-owned,
+	 * so Yarkora's opponents(self) filter must not offer break-cover.
+	 */
+	private void MakeMomawUndercoverAt(VirtualTableScenario scn, PhysicalCardImpl site) {
+		var momaw = scn.GetLSCard("momaw");
+		var undercover = scn.GetLSCard("ls_undercover");
+
+		scn.MoveCardsToLocation(site, momaw);
+		scn.MoveCardsToLSHand(undercover);
+
+		scn.SkipToLSTurn(Phase.DEPLOY);
+		boolean deployed = false;
+		try {
+			if (scn.LSDeployAvailable(undercover)) {
+				scn.LSDeployCard(undercover);
+				if (scn.LSHasCardChoiceAvailable(momaw)) {
+					scn.LSChooseCard(momaw);
+				}
+				scn.PassCardPlayResponses();
+				SafePassOptionalResponses(scn);
+				scn.PassAllResponses();
+				deployed = momaw.isUndercover();
+			}
+		} catch (RuntimeException ex) {
+			deployed = false;
+		}
+
+		if (!deployed) {
+			scn.AttachCardsTo(momaw, undercover);
+			var action = new TopLevelGameTextAction(undercover, undercover.getOwner(), undercover.getCardId());
+			scn.LSExecuteAdHocEffect(undercover, new PutUndercoverEffect(action, momaw));
+			SafePassOptionalResponses(scn);
+			scn.PassAllResponses();
+		}
+		assertTrue("Momaw should be undercover with LS Undercover (2_40)", momaw.isUndercover());
+	}
+
 	@Test
 	public void YarkoraStatsAndKeywordsAreCorrect() {
 		var scn = GetScenario();
@@ -197,16 +238,17 @@ public class Card_6_046_Tests {
 	@Test
 	public void YarkoraCannotTargetOwnUndercoverSpy() {
 		var scn = GetScenario();
-		// Own undercover would be LS Undercover 2_040; use DS spy path only for opponent targeting.
-		// This test verifies opponent filter: action requires opponents(self) undercover spy.
 		var yarkora = scn.GetLSCard("yarkora");
+		var momaw = scn.GetLSCard("momaw");
 		var site = scn.GetLSStartingLocation();
 
 		scn.StartGame();
 		scn.MoveCardsToLocation(site, yarkora);
+		MakeMomawUndercoverAt(scn, site);
+		assertTrue(momaw.isUndercover());
 
 		scn.SkipToLSTurn(Phase.CONTROL);
-		assertFalse("Without opponent undercover spy, action unavailable",
+		assertFalse("Yarkora must not break cover of own (LS-owned) undercover spy",
 				scn.LSCardActionAvailable(yarkora, "Break a spy's cover"));
 	}
 

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set6/light/Card_6_046_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set6/light/Card_6_046_Tests.java
@@ -1,0 +1,305 @@
+package com.gempukku.swccgo.cards.set6.light;
+
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Species;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.game.PhysicalCardImpl;
+import com.gempukku.swccgo.logic.actions.TopLevelGameTextAction;
+import com.gempukku.swccgo.logic.effects.PutUndercoverEffect;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * VHD tests for 6_46 Yarkora.
+ * Doc: control-phase vs Undercover spy; cumulative -1 destiny per Yarkora; cover broken if destiny = ability.
+ * Prefer real Undercover (2_129) when deploy path works; PutUndercoverEffect used only to finish cover after attach.
+ */
+public class Card_6_046_Tests {
+
+	protected VirtualTableScenario GetScenario() {
+		return new VirtualTableScenario(
+				new HashMap<>() {{
+					put("yarkora", "6_46");
+					put("yarkora2", "6_46");
+					put("saelt", "6_37");
+				}},
+				new HashMap<>() {{
+					put("garindan", "1_177");
+					put("undercover", "2_129");
+				}},
+				20,
+				20,
+				StartingSetup.DefaultLSGroundLocation,
+				StartingSetup.DefaultDSGroundLocation,
+				StartingSetup.NoLSStartingInterrupts,
+				StartingSetup.NoDSStartingInterrupts,
+				StartingSetup.NoLSShields,
+				StartingSetup.NoDSShields,
+				VirtualTableScenario.Open
+		);
+	}
+
+	private void SafePassOptionalResponses(VirtualTableScenario scn) {
+		for (int i = 0; i < 30; i++) {
+			var decision = scn.GetCurrentDecision();
+			if (decision == null) {
+				return;
+			}
+			String text = decision.getText();
+			if (text == null) {
+				return;
+			}
+			String lower = text.toLowerCase();
+			if (lower.contains("optional")) {
+				scn.PassResponses("optional");
+			} else if (lower.contains("required")) {
+				scn.PassResponses("required");
+			} else {
+				return;
+			}
+		}
+	}
+
+	/**
+	 * Deploy real Undercover on Garindan when possible; otherwise attach and finish with PutUndercoverEffect
+	 * after Undercover card is on the spy (still uses 2_129 on table).
+	 */
+	private void MakeGarindanUndercoverAt(VirtualTableScenario scn, PhysicalCardImpl site) {
+		var garindan = scn.GetDSCard("garindan");
+		var undercover = scn.GetDSCard("undercover");
+
+		scn.MoveCardsToLocation(site, garindan);
+		scn.MoveCardsToDSHand(undercover);
+
+		scn.SkipToDSTurn(Phase.DEPLOY);
+		boolean deployed = false;
+		try {
+			if (scn.DSDeployAvailable(undercover)) {
+				scn.DSDeployCard(undercover);
+				if (scn.DSHasCardChoiceAvailable(garindan)) {
+					scn.DSChooseCard(garindan);
+				}
+				scn.PassCardPlayResponses();
+				SafePassOptionalResponses(scn);
+				scn.PassAllResponses();
+				deployed = garindan.isUndercover();
+			}
+		} catch (RuntimeException | NullPointerException | IndexOutOfBoundsException ex) {
+			deployed = false;
+		}
+
+		if (!deployed) {
+			// Keep real Undercover (2_129) attached; finish cover via PutUndercoverEffect with a real Action.
+			scn.AttachCardsTo(garindan, undercover);
+			var action = new TopLevelGameTextAction(undercover, undercover.getOwner(), undercover.getCardId());
+			scn.DSExecuteAdHocEffect(undercover, new PutUndercoverEffect(action, garindan));
+			SafePassOptionalResponses(scn);
+			scn.PassAllResponses();
+		}
+		assertTrue("Garindan should be undercover with Undercover (2_129) involved", garindan.isUndercover());
+	}
+
+	@Test
+	public void YarkoraStatsAndKeywordsAreCorrect() {
+		var scn = GetScenario();
+		var card = scn.GetLSCard("yarkora").getBlueprint();
+		assertEquals("Yarkora", card.getTitle());
+		assertEquals(Uniqueness.UNRESTRICTED, card.getUniqueness());
+		assertEquals(Side.LIGHT, card.getSide());
+		assertEquals(3, card.getDestiny(), scn.epsilon);
+		assertEquals(2, card.getDeployCost(), scn.epsilon);
+		assertEquals(1, card.getPower(), scn.epsilon);
+		assertEquals(1, card.getAbility(), scn.epsilon);
+		assertEquals(2, card.getForfeit(), scn.epsilon);
+		assertEquals(Species.YARKORA, card.getSpecies());
+		scn.BlueprintCardTypeCheck(card, new ArrayList<>() {{
+			add(CardType.ALIEN);
+		}});
+		scn.BlueprintIconCheck(card, new ArrayList<>() {{
+			add(Icon.ALIEN);
+			add(Icon.JABBAS_PALACE);
+		}});
+		assertEquals(ExpansionSet.JABBAS_PALACE, card.getExpansionSet());
+		assertEquals(Rarity.C, card.getRarity());
+	}
+
+	@Test
+	public void YarkoraCannotTargetOutsideControlPhase() {
+		var scn = GetScenario();
+		var yarkora = scn.GetLSCard("yarkora");
+		var site = scn.GetLSStartingLocation();
+
+		scn.StartGame();
+		scn.MoveCardsToLocation(site, yarkora);
+		MakeGarindanUndercoverAt(scn, site);
+
+		scn.SkipToLSTurn(Phase.DEPLOY);
+		assertFalse("Yarkora cover-break not available outside control phase",
+				scn.LSCardActionAvailable(yarkora, "Break a spy's cover"));
+	}
+
+	@Test
+	public void YarkoraCannotTargetOwnUndercoverSpy() {
+		var scn = GetScenario();
+		// Own undercover would be LS Undercover 2_040; use DS spy path only for opponent targeting.
+		// This test verifies opponent filter: action requires opponents(self) undercover spy.
+		var yarkora = scn.GetLSCard("yarkora");
+		var site = scn.GetLSStartingLocation();
+
+		scn.StartGame();
+		scn.MoveCardsToLocation(site, yarkora);
+
+		scn.SkipToLSTurn(Phase.CONTROL);
+		assertFalse("Without opponent undercover spy, action unavailable",
+				scn.LSCardActionAvailable(yarkora, "Break a spy's cover"));
+	}
+
+	@Test
+	public void YarkoraBreaksCoverWhenDestinyEqualsAbility() {
+		var scn = GetScenario();
+		var yarkora = scn.GetLSCard("yarkora");
+		var garindan = scn.GetDSCard("garindan");
+		var site = scn.GetLSStartingLocation();
+
+		scn.StartGame();
+		scn.MoveCardsToLocation(site, yarkora);
+		MakeGarindanUndercoverAt(scn, site);
+
+		scn.SkipToLSTurn(Phase.CONTROL);
+		assertTrue(scn.LSCardActionAvailable(yarkora, "Break a spy's cover"));
+
+		scn.PrepareLSDestiny(1); // Garindan ability 1
+		scn.LSUseCardAction(yarkora, "Break a spy's cover");
+		scn.LSChooseCard(garindan);
+		scn.PassDestinyDrawResponses();
+		SafePassOptionalResponses(scn);
+		scn.PassAllResponses();
+
+		assertFalse("Cover should be broken when destiny equals ability", garindan.isUndercover());
+	}
+
+	@Test
+	public void YarkoraDoesNotBreakCoverWhenDestinyNotEqual() {
+		var scn = GetScenario();
+		var yarkora = scn.GetLSCard("yarkora");
+		var garindan = scn.GetDSCard("garindan");
+		var site = scn.GetLSStartingLocation();
+
+		scn.StartGame();
+		scn.MoveCardsToLocation(site, yarkora);
+		MakeGarindanUndercoverAt(scn, site);
+
+		scn.SkipToLSTurn(Phase.CONTROL);
+		scn.PrepareLSDestiny(3);
+		scn.LSUseCardAction(yarkora, "Break a spy's cover");
+		scn.LSChooseCard(garindan);
+		scn.PassDestinyDrawResponses();
+		SafePassOptionalResponses(scn);
+		scn.PassAllResponses();
+
+		assertTrue("Cover remains when destiny != ability", garindan.isUndercover());
+	}
+
+	@Test
+	public void YarkoraCumulativeSubtractAllowsBreakCover() {
+		var scn = GetScenario();
+		var yarkora = scn.GetLSCard("yarkora");
+		var yarkora2 = scn.GetLSCard("yarkora2");
+		var garindan = scn.GetDSCard("garindan");
+		var site = scn.GetLSStartingLocation();
+
+		scn.StartGame();
+		scn.MoveCardsToLocation(site, yarkora, yarkora2);
+		MakeGarindanUndercoverAt(scn, site);
+
+		scn.SkipToLSTurn(Phase.CONTROL);
+		scn.PrepareLSDestiny(3); // 3 -1 -1 = 1 == ability
+		scn.LSUseCardAction(yarkora, "Break a spy's cover");
+		scn.LSChooseCard(garindan);
+
+		// Destiny drawn; take both subtract optionals
+		for (int i = 0; i < 10; i++) {
+			var decision = scn.GetCurrentDecision();
+			if (decision == null) {
+				break;
+			}
+			String text = decision.getText() != null ? decision.getText() : "";
+			if (text.toLowerCase().contains("subtract 1")) {
+				scn.LSChooseAction("Subtract 1");
+			} else if (text.toLowerCase().contains("optional")) {
+				// Prefer subtract if listed in actions; otherwise pass after both used
+				try {
+					scn.LSChooseAction("Subtract 1");
+				} catch (AssertionError | RuntimeException ex) {
+					scn.PassResponses("optional");
+				}
+			} else {
+				break;
+			}
+		}
+		SafePassOptionalResponses(scn);
+		scn.PassAllResponses();
+
+		assertFalse("Two Yarkoras -1 each should make destiny 3 become 1 and break cover",
+				garindan.isUndercover());
+	}
+
+	@Test
+	public void YarkoraSaeltAlsoMaySubtract() {
+		var scn = GetScenario();
+		var yarkora = scn.GetLSCard("yarkora");
+		var saelt = scn.GetLSCard("saelt");
+		var garindan = scn.GetDSCard("garindan");
+		var site = scn.GetLSStartingLocation();
+
+		scn.StartGame();
+		scn.MoveCardsToLocation(site, yarkora, saelt);
+		MakeGarindanUndercoverAt(scn, site);
+
+		scn.SkipToLSTurn(Phase.CONTROL);
+		scn.PrepareLSDestiny(2); // 2 -1 (Saelt or Yarkora) = 1
+		scn.LSUseCardAction(yarkora, "Break a spy's cover");
+		scn.LSChooseCard(garindan);
+
+		boolean subtracted = false;
+		for (int i = 0; i < 10; i++) {
+			var decision = scn.GetCurrentDecision();
+			if (decision == null) {
+				break;
+			}
+			String text = decision.getText() != null ? decision.getText() : "";
+			if (text.toLowerCase().contains("subtract 1")) {
+				scn.LSChooseAction("Subtract 1");
+				subtracted = true;
+				break;
+			} else if (text.toLowerCase().contains("optional")) {
+				try {
+					scn.LSChooseAction("Subtract 1");
+					subtracted = true;
+					break;
+				} catch (AssertionError | RuntimeException ex) {
+					scn.PassResponses("optional");
+				}
+			} else {
+				break;
+			}
+		}
+		assertTrue("At least one Yarkora species character should offer subtract", subtracted);
+		SafePassOptionalResponses(scn);
+		scn.PassAllResponses();
+		assertFalse(garindan.isUndercover());
+	}
+}


### PR DESCRIPTION
## Summary
Implements **Yarkora (6_46)**, Jabba's Palace Light Alien. Closes #134.

## Game text
If at same site as an Undercover spy during your control phase, may draw destiny. Each of your Yarkoras on table may cumulatively subtract one from that destiny. Spy's "cover is broken" if destiny = spy's ability.

## What changed
- New alien `Card6_046` (species Yarkora, unrestricted).
- Control-phase top-level action mirrors Lt. Pol Treidum (`Card2_095`), targeting **opponent's** undercover spy at same site (`SpotOverride.INCLUDE_UNDERCOVER`).
- Destiny draw registers an until-end-of-draw **ActionProxy** so each **active owned Yarkora** (species filter — includes Saelt-Marae; works if gametext canceled) may optionally subtract 1 once (`ModifyDestinyEffect(..., true)` for unrestricted title stacking).
- Cover broken via existing `BreakCoverEffect` when final destiny equals spy ability.
- No shared Undercover / control-phase engine changes.

### Shared engine
None (card-local ActionProxy on the destiny draw only).

## Tests (`Card_6_046_Tests`)
1. Stats / species / icons
2. Not available outside control phase
3. Requires opponent undercover spy
4. Destiny = ability breaks cover (real Undercover `2_129` preferred)
5. Destiny ≠ ability leaves cover
6. Two Yarkoras cumulative −1
7. Saelt-Marae may subtract (species)

## Known gaps
Alien Rabble/Mob becoming Yarkora not explicitly covered; intermediate Fives-style between-subtract responses rely on existing optional-after re-query (not separately asserted).