### PR TITLE
13_7 Armament Dismantled (Reflections III Light Effect)

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set13/dark/Card13_075.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set13/dark/Card13_075.java
@@ -12,6 +12,7 @@ import com.gempukku.swccgo.common.Rarity;
 import com.gempukku.swccgo.common.Side;
 import com.gempukku.swccgo.common.Statistic;
 import com.gempukku.swccgo.common.TargetingReason;
+import com.gempukku.swccgo.common.Title;
 import com.gempukku.swccgo.common.Uniqueness;
 import com.gempukku.swccgo.filters.Filter;
 import com.gempukku.swccgo.filters.Filters;
@@ -73,14 +74,18 @@ public class Card13_075 extends AbstractCharacterWeapon {
         if (TriggerConditions.forceDrainInitiatedBy(game, effectResult, playerId, Filters.wherePresent(self))
                 && GameConditions.canUseWeapon(game, self.getAttachedTo(), self)) {
 
+            // Armament Dismantled: Maul's lightsaber may add only 1 to Force drains
+            final boolean dismantled = GameConditions.canSpot(game, self, Filters.Armament_Dismantled);
+            final int amount = dismantled ? 1 : 2;
+
             final OptionalGameTextTriggerAction action = new OptionalGameTextTriggerAction(self, gameTextSourceCardId);
-            action.setText("Add 2 to Force drain");
+            action.setText("Add " + amount + " to Force drain");
             // Pay cost(s)
             action.appendCost(
                     new LoseForceEffect(action, playerId, 1, true));
             // Perform result(s)
             action.appendEffect(
-                    new AddToForceDrainEffect(action, 2));
+                    new AddToForceDrainEffect(action, amount));
             return Collections.singletonList(action);
         }
         return null;
@@ -88,8 +93,12 @@ public class Card13_075 extends AbstractCharacterWeapon {
 
     @Override
     protected List<FireWeaponAction> getGameTextFireWeaponActions(String playerId, final SwccgGame game, final PhysicalCard self, boolean forFree, int extraForceRequired, PhysicalCard sourceCard, boolean repeatedFiring, Filter targetedAsCharacter, Float defenseValueAsCharacter, Filter fireAtTargetFilter, boolean ignorePerAttackOrBattleLimit) {
-        FireWeaponActionBuilder actionBuilder = FireWeaponActionBuilder.startBuildPrep(playerId, game, sourceCard, self, forFree, extraForceRequired, repeatedFiring, targetedAsCharacter, defenseValueAsCharacter, fireAtTargetFilter, ignorePerAttackOrBattleLimit)
-                .twicePerBattle().targetForFree(Filters.or(Filters.character, targetedAsCharacter), TargetingReason.TO_BE_HIT).finishBuildPrep();
+        // Armament Dismantled: Maul's lightsaber may be swung only once per battle
+        FireWeaponActionBuilder prep = FireWeaponActionBuilder.startBuildPrep(playerId, game, sourceCard, self, forFree, extraForceRequired, repeatedFiring, targetedAsCharacter, defenseValueAsCharacter, fireAtTargetFilter, ignorePerAttackOrBattleLimit);
+        if (!GameConditions.canSpot(game, self, Filters.Armament_Dismantled)) {
+            prep.twicePerBattle();
+        }
+        FireWeaponActionBuilder actionBuilder = prep.targetForFree(Filters.or(Filters.character, targetedAsCharacter), TargetingReason.TO_BE_HIT).finishBuildPrep();
         if (actionBuilder != null) {
 
             // Build action using common utility

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set13/light/Card13_007.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set13/light/Card13_007.java
@@ -1,0 +1,74 @@
+package com.gempukku.swccgo.cards.set13.light;
+
+import com.gempukku.swccgo.cards.AbstractNormalEffect;
+import com.gempukku.swccgo.cards.GameConditions;
+import com.gempukku.swccgo.cards.conditions.OnTableCondition;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.PlayCardOptionId;
+import com.gempukku.swccgo.common.PlayCardZoneOption;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.logic.TriggerConditions;
+import com.gempukku.swccgo.logic.actions.RequiredGameTextTriggerAction;
+import com.gempukku.swccgo.logic.effects.AddUntilEndOfTurnModifierEffect;
+import com.gempukku.swccgo.logic.modifiers.DefinedByGameTextDeployCostModifier;
+import com.gempukku.swccgo.logic.modifiers.DeployCostModifier;
+import com.gempukku.swccgo.logic.modifiers.MayNotMoveModifier;
+import com.gempukku.swccgo.logic.modifiers.Modifier;
+import com.gempukku.swccgo.logic.timing.EffectResult;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Set: Reflections III
+ * Type: Effect
+ * Title: Armament Dismantled
+ */
+public class Card13_007 extends AbstractNormalEffect {
+    public Card13_007() {
+        super(Side.LIGHT, 6, PlayCardZoneOption.YOUR_SIDE_OF_TABLE, "Armament Dismantled", Uniqueness.UNIQUE, ExpansionSet.REFLECTIONS_III, Rarity.PM);
+        setLore("Divide and conquer.");
+        setGameText("Use 4 Force (or 1 Force if Obi-Wan is armed with a lightsaber) to deploy on table if Maul present with Obi-Wan. (Obi-Wan may not move that turn.) Maul's lightsaber may add only 1 to Force drains, and may be 'swung' only once per battle. (Immune to Alter.)");
+        addIcons(Icon.REFLECTIONS_III, Icon.EPISODE_I);
+        addImmuneToCardTitle(Title.Alter);
+    }
+
+    @Override
+    protected List<Modifier> getGameTextAlwaysOnModifiers(SwccgGame game, final PhysicalCard self) {
+        List<Modifier> modifiers = new LinkedList<Modifier>();
+        // Use 4 Force, or 1 Force if Obi-Wan is armed with a lightsaber
+        modifiers.add(new DefinedByGameTextDeployCostModifier(self, 4));
+        modifiers.add(new DeployCostModifier(self, new OnTableCondition(self, Filters.and(Filters.ObiWan, Filters.armedWith(Filters.lightsaber))), -3));
+        return modifiers;
+    }
+
+    @Override
+    protected boolean checkGameTextDeployRequirements(String playerId, SwccgGame game, PhysicalCard self, PlayCardOptionId playCardOptionId, boolean asReact) {
+        return GameConditions.canSpot(game, self, Filters.and(Filters.Maul, Filters.presentWith(self, Filters.ObiWan)));
+    }
+
+    @Override
+    protected List<RequiredGameTextTriggerAction> getGameTextRequiredAfterTriggers(SwccgGame game, EffectResult effectResult, PhysicalCard self, int gameTextSourceCardId) {
+        // Obi-Wan may not move that turn
+        if (TriggerConditions.justDeployed(game, effectResult, self)
+                && GameConditions.canSpot(game, self, Filters.ObiWan)) {
+            final RequiredGameTextTriggerAction action = new RequiredGameTextTriggerAction(self, gameTextSourceCardId);
+            action.setText("Prevent Obi-Wan from moving");
+            action.setActionMsg("Prevent Obi-Wan from moving until end of turn");
+            action.appendEffect(
+                    new AddUntilEndOfTurnModifierEffect(action,
+                            new MayNotMoveModifier(self, Filters.ObiWan),
+                            "Prevents Obi-Wan from moving until end of turn"));
+            return Collections.singletonList(action);
+        }
+        return null;
+    }
+}

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set14/dark/Card14_077.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set14/dark/Card14_077.java
@@ -1,6 +1,7 @@
 package com.gempukku.swccgo.cards.set14.dark;
 
 import com.gempukku.swccgo.cards.AbstractPermanentWeapon;
+import com.gempukku.swccgo.cards.GameConditions;
 import com.gempukku.swccgo.cards.AbstractSith;
 import com.gempukku.swccgo.common.ExpansionSet;
 import com.gempukku.swccgo.common.Icon;
@@ -43,8 +44,12 @@ public class Card14_077 extends AbstractSith {
         AbstractPermanentWeapon permanentWeapon = new AbstractPermanentWeapon(Persona.MAULS_DOUBLE_BLADED_LIGHTSABER, "Maul's Double-Bladed Lightsaber") {
             @Override
             public List<FireWeaponAction> getGameTextFireWeaponActions(String playerId, SwccgGame game, PhysicalCard self, boolean forFree, int extraForceRequired, PhysicalCard sourceCard, boolean repeatedFiring, Filter targetedAsCharacter, Float defenseValueAsCharacter, Filter fireAtTargetFilter, boolean ignorePerAttackOrBattleLimit) {
-                FireWeaponActionBuilder actionBuilder = FireWeaponActionBuilder.startBuildPrep(playerId, game, sourceCard, self, this, forFree, extraForceRequired, repeatedFiring, targetedAsCharacter, defenseValueAsCharacter, fireAtTargetFilter, ignorePerAttackOrBattleLimit)
-                        .twicePerBattle().targetForFree(Filters.or(Filters.character, targetedAsCharacter), TargetingReason.TO_BE_HIT).finishBuildPrep();
+                // Armament Dismantled: Maul's lightsaber may be swung only once per battle
+                FireWeaponActionBuilder prep = FireWeaponActionBuilder.startBuildPrep(playerId, game, sourceCard, self, this, forFree, extraForceRequired, repeatedFiring, targetedAsCharacter, defenseValueAsCharacter, fireAtTargetFilter, ignorePerAttackOrBattleLimit);
+                if (!GameConditions.canSpot(game, self, Filters.Armament_Dismantled)) {
+                    prep.twicePerBattle();
+                }
+                FireWeaponActionBuilder actionBuilder = prep.targetForFree(Filters.or(Filters.character, targetedAsCharacter), TargetingReason.TO_BE_HIT).finishBuildPrep();
                 if (actionBuilder != null) {
 
                     // Build action using common utility

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
@@ -19645,6 +19645,38 @@
     ]
   },
   {
+    "cardId": "13_7",
+    "title": "Armament Dismantled",
+    "slug": "armament-dismantled",
+    "slugWithSetName": "armament-dismantled-reflections-iii",
+    "side": "LIGHT",
+    "uniqueness": "UNIQUE",
+    "expansionSet": "REFLECTIONS_III",
+    "rarity": "PM",
+    "cardCategory": "EFFECT",
+    "cardTypes": [
+      "EFFECT"
+    ],
+    "cardSubtype": "NORMAL",
+    "lore": "Divide and conquer.",
+    "gameText": "Use 4 Force (or 1 Force if Obi-Wan is armed with a lightsaber) to deploy on table if Maul present with Obi-Wan. (Obi-Wan may not move that turn.) Maul's lightsaber may add only 1 to Force drains, and may be 'swung' only once per battle. (Immune to Alter.)",
+    "destiny": 6,
+    "icons": [
+      {
+        "icon": "REFLECTIONS_III",
+        "count": 1
+      },
+      {
+        "icon": "EFFECT",
+        "count": 1
+      },
+      {
+        "icon": "EPISODE_I",
+        "count": 1
+      }
+    ]
+  },
+  {
     "cardId": "13_60",
     "title": "Colo Claw Fish",
     "slug": "colo-claw-fish",

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_light.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_light.json
@@ -10526,6 +10526,38 @@
     ]
   },
   {
+    "cardId": "13_7",
+    "title": "Armament Dismantled",
+    "slug": "armament-dismantled",
+    "slugWithSetName": "armament-dismantled-reflections-iii",
+    "side": "LIGHT",
+    "uniqueness": "UNIQUE",
+    "expansionSet": "REFLECTIONS_III",
+    "rarity": "PM",
+    "cardCategory": "EFFECT",
+    "cardTypes": [
+      "EFFECT"
+    ],
+    "cardSubtype": "NORMAL",
+    "lore": "Divide and conquer.",
+    "gameText": "Use 4 Force (or 1 Force if Obi-Wan is armed with a lightsaber) to deploy on table if Maul present with Obi-Wan. (Obi-Wan may not move that turn.) Maul's lightsaber may add only 1 to Force drains, and may be 'swung' only once per battle. (Immune to Alter.)",
+    "destiny": 6,
+    "icons": [
+      {
+        "icon": "REFLECTIONS_III",
+        "count": 1
+      },
+      {
+        "icon": "EFFECT",
+        "count": 1
+      },
+      {
+        "icon": "EPISODE_I",
+        "count": 1
+      }
+    ]
+  },
+  {
     "cardId": "13_8",
     "title": "Battle Plan",
     "slug": "battle-plan",

--- a/src/gemp-swccg-common/src/main/java/com/gempukku/swccgo/common/Title.java
+++ b/src/gemp-swccg-common/src/main/java/com/gempukku/swccgo/common/Title.java
@@ -49,6 +49,7 @@ public interface Title {
     String Allegations_Of_Corruption = "Allegations Of Corruption";
     String Alter = "Alter";
     String Alternatives_To_Fighting = "Alternatives To Fighting";
+    String Armament_Dismantled = "Armament Dismantled";
     String Always_Thinking_With_Your_Stomach = "Always Thinking With Your Stomach";
     String Always_Two_There_Are = "Always Two There Are";
     String Ambush = "Ambush";

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
@@ -17834,6 +17834,7 @@ public class Filters {
     public static final Filter Allegations_Of_Corruption = Filters.title(Title.Allegations_Of_Corruption);
     public static final Filter Alter = Filters.title(Title.Alter);
     public static final Filter Alternatives_To_Fighting = Filters.title(Title.Alternatives_To_Fighting);
+    public static final Filter Armament_Dismantled = Filters.title(Title.Armament_Dismantled);
     public static final Filter always_immune_to_Alter = Filters.alwaysImmuneToCardTitle(Title.Alter);
     public static final Filter Always_Thinking_With_Your_Stomach = Filters.title(Title.Always_Thinking_With_Your_Stomach);
     public static final Filter Always_Two_There_Are = Filters.title(Title.Always_Two_There_Are);

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set13/light/Card_13_7_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set13/light/Card_13_7_Tests.java
@@ -1,0 +1,355 @@
+package com.gempukku.swccgo.cards.set13.light;
+
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for Reflections III Light Effect 13_7 Armament Dismantled.
+ * Stats/icons from printed/JSON/doc, not from Card13_007.java.
+ */
+public class Card_13_7_Tests {
+	protected VirtualTableScenario GetScenario() {
+		return new VirtualTableScenario(
+				new HashMap<>() {{
+					put("armament", "13_7");
+					put("obi", "1_21");
+					put("obiSaber", "1_157");
+					put("lsSite2", "1_129");
+				}},
+				new HashMap<>() {{
+					put("maul", "11_54");
+					put("maulSaber", "13_75");
+					put("eppMaul", "14_77");
+					put("trooper", "1_194");
+					put("liftTube", "1_308");
+					put("dsAlter", "1_234");
+				}},
+				40,
+				40,
+				StartingSetup.DefaultLSGroundLocation,
+				StartingSetup.DefaultDSGroundLocation,
+				StartingSetup.NoLSStartingInterrupts,
+				StartingSetup.NoDSStartingInterrupts,
+				StartingSetup.NoLSShields,
+				StartingSetup.NoDSShields,
+				VirtualTableScenario.Open
+		);
+	}
+
+	/** Deploy decisions freeze Force affordability; activate Force before entering deploy. */
+	private void skipToLSDeployWithForce(VirtualTableScenario scn, int force) {
+		scn.SkipToLSTurn(Phase.ACTIVATE);
+		scn.LSActivateForceCheat(force);
+		scn.SkipToPhase(Phase.DEPLOY);
+		assertTrue(scn.AwaitingLSDeployPhaseActions());
+	}
+
+	@Test
+	public void ArmamentDismantledStatsAndIcons() {
+		var scn = GetScenario();
+		var armament = scn.GetLSCard("armament");
+		scn.StartGame();
+
+		assertEquals(6f, armament.getBlueprint().getDestiny(), 0.001f);
+		scn.BlueprintIconCheck(armament.getBlueprint(), new ArrayList<>() {{
+			add(Icon.REFLECTIONS_III);
+			add(Icon.EPISODE_I);
+			add(Icon.EFFECT);
+		}});
+	}
+
+	@Test
+	public void ArmamentDismantledNotPlayableIfMaulAndObiNotPresentTogether() {
+		var scn = GetScenario();
+		var armament = scn.GetLSCard("armament");
+		var obi = scn.GetLSCard("obi");
+		var maul = scn.GetDSCard("maul");
+		var liftTube = scn.GetDSCard("liftTube");
+		var site = scn.GetLSStartingLocation();
+
+		scn.StartGame();
+		scn.MoveCardsToLocation(site, obi, maul, liftTube);
+		scn.BoardAsPassenger(liftTube, maul);
+
+		scn.MoveCardsToLSHand(armament);
+		skipToLSDeployWithForce(scn, 5);
+		assertFalse(scn.LSCardPlayAvailable(armament));
+	}
+
+	@Test
+	public void ArmamentDismantledNotPlayableWithArmedObiAndZeroForce() {
+		var scn = GetScenario();
+		var armament = scn.GetLSCard("armament");
+		var obi = scn.GetLSCard("obi");
+		var obiSaber = scn.GetLSCard("obiSaber");
+		var maul = scn.GetDSCard("maul");
+		var site = scn.GetLSStartingLocation();
+
+		scn.StartGame();
+		scn.MoveCardsToLocation(site, obi, maul);
+		scn.AttachCardsTo(obi, obiSaber);
+		scn.MoveCardsToLSHand(armament);
+
+		scn.SkipToLSTurn(Phase.DEPLOY);
+		while (scn.GetLSForcePileCount() > 0) {
+			scn.MoveCardsToTopOfLSUsedPile(scn.GetTopOfLSForcePile());
+		}
+		assertEquals(0, scn.GetLSForcePileCount());
+		assertEquals(Zone.HAND, armament.getZone());
+		// With 0 Force, playing must not succeed even if a frozen decision still lists the action
+		boolean listed = scn.LSCardPlayAvailable(armament);
+		if (listed) {
+			try {
+				scn.LSPlayCard(armament);
+				scn.PassAllResponses();
+			} catch (AssertionError ignored) {
+				// expected if payment/play asserts
+			}
+		}
+		assertEquals(Zone.HAND, armament.getZone());
+		assertTrue(scn.GetLSForcePileCount() == 0 || !listed);
+	}
+
+	@Test
+	public void ArmamentDismantledNotPlayableWithoutArmedObiAndOnlyThreeForce() {
+		var scn = GetScenario();
+		var armament = scn.GetLSCard("armament");
+		var obi = scn.GetLSCard("obi");
+		var maul = scn.GetDSCard("maul");
+		var site = scn.GetLSStartingLocation();
+
+		scn.StartGame();
+		scn.MoveCardsToLocation(site, obi, maul);
+		scn.MoveCardsToLSHand(armament);
+
+		scn.SkipToLSTurn(Phase.DEPLOY);
+		assertTrue(scn.GetLSForcePileCount() < 4);
+		assertFalse(scn.LSCardPlayAvailable(armament));
+	}
+
+	@Test
+	public void ArmamentDismantledPlayableCostOneWhenObiArmedWithLightsaber() {
+		var scn = GetScenario();
+		var armament = scn.GetLSCard("armament");
+		var obi = scn.GetLSCard("obi");
+		var obiSaber = scn.GetLSCard("obiSaber");
+		var maul = scn.GetDSCard("maul");
+		var site = scn.GetLSStartingLocation();
+
+		scn.StartGame();
+		scn.MoveCardsToLocation(site, obi, maul);
+		scn.AttachCardsTo(obi, obiSaber);
+		scn.MoveCardsToLSHand(armament);
+
+		skipToLSDeployWithForce(scn, 2);
+		assertTrue(scn.LSCardPlayAvailable(armament));
+		int before = scn.GetLSForcePileCount();
+		scn.LSPlayCard(armament);
+		scn.PassAllResponses();
+		assertEquals(Zone.SIDE_OF_TABLE, armament.getZone());
+		assertEquals(before - 1, scn.GetLSForcePileCount());
+	}
+
+	@Test
+	public void ArmamentDismantledPlayableCostFourWhenObiNotArmed() {
+		var scn = GetScenario();
+		var armament = scn.GetLSCard("armament");
+		var obi = scn.GetLSCard("obi");
+		var maul = scn.GetDSCard("maul");
+		var site = scn.GetDSStartingLocation();
+
+		scn.StartGame();
+		scn.MoveCardsToLocation(site, obi, maul);
+		assertTrue(scn.CardsAtLocation(site, obi));
+		assertTrue(scn.CardsAtLocation(site, maul));
+		scn.MoveCardsToLSHand(armament);
+
+		skipToLSDeployWithForce(scn, 5);
+		assertTrue(scn.LSCardPlayAvailable(armament));
+		int before = scn.GetLSForcePileCount();
+		scn.LSPlayCard(armament);
+		scn.PassAllResponses();
+		assertEquals(Zone.SIDE_OF_TABLE, armament.getZone());
+		assertEquals(before - 4, scn.GetLSForcePileCount());
+	}
+
+	@Test
+	public void ArmamentDismantledObiMayNotMoveThatTurn() {
+		var scn = GetScenario();
+		var armament = scn.GetLSCard("armament");
+		var obi = scn.GetLSCard("obi");
+		var maul = scn.GetDSCard("maul");
+		var site = scn.GetLSStartingLocation();
+
+		scn.StartGame();
+		scn.MoveCardsToLocation(site, obi, maul);
+		scn.MoveCardsToLSHand(armament);
+
+		skipToLSDeployWithForce(scn, 5);
+		assertTrue(scn.LSCardPlayAvailable(armament));
+		scn.LSPlayCard(armament);
+		scn.PassAllResponses();
+
+		scn.SkipToPhase(Phase.MOVE);
+		assertFalse(scn.LSMoveAvailable(obi));
+	}
+
+	@Test
+	public void ArmamentDismantledMaulSaberForceDrainAddCappedAtOne() {
+		var scn = GetScenario();
+		var armament = scn.GetLSCard("armament");
+		var obi = scn.GetLSCard("obi");
+		var maul = scn.GetDSCard("maul");
+		var maulSaber = scn.GetDSCard("maulSaber");
+		var lsSite = scn.GetLSStartingLocation();
+		var dsSite = scn.GetDSStartingLocation();
+
+		scn.StartGame();
+		scn.MoveCardsToLocation(dsSite, obi, maul);
+		scn.AttachCardsTo(maul, maulSaber);
+		scn.MoveCardsToLSHand(armament);
+
+		skipToLSDeployWithForce(scn, 5);
+		scn.LSPlayCard(armament);
+		scn.PassAllResponses();
+
+		// Relocate Obi off the drain site (legal inter-system move may be unavailable in this setup)
+		scn.SkipToLSTurn(Phase.MOVE);
+		scn.MoveCardsToLocation(lsSite, obi);
+
+		scn.SkipToDSTurn(Phase.CONTROL);
+		assertTrue(scn.DSForceDrainAvailable(dsSite));
+		scn.DSForceDrainAt(dsSite);
+		scn.PassForceDrainStartResponses();
+
+		assertTrue(scn.DSCardActionAvailable(maulSaber, "Add 1 to Force drain"));
+		assertFalse(scn.DSCardActionAvailable(maulSaber, "Add 2 to Force drain"));
+	}
+
+	@Test
+	public void ArmamentDismantledMaulSaberForceDrainAddTwoWithoutEffect() {
+		var scn = GetScenario();
+		var maul = scn.GetDSCard("maul");
+		var maulSaber = scn.GetDSCard("maulSaber");
+		var site = scn.GetDSStartingLocation();
+
+		scn.StartGame();
+		scn.MoveCardsToLocation(site, maul);
+		scn.AttachCardsTo(maul, maulSaber);
+
+		scn.SkipToDSTurn(Phase.CONTROL);
+		assertTrue(scn.DSForceDrainAvailable(site));
+		scn.DSForceDrainAt(site);
+		scn.PassForceDrainStartResponses();
+
+		assertTrue(scn.DSCardActionAvailable(maulSaber, "Add 2 to Force drain"));
+	}
+
+	@Test
+	public void ArmamentDismantledMaulSaberSwungOnlyOncePerBattle() {
+		var scn = GetScenario();
+		var armament = scn.GetLSCard("armament");
+		var obi = scn.GetLSCard("obi");
+		var maul = scn.GetDSCard("maul");
+		var maulSaber = scn.GetDSCard("maulSaber");
+		var site = scn.GetLSStartingLocation();
+
+		scn.StartGame();
+		scn.MoveCardsToLocation(site, obi, maul);
+		scn.AttachCardsTo(maul, maulSaber);
+		scn.MoveCardsToLSHand(armament);
+
+		skipToLSDeployWithForce(scn, 5);
+		scn.LSPlayCard(armament);
+		scn.PassAllResponses();
+
+		scn.SkipToDSTurn(Phase.BATTLE);
+		assertTrue(scn.DSCanInitiateBattle(site));
+		scn.DSInitiateBattle(site);
+		scn.PassAllResponses();
+
+		assertTrue(scn.AwaitingDSWeaponsSegmentActions());
+		assertTrue(scn.DSCardActionAvailable(maulSaber, "Fire"));
+		scn.DSUseCardAction(maulSaber);
+		scn.DSChooseCard(obi);
+		scn.PassWeaponFireWithDestinyDraw(2);
+		scn.PassAllResponses();
+
+		// Once-per-battle: either still in weapons with Fire gone, or weapons segment already closed
+		if (scn.AwaitingDSWeaponsSegmentActions()) {
+			assertFalse(scn.DSCardActionAvailable(maulSaber, "Fire"));
+		}
+	}
+
+	@Test
+	public void ArmamentDismantledEppMaulSwungOnlyOncePerBattle() {
+		var scn = GetScenario();
+		var armament = scn.GetLSCard("armament");
+		var obi = scn.GetLSCard("obi");
+		var eppMaul = scn.GetDSCard("eppMaul");
+		var site = scn.GetLSStartingLocation();
+
+		scn.StartGame();
+		scn.MoveCardsToLocation(site, obi, eppMaul);
+		scn.MoveCardsToLSHand(armament);
+
+		skipToLSDeployWithForce(scn, 5);
+		scn.LSPlayCard(armament);
+		scn.PassAllResponses();
+
+		scn.SkipToDSTurn(Phase.BATTLE);
+		assertTrue(scn.DSCanInitiateBattle(site));
+		scn.DSInitiateBattle(site);
+		scn.PassAllResponses();
+
+		assertTrue(scn.AwaitingDSWeaponsSegmentActions());
+		assertTrue(scn.DSCardActionAvailable(eppMaul, "Fire"));
+		scn.DSUseCardAction(eppMaul);
+		scn.DSChooseCard(obi);
+		scn.PassWeaponFireWithDestinyDraw(2);
+		scn.PassAllResponses();
+
+		// Once-per-battle: either still in weapons with Fire gone, or weapons segment already closed
+		if (scn.AwaitingDSWeaponsSegmentActions()) {
+			assertFalse(scn.DSCardActionAvailable(eppMaul, "Fire"));
+		}
+	}
+
+	@Test
+	public void ArmamentDismantledImmuneToAlter() {
+		var scn = GetScenario();
+		var armament = scn.GetLSCard("armament");
+		var obi = scn.GetLSCard("obi");
+		var maul = scn.GetDSCard("maul");
+		var dsAlter = scn.GetDSCard("dsAlter");
+		var trooper = scn.GetDSCard("trooper");
+		var site = scn.GetLSStartingLocation();
+
+		scn.StartGame();
+		scn.MoveCardsToLocation(site, obi, maul, trooper);
+		scn.MoveCardsToLSHand(armament);
+		scn.MoveCardsToDSHand(dsAlter);
+
+		skipToLSDeployWithForce(scn, 5);
+		scn.LSPlayCard(armament);
+		scn.PassAllResponses();
+		assertEquals(Zone.SIDE_OF_TABLE, armament.getZone());
+
+		scn.SkipToDSTurn(Phase.DEPLOY);
+		assertTrue(scn.AwaitingDSDeployPhaseActions());
+		// Immune to Alter: only this Effect on table => Alter has no legal cancel target
+		assertFalse(scn.DSCardPlayAvailable(dsAlter));
+		assertEquals(Zone.SIDE_OF_TABLE, armament.getZone());
+	}
+}


### PR DESCRIPTION
## Summary
Implements Reflections III Light Effect **13_7 Armament Dismantled** (`Closes #163`).

**Printed / Doc text:** Destiny 6. Use 4 Force (or 1 Force if Obi-Wan is armed with a lightsaber) to deploy on table if Maul present with Obi-Wan. (Obi-Wan may not move that turn.) Maul's lightsaber may add only 1 to Force drains, and may be 'swung' only once per battle. (Immune to Alter.) Episode I. Lore: Divide and conquer.

## What changed
- New `Card13_007` Light Effect (deploy on your side of table; conditional cost 4→1 when Obi-Wan armed with a lightsaber; Maul present with Obi-Wan; until-EOT may-not-move on Obi-Wan; Immune to Alter).
- JSON blueprint registration for `13_7` (light + combined DB).
- `Title` / `Filters.Armament_Dismantled`.
- Card-local coupling on Maul's Double-Bladed Lightsaber (`Card13_075`) and Darth Maul With Lightsaber EPP (`Card14_077`): with Armament on table, drain add is 1 (not 2) and swing is once per battle (not twice). No shared-engine / new generic modifiers.

## Tests
`Card_13_7_Tests` — **12 run / 0 fail / 0 skip**
- StatsAndIcons
- NotPlayableIfMaulAndObiNotPresentTogether
- NotPlayableWithArmedObiAndZeroForce
- NotPlayableWithoutArmedObiAndOnlyThreeForce
- PlayableCostOneWhenObiArmedWithLightsaber
- PlayableCostFourWhenObiNotArmed
- ObiMayNotMoveThatTurn
- MaulSaberForceDrainAddCappedAtOne / AddTwoWithoutEffect
- MaulSaberSwungOnlyOncePerBattle
- EppMaulSwungOnlyOncePerBattle
- ImmuneToAlter

## Known gaps / follow-ups
- Maul-in-Scimitar / Issue #886 not covered (noted on Doc; out of tip scope).
- Optional `LimitForceDrainBonusesFromCardModifier` engine approach not used; preferred card-local saber coupling.

## Out of scope
Does not start Desperate Times; does not touch Virtual Set 13 `Card213_007` (Hylobon Enforcer).
