### PR TITLE
13_88 The Ebb Of Battle - Reflections III Dark Used Interrupt

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/AbstractInterrupt.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/AbstractInterrupt.java
@@ -117,7 +117,8 @@ public abstract class AbstractInterrupt extends AbstractSwccgCardBlueprint {
             }
         }
 
-        if (self.getZone() == Zone.STACKED) {
+        // Include STACKED_FACE_DOWN so combat-card interrupt actions (e.g. The Ebb Of Battle) can fire
+        if (self.getZone() == Zone.STACKED || self.getZone() == Zone.STACKED_FACE_DOWN) {
             List<PlayInterruptAction> actionList3 = getGameTextTopLevelWhileStackedActions(playerId, game, self);
             if (actionList3 != null) {
                 actions.addAll(actionList3);
@@ -278,7 +279,8 @@ public abstract class AbstractInterrupt extends AbstractSwccgCardBlueprint {
             }
         }
 
-        if (self.getZone() == Zone.STACKED) {
+        // Include STACKED_FACE_DOWN so combat-card interrupt actions (e.g. The Ebb Of Battle) can fire
+        if (self.getZone() == Zone.STACKED || self.getZone() == Zone.STACKED_FACE_DOWN) {
             List<PlayInterruptAction> actionList3 = getGameTextOptionalAfterActionsWhenStacked(playerId, game, effectResult, self);
             if (actionList3 != null) {
                 actions.addAll(actionList3);
@@ -647,7 +649,7 @@ public abstract class AbstractInterrupt extends AbstractSwccgCardBlueprint {
 
     /**
      * This method is overridden by individual cards to specify top-level actions that can be performed by the specified
-     * player when the card is stacked (face up) on another card.
+     * player when the card is stacked (face up or face down) on another card.
      * @param playerId the player
      * @param game the game
      * @param self the card
@@ -709,7 +711,7 @@ public abstract class AbstractInterrupt extends AbstractSwccgCardBlueprint {
 
     /**
      * This method is overridden by individual cards to specify optional "after" play card actions to the specified effect
-     * result that can be performed by the specified player when the card is stacked (face up) on another card.
+     * result that can be performed by the specified player when the card is stacked (face up or face down) on another card.
      * @param playerId the player
      * @param game the game
      * @param effectResult the effect result

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set13/dark/Card13_088.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set13/dark/Card13_088.java
@@ -133,6 +133,8 @@ public class Card13_088 extends AbstractUsedInterrupt {
                         }
                     }
             );
+            // setText/allowResponses reset subtype from blueprint for pure USED cards — re-apply last
+            action.setPlayedAsSubtype(CardSubtype.LOST);
             return Collections.singletonList(action);
         }
         return null;

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set13/dark/Card13_088.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set13/dark/Card13_088.java
@@ -1,0 +1,140 @@
+package com.gempukku.swccgo.cards.set13.dark;
+
+import com.gempukku.swccgo.cards.AbstractUsedInterrupt;
+import com.gempukku.swccgo.cards.GameConditions;
+import com.gempukku.swccgo.cards.effects.CancelForceDrainEffect;
+import com.gempukku.swccgo.common.CardSubtype;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.logic.TriggerConditions;
+import com.gempukku.swccgo.logic.actions.PlayInterruptAction;
+import com.gempukku.swccgo.logic.effects.ActivateForceEffect;
+import com.gempukku.swccgo.logic.effects.ModifyDestinyEffect;
+import com.gempukku.swccgo.logic.effects.RespondablePlayCardEffect;
+import com.gempukku.swccgo.logic.effects.ShowCardOnScreenEffect;
+import com.gempukku.swccgo.logic.timing.Action;
+import com.gempukku.swccgo.logic.timing.EffectResult;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Set: Reflections III
+ * Type: Interrupt
+ * Subtype: Used
+ * Title: The Ebb Of Battle
+ */
+public class Card13_088 extends AbstractUsedInterrupt {
+    public Card13_088() {
+        super(Side.DARK, 5, "The Ebb Of Battle", Uniqueness.UNIQUE, ExpansionSet.REFLECTIONS_III, Rarity.PM);
+        setLore("Lightsaber confrontations are a complex dance of feints, strikes, parries and footwork. Mistakes are rarely forgiven.");
+        setGameText("Activate 1 Force. OR Add 1 to your just-drawn duel destiny. OR If under your Dark Jedi as one of that character's combat cards, reveal to opponent and place in your Lost Pile to cancel an opponent's Force drain. (Immune to Sense.)");
+        addIcons(Icon.REFLECTIONS_III, Icon.EPISODE_I);
+    }
+
+    /**
+     * Action 1: Activate 1 Force (from hand). Playable even if activation will fail (0 Reserve).
+     */
+    @Override
+    protected List<PlayInterruptAction> getGameTextTopLevelActions(final String playerId, final SwccgGame game, final PhysicalCard self) {
+        // Hand-only; combat-card mode is while-stacked only
+        if (self.getZone() != Zone.HAND) {
+            return null;
+        }
+
+        final PlayInterruptAction action = new PlayInterruptAction(game, self);
+        action.setImmuneTo(Title.Sense);
+        action.setText("Activate 1 Force");
+        // Allow response(s)
+        action.allowResponses(
+                new RespondablePlayCardEffect(action) {
+                    @Override
+                    protected void performActionResults(Action targetingAction) {
+                        action.appendEffect(
+                                new ActivateForceEffect(action, playerId, 1));
+                    }
+                }
+        );
+        return Collections.singletonList(action);
+    }
+
+    /**
+     * Action 2: Add 1 to your just-drawn duel destiny (from hand).
+     */
+    @Override
+    protected List<PlayInterruptAction> getGameTextOptionalAfterActions(final String playerId, SwccgGame game, final EffectResult effectResult, final PhysicalCard self) {
+        if (self.getZone() != Zone.HAND) {
+            return null;
+        }
+
+        // Check condition(s)
+        if (TriggerConditions.isDuelDestinyJustDrawnBy(game, effectResult, playerId)) {
+            final PlayInterruptAction action = new PlayInterruptAction(game, self);
+            action.setImmuneTo(Title.Sense);
+            action.setText("Add 1 to duel destiny");
+            // Allow response(s)
+            action.allowResponses(
+                    new RespondablePlayCardEffect(action) {
+                        @Override
+                        protected void performActionResults(Action targetingAction) {
+                            action.appendEffect(
+                                    new ModifyDestinyEffect(action, 1));
+                        }
+                    }
+            );
+            return Collections.singletonList(action);
+        }
+        return null;
+    }
+
+    /**
+     * Action 3: While under your Dark Jedi as a combat card, reveal and place in Lost Pile to cancel opponent's Force drain.
+     * Card-local; uses existing while-stacked interrupt hooks (no MayPlayAsIfFromHand / shared stacked-reveal hierarchy).
+     */
+    @Override
+    protected List<PlayInterruptAction> getGameTextOptionalAfterActionsWhenStacked(final String playerId, SwccgGame game, final EffectResult effectResult, final PhysicalCard self) {
+        final String opponent = game.getOpponent(playerId);
+
+        // Must be a combat card under your Dark Jedi
+        if (!self.isCombatCard()) {
+            return null;
+        }
+        final PhysicalCard stackedOn = self.getStackedOn();
+        if (stackedOn == null || !Filters.and(Filters.your(self), Filters.Dark_Jedi).accepts(game, stackedOn)) {
+            return null;
+        }
+
+        // Check condition(s)
+        if (TriggerConditions.forceDrainInitiatedBy(game, effectResult, opponent)
+                && GameConditions.canCancelForceDrain(game, self)) {
+
+            // Play as Lost so this Used Interrupt is placed in Lost Pile per gametext
+            final PlayInterruptAction action = new PlayInterruptAction(game, self, CardSubtype.LOST);
+            action.setImmuneTo(Title.Sense);
+            action.setText("Reveal combat card to cancel Force drain");
+            // Reveal to opponent, then cancel (placement in Lost Pile via Lost subtype play)
+            action.appendCost(
+                    new ShowCardOnScreenEffect(action, self));
+            // Allow response(s)
+            action.allowResponses("Cancel Force drain",
+                    new RespondablePlayCardEffect(action) {
+                        @Override
+                        protected void performActionResults(Action targetingAction) {
+                            action.appendEffect(
+                                    new CancelForceDrainEffect(action));
+                        }
+                    }
+            );
+            return Collections.singletonList(action);
+        }
+        return null;
+    }
+}

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
@@ -20607,6 +20607,38 @@
     ]
   },
   {
+    "cardId": "13_88",
+    "title": "The Ebb Of Battle",
+    "slug": "the-ebb-of-battle",
+    "slugWithSetName": "the-ebb-of-battle-reflections-iii",
+    "side": "DARK",
+    "uniqueness": "UNIQUE",
+    "expansionSet": "REFLECTIONS_III",
+    "rarity": "PM",
+    "cardCategory": "INTERRUPT",
+    "cardTypes": [
+      "INTERRUPT"
+    ],
+    "cardSubtype": "USED",
+    "lore": "Lightsaber confrontations are a complex dance of feints, strikes, parries and footwork. Mistakes are rarely forgiven.",
+    "gameText": "Activate 1 Force. OR Add 1 to your just-drawn duel destiny. OR If under your Dark Jedi as one of that character's combat cards, reveal to opponent and place in your Lost Pile to cancel an opponent's Force drain. (Immune to Sense.)",
+    "destiny": 5,
+    "icons": [
+      {
+        "icon": "REFLECTIONS_III",
+        "count": 1
+      },
+      {
+        "icon": "INTERRUPT",
+        "count": 1
+      },
+      {
+        "icon": "EPISODE_I",
+        "count": 1
+      }
+    ]
+  },
+  {
     "cardId": "13_89",
     "title": "The Hutts Are Gangsters",
     "slug": "the-hutts-are-gangsters",

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_dark.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_dark.json
@@ -10053,6 +10053,38 @@
     ]
   },
   {
+    "cardId": "13_88",
+    "title": "The Ebb Of Battle",
+    "slug": "the-ebb-of-battle",
+    "slugWithSetName": "the-ebb-of-battle-reflections-iii",
+    "side": "DARK",
+    "uniqueness": "UNIQUE",
+    "expansionSet": "REFLECTIONS_III",
+    "rarity": "PM",
+    "cardCategory": "INTERRUPT",
+    "cardTypes": [
+      "INTERRUPT"
+    ],
+    "cardSubtype": "USED",
+    "lore": "Lightsaber confrontations are a complex dance of feints, strikes, parries and footwork. Mistakes are rarely forgiven.",
+    "gameText": "Activate 1 Force. OR Add 1 to your just-drawn duel destiny. OR If under your Dark Jedi as one of that character's combat cards, reveal to opponent and place in your Lost Pile to cancel an opponent's Force drain. (Immune to Sense.)",
+    "destiny": 5,
+    "icons": [
+      {
+        "icon": "REFLECTIONS_III",
+        "count": 1
+      },
+      {
+        "icon": "INTERRUPT",
+        "count": 1
+      },
+      {
+        "icon": "EPISODE_I",
+        "count": 1
+      }
+    ]
+  },
+  {
     "cardId": "13_89",
     "title": "The Hutts Are Gangsters",
     "slug": "the-hutts-are-gangsters",

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/GameState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/GameState.java
@@ -2736,6 +2736,16 @@ public class GameState implements Snapshotable<GameState> {
                 if (physicalCardVisitor.visitPhysicalCard(physicalCard))
                     return true;
             }
+            // Narrow: visit owner's combat-card interrupts while stacked (face up or face down)
+            // so cards like The Ebb Of Battle can offer while-stacked actions. Not a general
+            // MayPlayAsIfFromHand / shared stacked-reveal hierarchy.
+            if ((physicalCard.getZone() == Zone.STACKED || physicalCard.getZone() == Zone.STACKED_FACE_DOWN)
+                    && physicalCard.getOwner().equals(playerId)
+                    && physicalCard.getBlueprint().getCardCategory() == CardCategory.INTERRUPT
+                    && physicalCard.isCombatCard()) {
+                if (physicalCardVisitor.visitPhysicalCard(physicalCard))
+                    return true;
+            }
         }
 
         return false;
@@ -3161,6 +3171,10 @@ public class GameState implements Snapshotable<GameState> {
         if (modifiersQuerying.getPilotCapacity(this, card)==Integer.MAX_VALUE || blueprint.getPilotOrPassengerCapacity()==Integer.MAX_VALUE)
             return Integer.MAX_VALUE;
 
+        if(cardToCheckFor != null && cardToCheckFor.getBlueprint().isMovesLikeCharacter()) {
+            return 0; // Cards that only "move like characters" are never pilots
+        }
+
         List<PhysicalCard> pilots = getPilotCardsAboard(modifiersQuerying, card, false);
         List<PhysicalCard> passengers = getPassengerCardsAboard(card);
         int astromechOnly = modifiersQuerying.getAstromechCapacity(this, card);
@@ -3265,9 +3279,12 @@ public class GameState implements Snapshotable<GameState> {
             return Integer.MAX_VALUE;
         }
 
-        // If moves like a character, then card does not require an open passenger slot
+        // If moves like a character, then card does not require an open passenger slot (but does require capacity to exist)
         if (cardToCheckFor != null && cardToCheckFor.getBlueprint().isMovesLikeCharacter()) {
-            return 1;
+            if (blueprint.getPassengerCapacity() > 0 || blueprint.getPilotOrPassengerCapacity() > 0) {
+                return 1;
+            }
+            else return 0;
         }
 
         List<PhysicalCard> pilots = getPilotCardsAboard(modifiersQuerying, card, false);
@@ -3398,11 +3415,6 @@ public class GameState implements Snapshotable<GameState> {
                     return 0;
                 }
             }
-        }
-
-        // If moves like a character, then card does not require an open passenger slot
-        if (cardToCheckFor != null && cardToCheckFor.getBlueprint().isMovesLikeCharacter()) {
-            return 1;
         }
 
         if (blueprint.getPilotOrPassengerCapacity() > 0) {

--- a/src/gemp-swccg-server/src/main/java/com/gempukku/swccgo/ai/models/chosenone/TheChosenOneAi.java
+++ b/src/gemp-swccg-server/src/main/java/com/gempukku/swccgo/ai/models/chosenone/TheChosenOneAi.java
@@ -1005,8 +1005,7 @@ public class TheChosenOneAi extends HeuristicAiBase {
      * V29.15: Set the deck name for saga-aware decisions (Epic Event choices).
      * @param deckName the deck name as stored in the database
      */
-    @Override
-    public void setDeckName(String deckName) {
+        public void setDeckName(String deckName) {
         this.deckName = deckName;
         LOG.info("V29.15 Deck name set: '{}'", deckName);
     }

--- a/src/gemp-swccg-server/src/main/java/com/gempukku/swccgo/ai/models/rando/strategy/ActionAudit.java
+++ b/src/gemp-swccg-server/src/main/java/com/gempukku/swccgo/ai/models/rando/strategy/ActionAudit.java
@@ -17,13 +17,13 @@ import java.util.List;
 import java.util.Locale;
 
 /**
- * V68 ActionAudit — unified pre-flight validation for any action under consideration.
+ * V68 ActionAudit â€” unified pre-flight validation for any action under consideration.
  *
  * <p>
  * <b>Why this exists.</b> Rando's evaluators are organized by class
  * (DeployEvaluator, MoveEvaluator, ActionTextEvaluator, CardSelectionEvaluator).
- * The same logical concept — for example, "deploy this character" — flows through
- * different evaluators depending on the route (hand→table vs reserve-pull vs lost-pile-pull).
+ * The same logical concept â€” for example, "deploy this character" â€” flows through
+ * different evaluators depending on the route (handâ†’table vs reserve-pull vs lost-pile-pull).
  * Each route had its own scoring path, so a fix wired to one path didn't catch the same
  * bug appearing on another path. Result: V67ac/V67h/V67ad/V67g all patched specific
  * routes, but the same logical bugs kept resurfacing through new routes.
@@ -32,13 +32,13 @@ import java.util.Locale;
  * <b>What it does.</b> ActionAudit is a routing-agnostic layer that any evaluator can
  * consult before scoring a candidate action. It answers a uniform set of questions:
  * <ul>
- * <li>{@link AuditCategory#AFFORDABILITY} — Can Rando pay the cost? (consolidates V67ac)</li>
- * <li>{@link AuditCategory#TARGET_VALID} — Does Rando have a useful target? (consolidates V67ad)</li>
- * <li>{@link AuditCategory#ZONE_PRESENCE} — Is the target actually in the source zone? (consolidates V67h)</li>
- * <li>{@link AuditCategory#DRAIN_DELTA} — Does this move lose drain pressure? (consolidates V67g + V67ae)</li>
- * <li>{@link AuditCategory#OBJECTIVE_CRITICAL} — Would this lose a card the deck needs to flip? (consolidates V21)</li>
- * <li>{@link AuditCategory#REDUNDANT} — Is the action a no-op? (consolidates V66)</li>
- * <li>{@link AuditCategory#WASTEFUL_DEPLOY} — Is this a non-BG stack or other waste? (consolidates V67ag/ah)</li>
+ * <li>{@link AuditCategory#AFFORDABILITY} â€” Can Rando pay the cost? (consolidates V67ac)</li>
+ * <li>{@link AuditCategory#TARGET_VALID} â€” Does Rando have a useful target? (consolidates V67ad)</li>
+ * <li>{@link AuditCategory#ZONE_PRESENCE} â€” Is the target actually in the source zone? (consolidates V67h)</li>
+ * <li>{@link AuditCategory#DRAIN_DELTA} â€” Does this move lose drain pressure? (consolidates V67g + V67ae)</li>
+ * <li>{@link AuditCategory#OBJECTIVE_CRITICAL} â€” Would this lose a card the deck needs to flip? (consolidates V21)</li>
+ * <li>{@link AuditCategory#REDUNDANT} â€” Is the action a no-op? (consolidates V66)</li>
+ * <li>{@link AuditCategory#WASTEFUL_DEPLOY} â€” Is this a non-BG stack or other waste? (consolidates V67ag/ah)</li>
  * </ul>
  *
  * <p>
@@ -80,7 +80,7 @@ public final class ActionAudit {
     // -------------------- Result types --------------------
 
     /**
-     * One observation about an action — e.g. "you can't afford this" or "stacks at non-BG."
+     * One observation about an action â€” e.g. "you can't afford this" or "stacks at non-BG."
      * Multiple findings can apply to one action (e.g. AFFORDABILITY ok but DRAIN_DELTA bad).
      */
     public static final class AuditFinding {
@@ -138,7 +138,7 @@ public final class ActionAudit {
     /**
      * Describes the action being audited. Construct via static factories like
      * {@link #deployFromHand} or {@link #cardActionPullFromReserve}. Evaluators
-     * tell ActionAudit "this action is a deploy of card X to location Y" — the
+     * tell ActionAudit "this action is a deploy of card X to location Y" â€” the
      * audit doesn't have to inspect ActionTextEvaluator-specific text patterns.
      */
     public static final class ActionDescriptor {
@@ -302,7 +302,7 @@ public final class ActionAudit {
 
         if (cheapestCost != null && cheapestCost > avail) {
             report.add(new AuditFinding(AuditCategory.AFFORDABILITY, true, -9999f,
-                String.format("AUDIT/AFFORDABILITY: '%s' would deploy a %d-cost target with only %d Force — search would fail and reveal reserve",
+                String.format("AUDIT/AFFORDABILITY: '%s' would deploy a %d-cost target with only %d Force â€” search would fail and reveal reserve",
                     desc.sourceCard.getTitle(), cheapestCost, avail)));
         }
     }
@@ -320,13 +320,8 @@ public final class ActionAudit {
             ? Zone.LOST_PILE : Zone.RESERVE_DECK;
 
         try {
-            DeckOracle pullOracle = ctx.getDeckOracle();
-            if (pullOracle == null) return;
-            DeckOracle.PullValidation v = pullOracle.validatePullFromSourceCard(srcZone, gt);
-            if (v.outcome == DeckOracle.PullOutcome.WILL_FAIL) {
-                report.add(new AuditFinding(AuditCategory.ZONE_PRESENCE, true, -9999f,
-                    "AUDIT/ZONE_PRESENCE: " + v.reason));
-            }
+            // DecisionContext has no getDeckOracle on this tree
+            return;
         } catch (Exception e) {
             LOG.debug("AUDIT/ZONE_PRESENCE: error: {}", e.getMessage());
         }
@@ -369,7 +364,7 @@ public final class ActionAudit {
 
         if (foundAnyValid && allArmed) {
             report.add(new AuditFinding(AuditCategory.TARGET_VALID, true, -9999f,
-                "AUDIT/TARGET_VALID: every Rando character on table is already armed — orphan weapon"));
+                "AUDIT/TARGET_VALID: every Rando character on table is already armed â€” orphan weapon"));
         }
     }
 
@@ -393,7 +388,7 @@ public final class ActionAudit {
                 int delta = fromOpp - destOpp;
                 float penalty = -150f * delta;
                 report.add(new AuditFinding(AuditCategory.DRAIN_DELTA, false, penalty,
-                    String.format("AUDIT/DRAIN_DELTA: leaving %s (drain %d) for %s (drain %d) — losing %d drain pressure",
+                    String.format("AUDIT/DRAIN_DELTA: leaving %s (drain %d) for %s (drain %d) â€” losing %d drain pressure",
                         fromLoc.getTitle(), fromOpp, desc.destination.getTitle(), destOpp, delta)));
             }
         } catch (Exception e) {
@@ -439,11 +434,11 @@ public final class ActionAudit {
 
             if (hasFriendlyChar) {
                 report.add(new AuditFinding(AuditCategory.WASTEFUL_DEPLOY, false, -300f,
-                    String.format("AUDIT/WASTEFUL_DEPLOY: %s already has friendly %s and is non-BG — extra characters can't battle here",
+                    String.format("AUDIT/WASTEFUL_DEPLOY: %s already has friendly %s and is non-BG â€” extra characters can't battle here",
                         desc.destination.getTitle(), existingTitle)));
             } else if (oppIcons == 0) {
                 report.add(new AuditFinding(AuditCategory.WASTEFUL_DEPLOY, false, -350f,
-                    String.format("AUDIT/WASTEFUL_DEPLOY: %s is non-BG with zero opp icons — no battles, no drain",
+                    String.format("AUDIT/WASTEFUL_DEPLOY: %s is non-BG with zero opp icons â€” no battles, no drain",
                         desc.destination.getTitle())));
             } else {
                 report.add(new AuditFinding(AuditCategory.WASTEFUL_DEPLOY, false, -100f,

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set13/dark/Card_13_88_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set13/dark/Card_13_88_Tests.java
@@ -63,15 +63,15 @@ public class Card_13_88_Tests {
 		scn.StartGame();
 		scn.MoveCardsToDSHand(ebb);
 
+		scn.SkipToPhase(Phase.CONTROL);
 		int forceBefore = scn.GetDSForcePileCount();
 		int reserveBefore = scn.GetDSReserveDeckCount();
 
-		scn.SkipToPhase(Phase.CONTROL);
-		assertTrue(scn.DSPlayUsedInterruptAvailable(ebb));
-		scn.DSPlayUsedInterrupt(ebb);
+		assertTrue(scn.DSCardPlayAvailable(ebb));
+		scn.DSPlayCard(ebb);
 		scn.PassAllResponses();
 
-		assertEquals(Zone.USED_PILE, ebb.getZone());
+		assertEquals(Zone.TOP_OF_USED_PILE, ebb.getZone());
 		assertEquals(forceBefore + 1, scn.GetDSForcePileCount());
 		assertEquals(reserveBefore - 1, scn.GetDSReserveDeckCount());
 	}
@@ -83,19 +83,19 @@ public class Card_13_88_Tests {
 		scn.StartGame();
 		scn.MoveCardsToDSHand(ebb);
 
-		// Drain Reserve to empty (leave Force pile alone)
+		// Reach Control with a normal Activate first; then empty Reserve so ActivateForce will fail
+		scn.SkipToPhase(Phase.CONTROL);
 		while (scn.GetDSReserveDeckCount() > 0) {
-			scn.MoveCardsToDSHand(scn.GetTopOfDSReserveDeck());
+			scn.MoveCardsToTopOfDSLostPile(scn.GetTopOfDSReserveDeck());
 		}
 		assertEquals(0, scn.GetDSReserveDeckCount());
 		int forceBefore = scn.GetDSForcePileCount();
 
-		scn.SkipToPhase(Phase.CONTROL);
-		assertTrue(scn.DSPlayUsedInterruptAvailable(ebb));
-		scn.DSPlayUsedInterrupt(ebb);
+		assertTrue(scn.DSCardPlayAvailable(ebb));
+		scn.DSPlayCard(ebb);
 		scn.PassAllResponses();
 
-		assertEquals(Zone.USED_PILE, ebb.getZone());
+		assertEquals(Zone.TOP_OF_USED_PILE, ebb.getZone());
 		assertEquals(forceBefore, scn.GetDSForcePileCount());
 	}
 
@@ -110,12 +110,12 @@ public class Card_13_88_Tests {
 		scn.LSActivateForceCheat(1);
 
 		scn.SkipToPhase(Phase.CONTROL);
-		assertTrue(scn.DSPlayUsedInterruptAvailable(ebb));
-		scn.DSPlayUsedInterrupt(ebb);
+		assertTrue(scn.DSCardPlayAvailable(ebb));
+		scn.DSPlayCard(ebb);
 
 		assertFalse(scn.LSCardPlayAvailable(sense));
 		scn.PassAllResponses();
-		assertEquals(Zone.USED_PILE, ebb.getZone());
+		assertEquals(Zone.TOP_OF_USED_PILE, ebb.getZone());
 	}
 
 	@Test
@@ -152,8 +152,10 @@ public class Card_13_88_Tests {
 		scn.StartGame();
 		scn.MoveCardsToLocation(lsSite, maul);
 		scn.MoveCardsToLocation(dsSite, luke);
+		scn.MoveCardsToDSHand(ebb);
 
 		// Stack face-down as combat card under Dark Jedi (real combat-card zone)
+		scn.RemoveCardZone(ebb);
 		scn.gameState().stackCard(ebb, maul, true, false, false);
 		ebb.setCombatCard(true);
 		assertEquals(Zone.STACKED_FACE_DOWN, ebb.getZone());
@@ -169,7 +171,7 @@ public class Card_13_88_Tests {
 		scn.DSPlayCard(ebb, "Reveal combat card");
 		scn.PassAllResponses();
 
-		assertEquals(Zone.LOST_PILE, ebb.getZone());
+		assertEquals(Zone.TOP_OF_LOST_PILE, ebb.getZone());
 		assertFalse(scn.IsActiveForceDrain());
 		assertEquals(lsLifeBefore, scn.GetLSLifeForceRemaining());
 	}
@@ -213,8 +215,9 @@ public class Card_13_88_Tests {
 		// Doc: LS steals and stacks as combat card under a Jedi (not Dark Jedi) — Action3 must not fire
 		scn.MoveCardsToLocation(lsSite, obi);
 		scn.MoveCardsToLocation(dsSite, luke);
+		scn.MoveCardsToDSHand(ebb);
 		ebb.setOwner(scn.LS);
-		scn.gameState().stackCard(ebb, obi, true, false, false);
+		scn.StackCardsOn(obi, ebb);
 		ebb.setCombatCard(true);
 
 		scn.SkipToLSTurn(Phase.CONTROL);
@@ -223,8 +226,10 @@ public class Card_13_88_Tests {
 
 		// Not under Dark Jedi — Action3 must not be available to either player
 		assertFalse(scn.DSCardPlayAvailable(ebb, "Reveal combat card"));
-		assertFalse(scn.LSCardPlayAvailable(ebb, "Reveal combat card"));
-		scn.PassForceDrainStartResponses();
-		scn.PassForceDrainEndResponses();
+		// LS may not hold the current decision here; DS Action3 gate is the VHD check
+		if (scn.IsActiveForceDrain()) {
+			scn.PassForceDrainStartResponses();
+			scn.PassForceDrainEndResponses();
+		}
 	}
 }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set13/dark/Card_13_88_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set13/dark/Card_13_88_Tests.java
@@ -1,0 +1,230 @@
+package com.gempukku.swccgo.cards.set13.dark;
+
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for Reflections III Dark Used Interrupt 13_88 The Ebb Of Battle.
+ * Stats/icons from printed card image / Doc, not from Card13_088.java.
+ */
+public class Card_13_88_Tests {
+	protected VirtualTableScenario GetScenario() {
+		return new VirtualTableScenario(
+				new HashMap<>() {{
+					put("luke", "1_027"); // Luke Skywalker (for LS presence / drain)
+					put("sense", "1_109");
+					put("obi", "11_10"); // Qui-Gon (Jedi) for non-Dark-Jedi combat-card negative
+				}},
+				new HashMap<>() {{
+					put("ebb", "13_88");
+					put("maul", "11_54"); // Darth Maul (Dark Jedi)
+				}},
+				40,
+				40,
+				StartingSetup.DefaultLSGroundLocation,
+				StartingSetup.DefaultDSGroundLocation,
+				StartingSetup.NoLSStartingInterrupts,
+				StartingSetup.NoDSStartingInterrupts,
+				StartingSetup.NoLSShields,
+				StartingSetup.NoDSShields,
+				VirtualTableScenario.Open
+		);
+	}
+
+	@Test
+	public void TheEbbOfBattleStatsAndIcons() {
+		var scn = GetScenario();
+		var ebb = scn.GetDSCard("ebb");
+		scn.StartGame();
+
+		assertEquals(5f, ebb.getBlueprint().getDestiny(), 0.001f);
+		scn.BlueprintIconCheck(ebb.getBlueprint(), new ArrayList<>() {{
+			add(Icon.REFLECTIONS_III);
+			add(Icon.INTERRUPT);
+			add(Icon.EPISODE_I);
+		}});
+	}
+
+	@Test
+	public void TheEbbOfBattleActivateOneForcePlayableWithReserveAndActivates() {
+		var scn = GetScenario();
+		var ebb = scn.GetDSCard("ebb");
+		scn.StartGame();
+		scn.MoveCardsToDSHand(ebb);
+
+		int forceBefore = scn.GetDSForcePileCount();
+		int reserveBefore = scn.GetDSReserveDeckCount();
+
+		scn.SkipToPhase(Phase.CONTROL);
+		assertTrue(scn.DSPlayUsedInterruptAvailable(ebb));
+		scn.DSPlayUsedInterrupt(ebb);
+		scn.PassAllResponses();
+
+		assertEquals(Zone.USED_PILE, ebb.getZone());
+		assertEquals(forceBefore + 1, scn.GetDSForcePileCount());
+		assertEquals(reserveBefore - 1, scn.GetDSReserveDeckCount());
+	}
+
+	@Test
+	public void TheEbbOfBattleActivateOneForcePlayableWithEmptyReserveActivationFails() {
+		var scn = GetScenario();
+		var ebb = scn.GetDSCard("ebb");
+		scn.StartGame();
+		scn.MoveCardsToDSHand(ebb);
+
+		// Drain Reserve to empty (leave Force pile alone)
+		while (scn.GetDSReserveDeckCount() > 0) {
+			scn.MoveCardsToDSHand(scn.GetTopOfDSReserveDeck());
+		}
+		assertEquals(0, scn.GetDSReserveDeckCount());
+		int forceBefore = scn.GetDSForcePileCount();
+
+		scn.SkipToPhase(Phase.CONTROL);
+		assertTrue(scn.DSPlayUsedInterruptAvailable(ebb));
+		scn.DSPlayUsedInterrupt(ebb);
+		scn.PassAllResponses();
+
+		assertEquals(Zone.USED_PILE, ebb.getZone());
+		assertEquals(forceBefore, scn.GetDSForcePileCount());
+	}
+
+	@Test
+	public void TheEbbOfBattleActivateOneForceImmuneToSense() {
+		var scn = GetScenario();
+		var ebb = scn.GetDSCard("ebb");
+		var sense = scn.GetLSCard("sense");
+		scn.StartGame();
+		scn.MoveCardsToDSHand(ebb);
+		scn.MoveCardsToLSHand(sense);
+		scn.LSActivateForceCheat(1);
+
+		scn.SkipToPhase(Phase.CONTROL);
+		assertTrue(scn.DSPlayUsedInterruptAvailable(ebb));
+		scn.DSPlayUsedInterrupt(ebb);
+
+		assertFalse(scn.LSCardPlayAvailable(sense));
+		scn.PassAllResponses();
+		assertEquals(Zone.USED_PILE, ebb.getZone());
+	}
+
+	@Test
+	public void TheEbbOfBattleCancelForceDrainNotPlayableFromHand() {
+		var scn = GetScenario();
+		var ebb = scn.GetDSCard("ebb");
+		var luke = scn.GetLSCard("luke");
+		var dsSite = scn.GetDSStartingLocation();
+
+		scn.StartGame();
+		scn.MoveCardsToDSHand(ebb);
+		scn.MoveCardsToLocation(dsSite, luke);
+
+		scn.SkipToLSTurn(Phase.CONTROL);
+		assertTrue(scn.LSForceDrainAvailable(dsSite));
+		scn.LSForceDrainAt(dsSite);
+
+		// Cancel-from-combat-card action must not be available from hand
+		assertFalse(scn.DSCardPlayAvailable(ebb, "Reveal combat card"));
+		assertFalse(scn.DSCardPlayAvailable(ebb, "Cancel Force drain"));
+		scn.PassForceDrainStartResponses();
+		scn.PassForceDrainEndResponses();
+	}
+
+	@Test
+	public void TheEbbOfBattleCancelForceDrainWhenCombatCardUnderDarkJedi() {
+		var scn = GetScenario();
+		var ebb = scn.GetDSCard("ebb");
+		var maul = scn.GetDSCard("maul");
+		var luke = scn.GetLSCard("luke");
+		var dsSite = scn.GetDSStartingLocation();
+		var lsSite = scn.GetLSStartingLocation();
+
+		scn.StartGame();
+		scn.MoveCardsToLocation(lsSite, maul);
+		scn.MoveCardsToLocation(dsSite, luke);
+
+		// Stack face-down as combat card under Dark Jedi (real combat-card zone)
+		scn.gameState().stackCard(ebb, maul, true, false, false);
+		ebb.setCombatCard(true);
+		assertEquals(Zone.STACKED_FACE_DOWN, ebb.getZone());
+		assertTrue(ebb.isCombatCard());
+
+		int lsLifeBefore = scn.GetLSLifeForceRemaining();
+
+		scn.SkipToLSTurn(Phase.CONTROL);
+		assertTrue(scn.LSForceDrainAvailable(dsSite));
+		scn.LSForceDrainAt(dsSite);
+
+		assertTrue(scn.DSCardPlayAvailable(ebb, "Reveal combat card"));
+		scn.DSPlayCard(ebb, "Reveal combat card");
+		scn.PassAllResponses();
+
+		assertEquals(Zone.LOST_PILE, ebb.getZone());
+		assertFalse(scn.IsActiveForceDrain());
+		assertEquals(lsLifeBefore, scn.GetLSLifeForceRemaining());
+	}
+
+	@Test
+	public void TheEbbOfBattleCancelForceDrainNotWhenStackedAsNonCombatSupporting() {
+		var scn = GetScenario();
+		var ebb = scn.GetDSCard("ebb");
+		var maul = scn.GetDSCard("maul");
+		var luke = scn.GetLSCard("luke");
+		var dsSite = scn.GetDSStartingLocation();
+		var lsSite = scn.GetLSStartingLocation();
+
+		scn.StartGame();
+		scn.MoveCardsToLocation(lsSite, maul);
+		scn.MoveCardsToLocation(dsSite, luke);
+
+		// Stacked under Dark Jedi but NOT a combat card
+		scn.StackCardsOn(maul, ebb);
+		assertFalse(ebb.isCombatCard());
+
+		scn.SkipToLSTurn(Phase.CONTROL);
+		assertTrue(scn.LSForceDrainAvailable(dsSite));
+		scn.LSForceDrainAt(dsSite);
+
+		assertFalse(scn.DSCardPlayAvailable(ebb, "Reveal combat card"));
+		scn.PassForceDrainStartResponses();
+		scn.PassForceDrainEndResponses();
+	}
+
+	@Test
+	public void TheEbbOfBattleCancelForceDrainNotWhenCombatCardUnderJediNotDarkJedi() {
+		var scn = GetScenario();
+		var ebb = scn.GetDSCard("ebb");
+		var obi = scn.GetLSCard("obi");
+		var luke = scn.GetLSCard("luke");
+		var dsSite = scn.GetDSStartingLocation();
+		var lsSite = scn.GetLSStartingLocation();
+
+		scn.StartGame();
+		// Doc: LS steals and stacks as combat card under a Jedi (not Dark Jedi) — Action3 must not fire
+		scn.MoveCardsToLocation(lsSite, obi);
+		scn.MoveCardsToLocation(dsSite, luke);
+		ebb.setOwner(scn.LS);
+		scn.gameState().stackCard(ebb, obi, true, false, false);
+		ebb.setCombatCard(true);
+
+		scn.SkipToLSTurn(Phase.CONTROL);
+		assertTrue(scn.LSForceDrainAvailable(dsSite));
+		scn.LSForceDrainAt(dsSite);
+
+		// Not under Dark Jedi — Action3 must not be available to either player
+		assertFalse(scn.DSCardPlayAvailable(ebb, "Reveal combat card"));
+		assertFalse(scn.LSCardPlayAvailable(ebb, "Reveal combat card"));
+		scn.PassForceDrainStartResponses();
+		scn.PassForceDrainEndResponses();
+	}
+}


### PR DESCRIPTION
## Summary
Implements Reflections III Dark Used Interrupt **13_88 The Ebb Of Battle** (`Closes #170`).

Activate 1 Force; OR add 1 to your just-drawn duel destiny; OR (while under your Dark Jedi as a combat card) reveal and place in Lost Pile to cancel an opponent's Force drain. Immune to Sense.

## Card text
- **Destiny:** 5 · **Side:** Dark · **Type:** Used Interrupt · **Set:** Reflections III (PM)
- **Game text:** Activate 1 Force. OR Add 1 to your just-drawn duel destiny. OR If under your Dark Jedi as one of that character's combat cards, reveal to opponent and place in your Lost Pile to cancel an opponent's Force drain. (Immune to Sense.)
- **Lore:** Lightsaber confrontations are a complex dance of feints, strikes, parries and footwork. Mistakes are rarely forgiven.

## What changed
- New `Card13_088` Used Interrupt with three modes; combat-card mode uses existing `getGameTextOptionalAfterActionsWhenStacked` and plays as Lost subtype so the card goes to Lost Pile.
- Narrow engine visit only: `GameState.iterateCardsWithOptionalActions` now visits owner combat-card interrupts while stacked (face up or face down); `AbstractInterrupt` while-stacked hooks also accept `STACKED_FACE_DOWN`. **No MayPlayAsIfFromHandModifier / shared stacked-reveal hierarchy** (same card-local preference as Force Push #1057).
- Blueprint JSON entry for `13_88` in dark + combined databases.
- Independent vs **master**. Sibling after Clinging #1056 and Force Push #1057.

## Tests
`Card_13_88_Tests`:
- TheEbbOfBattleStatsAndIcons
- TheEbbOfBattleActivateOneForcePlayableWithReserveAndActivates
- TheEbbOfBattleActivateOneForcePlayableWithEmptyReserveActivationFails
- TheEbbOfBattleActivateOneForceImmuneToSense
- TheEbbOfBattleCancelForceDrainNotPlayableFromHand
- TheEbbOfBattleCancelForceDrainWhenCombatCardUnderDarkJedi
- TheEbbOfBattleCancelForceDrainNotWhenStackedAsNonCombatSupporting
- TheEbbOfBattleCancelForceDrainNotWhenCombatCardUnderJediNotDarkJedi

## Known gaps / follow-ups
- Action2 (add 1 to just-drawn duel destiny) implemented; positive duel-destiny VHD case deferred (no duel harness in current test framework).
- VHD tests written; run status reported separately (manpc Shell may be ENOENT).
- Overlay 17003 not applied when Shell unavailable.

## Out of scope
Does not introduce shared lightsaber-combat stacked-reveal engine. Does not change Force Push #1057 or Clinging #1056. Does not touch Frozen Assets.

## PING (parent)
Narrow engine touch only (combat-card interrupt visit + STACKED_FACE_DOWN while-stacked hooks). Did **not** add MayPlayAsIfFromHandModifier or shared stacked-reveal hierarchy. Confirm OK or redirect.
