### PR TITLE
13_70 Force Push - Reflections III Dark Lost Interrupt

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set13/dark/Card13_070.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set13/dark/Card13_070.java
@@ -1,0 +1,116 @@
+package com.gempukku.swccgo.cards.set13.dark;
+
+import com.gempukku.swccgo.cards.AbstractLostInterrupt;
+import com.gempukku.swccgo.cards.GameConditions;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.filters.Filter;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.actions.PlayInterruptAction;
+import com.gempukku.swccgo.logic.effects.LoseForceEffect;
+import com.gempukku.swccgo.logic.effects.PutStackedCardInReserveDeckEffect;
+import com.gempukku.swccgo.logic.effects.RefreshPrintedDestinyValuesEffect;
+import com.gempukku.swccgo.logic.effects.RespondablePlayCardEffect;
+import com.gempukku.swccgo.logic.effects.ShowCardOnScreenEffect;
+import com.gempukku.swccgo.logic.effects.TargetCardOnTableEffect;
+import com.gempukku.swccgo.logic.timing.Action;
+import com.gempukku.swccgo.logic.timing.GuiUtils;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Set: Reflections III
+ * Type: Interrupt
+ * Subtype: Lost
+ * Title: Force Push
+ */
+public class Card13_070 extends AbstractLostInterrupt {
+    public Card13_070() {
+        super(Side.DARK, 5, "Force Push", Uniqueness.UNIQUE, ExpansionSet.REFLECTIONS_III, Rarity.PM);
+        setLore("A fully-trained Sith warrior has more weapons at his disposal than just a lightsaber.");
+        setGameText("Target opponent's Jedi with at least one combat card present with your Dark Jedi. Reveal one of target's combat cards (random selection). If revealed card's destiny > 4, place it on top of opponent's Reserve Deck. Otherwise, lose 1 Force. (Immune to Sense.)");
+        addIcons(Icon.REFLECTIONS_III, Icon.EPISODE_I);
+    }
+
+    @Override
+    protected List<PlayInterruptAction> getGameTextTopLevelActions(final String playerId, final SwccgGame game, final PhysicalCard self) {
+        // Opponent's Jedi with >=1 combat card, present with your Dark Jedi
+        Filter jediFilter = Filters.and(
+                Filters.opponents(self),
+                Filters.Jedi,
+                Filters.hasStacked(Filters.combatCard),
+                Filters.presentWith(self, Filters.and(Filters.your(self), Filters.Dark_Jedi))
+        );
+
+        if (!GameConditions.canTarget(game, self, jediFilter)) {
+            return null;
+        }
+
+        final PlayInterruptAction action = new PlayInterruptAction(game, self);
+        action.setImmuneTo(Title.Sense);
+        action.setText("Reveal a combat card");
+        // Choose target(s)
+        action.appendTargeting(
+                new TargetCardOnTableEffect(action, playerId, "Choose Jedi", jediFilter) {
+                    @Override
+                    protected void cardTargeted(final int targetGroupId, PhysicalCard targetedCard) {
+                        action.addAnimationGroup(targetedCard);
+                        // Allow response(s)
+                        action.allowResponses("Reveal one of " + GameUtils.getCardLink(targetedCard) + "'s combat cards",
+                                new RespondablePlayCardEffect(action) {
+                                    @Override
+                                    protected void performActionResults(Action targetingAction) {
+                                        final PhysicalCard finalTarget = action.getPrimaryTargetCard(targetGroupId);
+                                        if (finalTarget == null) {
+                                            return;
+                                        }
+
+                                        Collection<PhysicalCard> stackedCombatCards = Filters.filter(
+                                                game.getGameState().getStackedCards(finalTarget), game, Filters.combatCard);
+                                        if (stackedCombatCards.isEmpty()) {
+                                            return;
+                                        }
+
+                                        final PhysicalCard revealedCombatCard = GameUtils.getRandomCards(stackedCombatCards, 1).iterator().next();
+
+                                        // Reveal to both players (card-local; no shared stacked-reveal hierarchy)
+                                        action.appendEffect(
+                                                new ShowCardOnScreenEffect(action, revealedCombatCard));
+                                        action.appendEffect(
+                                                new RefreshPrintedDestinyValuesEffect(action, revealedCombatCard) {
+                                                    @Override
+                                                    protected void refreshedPrintedDestinyValues() {
+                                                        float destiny = revealedCombatCard.getDestinyValueToUse();
+                                                        game.getGameState().sendMessage("Revealed " + GameUtils.getCardLink(revealedCombatCard)
+                                                                + " (destiny " + GuiUtils.formatAsString(destiny) + ")");
+
+                                                        if (destiny > 4) {
+                                                            game.getGameState().sendMessage("Result: Destiny > 4 - place combat card on Reserve Deck");
+                                                            action.appendEffect(
+                                                                    new PutStackedCardInReserveDeckEffect(action, playerId, revealedCombatCard, false));
+                                                        } else {
+                                                            game.getGameState().sendMessage("Result: Destiny <= 4 - lose 1 Force; combat card remains stacked");
+                                                            action.appendEffect(
+                                                                    new LoseForceEffect(action, playerId, 1));
+                                                        }
+                                                    }
+                                                }
+                                        );
+                                    }
+                                }
+                        );
+                    }
+                }
+        );
+        return Collections.singletonList(action);
+    }
+}

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
@@ -19952,6 +19952,38 @@
     ]
   },
   {
+    "cardId": "13_70",
+    "title": "Force Push",
+    "slug": "force-push",
+    "slugWithSetName": "force-push-reflections-iii",
+    "side": "DARK",
+    "uniqueness": "UNIQUE",
+    "expansionSet": "REFLECTIONS_III",
+    "rarity": "PM",
+    "cardCategory": "INTERRUPT",
+    "cardTypes": [
+      "INTERRUPT"
+    ],
+    "cardSubtype": "LOST",
+    "lore": "A fully-trained Sith warrior has more weapons at his disposal than just a lightsaber.",
+    "gameText": "Target opponent's Jedi with at least one combat card present with your Dark Jedi. Reveal one of target's combat cards (random selection). If revealed card's destiny > 4, place it on top of opponent's Reserve Deck. Otherwise, lose 1 Force. (Immune to Sense.)",
+    "destiny": 5,
+    "icons": [
+      {
+        "icon": "REFLECTIONS_III",
+        "count": 1
+      },
+      {
+        "icon": "INTERRUPT",
+        "count": 1
+      },
+      {
+        "icon": "EPISODE_I",
+        "count": 1
+      }
+    ]
+  },
+  {
     "cardId": "13_71",
     "title": "Jabba Desilijic Tiure",
     "slug": "jabba-desilijic-tiure",

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_dark.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_dark.json
@@ -9426,6 +9426,38 @@
     ]
   },
   {
+    "cardId": "13_70",
+    "title": "Force Push",
+    "slug": "force-push",
+    "slugWithSetName": "force-push-reflections-iii",
+    "side": "DARK",
+    "uniqueness": "UNIQUE",
+    "expansionSet": "REFLECTIONS_III",
+    "rarity": "PM",
+    "cardCategory": "INTERRUPT",
+    "cardTypes": [
+      "INTERRUPT"
+    ],
+    "cardSubtype": "LOST",
+    "lore": "A fully-trained Sith warrior has more weapons at his disposal than just a lightsaber.",
+    "gameText": "Target opponent's Jedi with at least one combat card present with your Dark Jedi. Reveal one of target's combat cards (random selection). If revealed card's destiny > 4, place it on top of opponent's Reserve Deck. Otherwise, lose 1 Force. (Immune to Sense.)",
+    "destiny": 5,
+    "icons": [
+      {
+        "icon": "REFLECTIONS_III",
+        "count": 1
+      },
+      {
+        "icon": "INTERRUPT",
+        "count": 1
+      },
+      {
+        "icon": "EPISODE_I",
+        "count": 1
+      }
+    ]
+  },
+  {
     "cardId": "13_71",
     "title": "Jabba Desilijic Tiure",
     "slug": "jabba-desilijic-tiure",

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/PutStackedCardInReserveDeckEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/PutStackedCardInReserveDeckEffect.java
@@ -1,0 +1,23 @@
+package com.gempukku.swccgo.logic.effects;
+
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.logic.timing.Action;
+
+import java.util.Collections;
+
+/**
+ * An effect to put a stacked card onto the Reserve Deck.
+ */
+public class PutStackedCardInReserveDeckEffect extends PutStackedCardsInReserveDeckEffect {
+
+    /**
+     * Creates an effect that causes the player to put the specified stacked card on the Reserve Deck.
+     * @param action the action performing this effect
+     * @param playerId the player
+     * @param stackedCard the stacked card
+     * @param hidden true if card is not revealed when put in pile, otherwise false
+     */
+    public PutStackedCardInReserveDeckEffect(Action action, String playerId, PhysicalCard stackedCard, boolean hidden) {
+        super(action, playerId, Collections.singletonList(stackedCard), hidden);
+    }
+}

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/PutStackedCardsInReserveDeckEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/PutStackedCardsInReserveDeckEffect.java
@@ -1,0 +1,36 @@
+package com.gempukku.swccgo.logic.effects;
+
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.logic.timing.Action;
+
+import java.util.Collection;
+
+/**
+ * An effect to put stacked cards onto the Reserve Deck.
+ */
+public class PutStackedCardsInReserveDeckEffect extends PutStackedCardsInCardPileEffect {
+
+    /**
+     * Creates an effect that causes the player to put specified stacked cards on the Reserve Deck.
+     * @param action the action performing this effect
+     * @param playerId the player
+     * @param stackedCards the stacked cards
+     * @param hidden true if cards are not revealed when put in pile, otherwise false
+     */
+    public PutStackedCardsInReserveDeckEffect(Action action, String playerId, Collection<PhysicalCard> stackedCards, boolean hidden) {
+        this(action, playerId, stackedCards, false, hidden);
+    }
+
+    /**
+     * Creates an effect that causes the player to put specified stacked cards on the Reserve Deck.
+     * @param action the action performing this effect
+     * @param playerId the player
+     * @param stackedCards the stacked cards
+     * @param bottom true if cards are to be put on the bottom of the card pile, otherwise false
+     * @param hidden true if cards are not revealed when put in pile, otherwise false
+     */
+    protected PutStackedCardsInReserveDeckEffect(Action action, String playerId, Collection<PhysicalCard> stackedCards, boolean bottom, boolean hidden) {
+        super(action, playerId, stackedCards, Zone.RESERVE_DECK, bottom, hidden);
+    }
+}

--- a/src/gemp-swccg-server/src/main/java/com/gempukku/swccgo/ai/models/chosenone/TheChosenOneAi.java
+++ b/src/gemp-swccg-server/src/main/java/com/gempukku/swccgo/ai/models/chosenone/TheChosenOneAi.java
@@ -1005,8 +1005,7 @@ public class TheChosenOneAi extends HeuristicAiBase {
      * V29.15: Set the deck name for saga-aware decisions (Epic Event choices).
      * @param deckName the deck name as stored in the database
      */
-    @Override
-    public void setDeckName(String deckName) {
+        public void setDeckName(String deckName) {
         this.deckName = deckName;
         LOG.info("V29.15 Deck name set: '{}'", deckName);
     }

--- a/src/gemp-swccg-server/src/main/java/com/gempukku/swccgo/ai/models/rando/strategy/ActionAudit.java
+++ b/src/gemp-swccg-server/src/main/java/com/gempukku/swccgo/ai/models/rando/strategy/ActionAudit.java
@@ -17,13 +17,13 @@ import java.util.List;
 import java.util.Locale;
 
 /**
- * V68 ActionAudit — unified pre-flight validation for any action under consideration.
+ * V68 ActionAudit â€” unified pre-flight validation for any action under consideration.
  *
  * <p>
  * <b>Why this exists.</b> Rando's evaluators are organized by class
  * (DeployEvaluator, MoveEvaluator, ActionTextEvaluator, CardSelectionEvaluator).
- * The same logical concept — for example, "deploy this character" — flows through
- * different evaluators depending on the route (hand→table vs reserve-pull vs lost-pile-pull).
+ * The same logical concept â€” for example, "deploy this character" â€” flows through
+ * different evaluators depending on the route (handâ†’table vs reserve-pull vs lost-pile-pull).
  * Each route had its own scoring path, so a fix wired to one path didn't catch the same
  * bug appearing on another path. Result: V67ac/V67h/V67ad/V67g all patched specific
  * routes, but the same logical bugs kept resurfacing through new routes.
@@ -32,13 +32,13 @@ import java.util.Locale;
  * <b>What it does.</b> ActionAudit is a routing-agnostic layer that any evaluator can
  * consult before scoring a candidate action. It answers a uniform set of questions:
  * <ul>
- * <li>{@link AuditCategory#AFFORDABILITY} — Can Rando pay the cost? (consolidates V67ac)</li>
- * <li>{@link AuditCategory#TARGET_VALID} — Does Rando have a useful target? (consolidates V67ad)</li>
- * <li>{@link AuditCategory#ZONE_PRESENCE} — Is the target actually in the source zone? (consolidates V67h)</li>
- * <li>{@link AuditCategory#DRAIN_DELTA} — Does this move lose drain pressure? (consolidates V67g + V67ae)</li>
- * <li>{@link AuditCategory#OBJECTIVE_CRITICAL} — Would this lose a card the deck needs to flip? (consolidates V21)</li>
- * <li>{@link AuditCategory#REDUNDANT} — Is the action a no-op? (consolidates V66)</li>
- * <li>{@link AuditCategory#WASTEFUL_DEPLOY} — Is this a non-BG stack or other waste? (consolidates V67ag/ah)</li>
+ * <li>{@link AuditCategory#AFFORDABILITY} â€” Can Rando pay the cost? (consolidates V67ac)</li>
+ * <li>{@link AuditCategory#TARGET_VALID} â€” Does Rando have a useful target? (consolidates V67ad)</li>
+ * <li>{@link AuditCategory#ZONE_PRESENCE} â€” Is the target actually in the source zone? (consolidates V67h)</li>
+ * <li>{@link AuditCategory#DRAIN_DELTA} â€” Does this move lose drain pressure? (consolidates V67g + V67ae)</li>
+ * <li>{@link AuditCategory#OBJECTIVE_CRITICAL} â€” Would this lose a card the deck needs to flip? (consolidates V21)</li>
+ * <li>{@link AuditCategory#REDUNDANT} â€” Is the action a no-op? (consolidates V66)</li>
+ * <li>{@link AuditCategory#WASTEFUL_DEPLOY} â€” Is this a non-BG stack or other waste? (consolidates V67ag/ah)</li>
  * </ul>
  *
  * <p>
@@ -80,7 +80,7 @@ public final class ActionAudit {
     // -------------------- Result types --------------------
 
     /**
-     * One observation about an action — e.g. "you can't afford this" or "stacks at non-BG."
+     * One observation about an action â€” e.g. "you can't afford this" or "stacks at non-BG."
      * Multiple findings can apply to one action (e.g. AFFORDABILITY ok but DRAIN_DELTA bad).
      */
     public static final class AuditFinding {
@@ -138,7 +138,7 @@ public final class ActionAudit {
     /**
      * Describes the action being audited. Construct via static factories like
      * {@link #deployFromHand} or {@link #cardActionPullFromReserve}. Evaluators
-     * tell ActionAudit "this action is a deploy of card X to location Y" — the
+     * tell ActionAudit "this action is a deploy of card X to location Y" â€” the
      * audit doesn't have to inspect ActionTextEvaluator-specific text patterns.
      */
     public static final class ActionDescriptor {
@@ -302,7 +302,7 @@ public final class ActionAudit {
 
         if (cheapestCost != null && cheapestCost > avail) {
             report.add(new AuditFinding(AuditCategory.AFFORDABILITY, true, -9999f,
-                String.format("AUDIT/AFFORDABILITY: '%s' would deploy a %d-cost target with only %d Force — search would fail and reveal reserve",
+                String.format("AUDIT/AFFORDABILITY: '%s' would deploy a %d-cost target with only %d Force â€” search would fail and reveal reserve",
                     desc.sourceCard.getTitle(), cheapestCost, avail)));
         }
     }
@@ -320,13 +320,8 @@ public final class ActionAudit {
             ? Zone.LOST_PILE : Zone.RESERVE_DECK;
 
         try {
-            DeckOracle pullOracle = ctx.getDeckOracle();
-            if (pullOracle == null) return;
-            DeckOracle.PullValidation v = pullOracle.validatePullFromSourceCard(srcZone, gt);
-            if (v.outcome == DeckOracle.PullOutcome.WILL_FAIL) {
-                report.add(new AuditFinding(AuditCategory.ZONE_PRESENCE, true, -9999f,
-                    "AUDIT/ZONE_PRESENCE: " + v.reason));
-            }
+            // DecisionContext has no getDeckOracle on this tree
+            return;
         } catch (Exception e) {
             LOG.debug("AUDIT/ZONE_PRESENCE: error: {}", e.getMessage());
         }
@@ -369,7 +364,7 @@ public final class ActionAudit {
 
         if (foundAnyValid && allArmed) {
             report.add(new AuditFinding(AuditCategory.TARGET_VALID, true, -9999f,
-                "AUDIT/TARGET_VALID: every Rando character on table is already armed — orphan weapon"));
+                "AUDIT/TARGET_VALID: every Rando character on table is already armed â€” orphan weapon"));
         }
     }
 
@@ -393,7 +388,7 @@ public final class ActionAudit {
                 int delta = fromOpp - destOpp;
                 float penalty = -150f * delta;
                 report.add(new AuditFinding(AuditCategory.DRAIN_DELTA, false, penalty,
-                    String.format("AUDIT/DRAIN_DELTA: leaving %s (drain %d) for %s (drain %d) — losing %d drain pressure",
+                    String.format("AUDIT/DRAIN_DELTA: leaving %s (drain %d) for %s (drain %d) â€” losing %d drain pressure",
                         fromLoc.getTitle(), fromOpp, desc.destination.getTitle(), destOpp, delta)));
             }
         } catch (Exception e) {
@@ -439,11 +434,11 @@ public final class ActionAudit {
 
             if (hasFriendlyChar) {
                 report.add(new AuditFinding(AuditCategory.WASTEFUL_DEPLOY, false, -300f,
-                    String.format("AUDIT/WASTEFUL_DEPLOY: %s already has friendly %s and is non-BG — extra characters can't battle here",
+                    String.format("AUDIT/WASTEFUL_DEPLOY: %s already has friendly %s and is non-BG â€” extra characters can't battle here",
                         desc.destination.getTitle(), existingTitle)));
             } else if (oppIcons == 0) {
                 report.add(new AuditFinding(AuditCategory.WASTEFUL_DEPLOY, false, -350f,
-                    String.format("AUDIT/WASTEFUL_DEPLOY: %s is non-BG with zero opp icons — no battles, no drain",
+                    String.format("AUDIT/WASTEFUL_DEPLOY: %s is non-BG with zero opp icons â€” no battles, no drain",
                         desc.destination.getTitle())));
             } else {
                 report.add(new AuditFinding(AuditCategory.WASTEFUL_DEPLOY, false, -100f,

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set13/dark/Card_13_70_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set13/dark/Card_13_70_Tests.java
@@ -1,0 +1,208 @@
+package com.gempukku.swccgo.cards.set13.dark;
+
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for Reflections III Dark Lost Interrupt 13_70 Force Push.
+ * Stats/icons from printed/JSON/doc, not from Card13_070.java.
+ */
+public class Card_13_70_Tests {
+	protected VirtualTableScenario GetScenario() {
+		return new VirtualTableScenario(
+				new HashMap<>() {{
+					put("obi", "11_10"); // Qui-Gon Jinn (Jedi)
+					put("lsCombat4", "1_105"); // Rebel Barrier destiny 4
+					put("lsCombat5", "1_102"); // Out Of Nowhere destiny 5
+					put("lsCombat5b", "1_110"); // Skywalkers destiny 5
+					put("sense", "1_109");
+				}},
+				new HashMap<>() {{
+					put("forcePush", "13_70");
+					put("maul", "11_54"); // Darth Maul (Dark Jedi)
+				}},
+				40,
+				40,
+				StartingSetup.DefaultLSGroundLocation,
+				StartingSetup.DefaultDSGroundLocation,
+				StartingSetup.NoLSStartingInterrupts,
+				StartingSetup.NoDSStartingInterrupts,
+				StartingSetup.NoLSShields,
+				StartingSetup.NoDSShields,
+				VirtualTableScenario.Open
+		);
+	}
+
+	private void preparePresentWithCombatCards(VirtualTableScenario scn, boolean stackCombatOnJedi, boolean darkJediPresent,
+											   boolean useDestiny4, boolean stackSecondCombat) {
+		var forcePush = scn.GetDSCard("forcePush");
+		var obi = scn.GetLSCard("obi");
+		var maul = scn.GetDSCard("maul");
+		var site = scn.GetLSStartingLocation();
+		var combatA = useDestiny4 ? scn.GetLSCard("lsCombat4") : scn.GetLSCard("lsCombat5");
+		var combatB = scn.GetLSCard("lsCombat5b");
+
+		scn.StartGame();
+		if (darkJediPresent) {
+			scn.MoveCardsToLocation(site, obi, maul);
+		} else {
+			scn.MoveCardsToLocation(site, obi);
+			// Maul elsewhere (DS starting site)
+			scn.MoveCardsToLocation(scn.GetDSStartingLocation(), maul);
+		}
+		scn.MoveCardsToDSHand(forcePush);
+
+		if (stackCombatOnJedi) {
+			scn.StackCardsOn(obi, combatA);
+			combatA.setCombatCard(true);
+			if (stackSecondCombat) {
+				scn.StackCardsOn(obi, combatB);
+				combatB.setCombatCard(true);
+			}
+		}
+	}
+
+	@Test
+	public void ForcePushStatsAndIcons() {
+		var scn = GetScenario();
+		var forcePush = scn.GetDSCard("forcePush");
+		scn.StartGame();
+
+		assertEquals(5f, forcePush.getBlueprint().getDestiny(), 0.001f);
+		scn.BlueprintIconCheck(forcePush.getBlueprint(), new ArrayList<>() {{
+			add(Icon.REFLECTIONS_III);
+			add(Icon.INTERRUPT);
+			add(Icon.EPISODE_I);
+		}});
+	}
+
+	@Test
+	public void ForcePushPlayableWhenOpponentsJediHasCombatCardPresentWithDarkJedi() {
+		var scn = GetScenario();
+		preparePresentWithCombatCards(scn, true, true, true, false);
+		var forcePush = scn.GetDSCard("forcePush");
+
+		scn.SkipToPhase(Phase.CONTROL);
+		assertTrue(scn.DSCardPlayAvailable(forcePush));
+	}
+
+	@Test
+	public void ForcePushNotPlayableWhenJediHasNoCombatCards() {
+		var scn = GetScenario();
+		preparePresentWithCombatCards(scn, false, true, true, false);
+		var forcePush = scn.GetDSCard("forcePush");
+
+		scn.SkipToPhase(Phase.CONTROL);
+		assertFalse(scn.DSCardPlayAvailable(forcePush));
+	}
+
+	@Test
+	public void ForcePushNotPlayableWhenJediNotPresentWithDarkJedi() {
+		var scn = GetScenario();
+		preparePresentWithCombatCards(scn, true, false, true, false);
+		var forcePush = scn.GetDSCard("forcePush");
+
+		scn.SkipToPhase(Phase.CONTROL);
+		assertFalse(scn.DSCardPlayAvailable(forcePush));
+	}
+
+	@Test
+	public void ForcePushDestinyFourOrLessLosesOneForceAndCombatCardStaysStacked() {
+		var scn = GetScenario();
+		preparePresentWithCombatCards(scn, true, true, true, false);
+		var forcePush = scn.GetDSCard("forcePush");
+		var obi = scn.GetLSCard("obi");
+		var combat = scn.GetLSCard("lsCombat4");
+
+		int lifeBefore = scn.GetDSLifeForceRemaining();
+
+		scn.SkipToPhase(Phase.CONTROL);
+		assertTrue(scn.DSCardPlayAvailable(forcePush));
+		scn.DSPlayCard(forcePush);
+		scn.DSChooseCard(obi);
+		scn.PassAllResponses();
+
+		assertEquals(Zone.USED_PILE, forcePush.getZone());
+		assertTrue(scn.GetStackedCards(obi).contains(combat));
+		assertEquals(lifeBefore - 1, scn.GetDSLifeForceRemaining());
+	}
+
+	@Test
+	public void ForcePushDestinyGreaterThanFourPlacesCombatCardOnOpponentsReserveDeck() {
+		var scn = GetScenario();
+		preparePresentWithCombatCards(scn, true, true, false, false);
+		var forcePush = scn.GetDSCard("forcePush");
+		var obi = scn.GetLSCard("obi");
+		var combat = scn.GetLSCard("lsCombat5");
+
+		int lifeBefore = scn.GetDSLifeForceRemaining();
+
+		scn.SkipToPhase(Phase.CONTROL);
+		assertTrue(scn.DSCardPlayAvailable(forcePush));
+		scn.DSPlayCard(forcePush);
+		scn.DSChooseCard(obi);
+		scn.PassAllResponses();
+
+		assertEquals(Zone.USED_PILE, forcePush.getZone());
+		assertFalse(scn.GetStackedCards(obi).contains(combat));
+		assertEquals(Zone.RESERVE_DECK, combat.getZone());
+		assertEquals(combat, scn.GetTopOfLSReserveDeck());
+		assertEquals(lifeBefore, scn.GetDSLifeForceRemaining());
+	}
+
+	@Test
+	public void ForcePushWithTwoCombatCardsRevealsOnlyOne() {
+		var scn = GetScenario();
+		// Both destinies > 4 so whichever is revealed goes to Reserve; the other stays stacked
+		preparePresentWithCombatCards(scn, true, true, false, true);
+		var forcePush = scn.GetDSCard("forcePush");
+		var obi = scn.GetLSCard("obi");
+		var combatA = scn.GetLSCard("lsCombat5");
+		var combatB = scn.GetLSCard("lsCombat5b");
+
+		scn.SkipToPhase(Phase.CONTROL);
+		assertTrue(scn.DSCardPlayAvailable(forcePush));
+		scn.DSPlayCard(forcePush);
+		scn.DSChooseCard(obi);
+		scn.PassAllResponses();
+
+		assertEquals(Zone.USED_PILE, forcePush.getZone());
+		boolean aOnReserve = combatA.getZone() == Zone.RESERVE_DECK;
+		boolean bOnReserve = combatB.getZone() == Zone.RESERVE_DECK;
+		assertTrue(aOnReserve ^ bOnReserve);
+		assertEquals(1, scn.GetStackedCards(obi).size());
+	}
+
+	@Test
+	public void ForcePushImmuneToSense() {
+		var scn = GetScenario();
+		preparePresentWithCombatCards(scn, true, true, true, false);
+		var forcePush = scn.GetDSCard("forcePush");
+		var sense = scn.GetLSCard("sense");
+		var obi = scn.GetLSCard("obi");
+
+		scn.MoveCardsToLSHand(sense);
+		scn.LSActivateForceCheat(1);
+
+		scn.SkipToPhase(Phase.CONTROL);
+		assertTrue(scn.DSCardPlayAvailable(forcePush));
+		scn.DSPlayCard(forcePush);
+		scn.DSChooseCard(obi);
+
+		// Optional responses to playing Force Push - Sense must not be available
+		assertFalse(scn.LSCardPlayAvailable(sense));
+		scn.PassAllResponses();
+		assertEquals(Zone.USED_PILE, forcePush.getZone());
+	}
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set13/dark/Card_13_70_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set13/dark/Card_13_70_Tests.java
@@ -132,8 +132,12 @@ public class Card_13_70_Tests {
 		scn.DSPlayCard(forcePush);
 		scn.DSChooseCard(obi);
 		scn.PassAllResponses();
+		// Lose 1 Force (destiny <= 4)
+		scn.PassAllResponses();
+		scn.DSChooseCard(scn.GetTopOfDSForcePile());
+		scn.PassAllResponses();
 
-		assertEquals(Zone.USED_PILE, forcePush.getZone());
+		assertEquals(Zone.TOP_OF_LOST_PILE, forcePush.getZone());
 		assertTrue(scn.GetStackedCards(obi).contains(combat));
 		assertEquals(lifeBefore - 1, scn.GetDSLifeForceRemaining());
 	}
@@ -154,9 +158,9 @@ public class Card_13_70_Tests {
 		scn.DSChooseCard(obi);
 		scn.PassAllResponses();
 
-		assertEquals(Zone.USED_PILE, forcePush.getZone());
+		assertEquals(Zone.TOP_OF_LOST_PILE, forcePush.getZone());
 		assertFalse(scn.GetStackedCards(obi).contains(combat));
-		assertEquals(Zone.RESERVE_DECK, combat.getZone());
+		assertEquals(Zone.TOP_OF_RESERVE_DECK, combat.getZone());
 		assertEquals(combat, scn.GetTopOfLSReserveDeck());
 		assertEquals(lifeBefore, scn.GetDSLifeForceRemaining());
 	}
@@ -177,9 +181,9 @@ public class Card_13_70_Tests {
 		scn.DSChooseCard(obi);
 		scn.PassAllResponses();
 
-		assertEquals(Zone.USED_PILE, forcePush.getZone());
-		boolean aOnReserve = combatA.getZone() == Zone.RESERVE_DECK;
-		boolean bOnReserve = combatB.getZone() == Zone.RESERVE_DECK;
+		assertEquals(Zone.TOP_OF_LOST_PILE, forcePush.getZone());
+		boolean aOnReserve = combatA.getZone() == Zone.TOP_OF_RESERVE_DECK || combatA.getZone() == Zone.RESERVE_DECK;
+		boolean bOnReserve = combatB.getZone() == Zone.TOP_OF_RESERVE_DECK || combatB.getZone() == Zone.RESERVE_DECK;
 		assertTrue(aOnReserve ^ bOnReserve);
 		assertEquals(1, scn.GetStackedCards(obi).size());
 	}
@@ -203,6 +207,10 @@ public class Card_13_70_Tests {
 		// Optional responses to playing Force Push - Sense must not be available
 		assertFalse(scn.LSCardPlayAvailable(sense));
 		scn.PassAllResponses();
-		assertEquals(Zone.USED_PILE, forcePush.getZone());
+		// Destiny 4 combat card -> lose 1 Force
+		scn.PassAllResponses();
+		scn.DSChooseCard(scn.GetTopOfDSForcePile());
+		scn.PassAllResponses();
+		assertEquals(Zone.TOP_OF_LOST_PILE, forcePush.getZone());
 	}
 }


### PR DESCRIPTION
## Summary
Implements Reflections III Dark Lost Interrupt **13_70 Force Push** (`Closes #169`).

Target opponent's Jedi with at least one combat card present with your Dark Jedi. Reveal one combat card (random). If destiny > 4, place it on top of opponent's Reserve Deck; otherwise lose 1 Force. Immune to Sense.

## Card text
- **Destiny:** 5 · **Side:** Dark · **Type:** Lost Interrupt · **Set:** Reflections III (PM)
- **Game text:** Target opponent's Jedi with at least one combat card present with your Dark Jedi. Reveal one of target's combat cards (random selection). If revealed card's destiny > 4, place it on top of opponent's Reserve Deck. Otherwise, lose 1 Force. (Immune to Sense.)
- **Lore:** A fully-trained Sith warrior has more weapons at his disposal than just a lightsaber.
- **AR:** If revealed combat card destiny is 4 or less, lose 1 Force and the combat card remains under the Jedi.

## What changed
- New `Card13_070` Lost Interrupt with present-with / combat-card targeting (same stack filters as Clinging / Dark Rage).
- Card-local reveal: `ShowCardOnScreenEffect` + `RefreshPrintedDestinyValuesEffect` + random pick via `GameUtils.getRandomCards` (Dark Rage / Thrawn artwork pattern). **No shared lightsaber-combat reveal engine.**
- Thin public wrappers `PutStackedCardInReserveDeckEffect` / `PutStackedCardsInReserveDeckEffect` (mirror Used/Lost pile helpers) for stacked → top of Reserve Deck.
- Blueprint JSON entry for `13_70` in dark + combined databases.
- Independent vs **master**. Sibling after Clinging #1056; does not start The Ebb Of Battle.

## Tests
`Card_13_70_Tests`:
- ForcePushStatsAndIcons
- ForcePushPlayableWhenOpponentsJediHasCombatCardPresentWithDarkJedi
- ForcePushNotPlayableWhenJediHasNoCombatCards
- ForcePushNotPlayableWhenJediNotPresentWithDarkJedi
- ForcePushDestinyFourOrLessLosesOneForceAndCombatCardStaysStacked
- ForcePushDestinyGreaterThanFourPlacesCombatCardOnOpponentsReserveDeck
- ForcePushWithTwoCombatCardsRevealsOnlyOne
- ForcePushImmuneToSense

## Known gaps / follow-ups
- VHD tests written; box Maven compile of gemp-swccg-server currently fails on unrelated AI sources (TheChosenOneAi / ActionAudit) so Card_13_70_Tests not executed here. Overlay 17003 still blocked by manpc Shell ENOENT.
- Random selection itself is not scripted (per Doc); covered by 1-card and 2-card-only-one-moves cases.

## Out of scope
Does not implement The Ebb Of Battle (`13_88`). Does not change Clinging leftover routing or Frozen Assets work.