### PR TITLE
14_71 3B3-21 reveal/deploy battle droids (Closes #171)

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set14/dark/Card14_071.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set14/dark/Card14_071.java
@@ -1,0 +1,87 @@
+package com.gempukku.swccgo.cards.set14.dark;
+
+import com.gempukku.swccgo.cards.AbstractDroid;
+import com.gempukku.swccgo.cards.GameConditions;
+import com.gempukku.swccgo.cards.effects.RevealTopCardsOfReserveDeckEffect;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Keyword;
+import com.gempukku.swccgo.common.ModelType;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.logic.TriggerConditions;
+import com.gempukku.swccgo.logic.actions.OptionalGameTextTriggerAction;
+import com.gempukku.swccgo.logic.decisions.DecisionResultInvalidException;
+import com.gempukku.swccgo.logic.decisions.IntegerAwaitingDecision;
+import com.gempukku.swccgo.logic.effects.PlayoutDecisionEffect;
+import com.gempukku.swccgo.logic.effects.UseForceEffect;
+import com.gempukku.swccgo.logic.effects.choose.DeployCardsFromReserveDeckAndLoseTheRestEffect;
+import com.gempukku.swccgo.logic.timing.EffectResult;
+
+import java.util.Collections;
+import java.util.List;
+
+
+/**
+ * Set: Theed Palace
+ * Type: Character
+ * Subtype: Droid
+ * Title: 3B3-21
+ */
+public class Card14_071 extends AbstractDroid {
+    public Card14_071() {
+        super(Side.DARK, 2, 3, 3, 3, "3B3-21", Uniqueness.UNIQUE, ExpansionSet.THEED_PALACE, Rarity.U);
+        setArmor(4);
+        setLore("Infantry battle droid equipped with command programs to call reinforcements into his patrol zone when needed. Assigned to escort Amidala soon after her capture.");
+        setGameText("If opponent just initiated a battle at same site, may use X Force to reveal the top X cards of your Reserve Deck. (maximum 4). Any battle droids revealed this way may deploy for free; all other cards are lost.");
+        addIcons(Icon.THEED_PALACE, Icon.EPISODE_I, Icon.PRESENCE);
+        addKeywords(Keyword.INFANTRY_BATTLE_DROID);
+        addModelType(ModelType.BATTLE);
+    }
+
+    @Override
+    protected List<OptionalGameTextTriggerAction> getGameTextOptionalAfterTriggers(final String playerId, SwccgGame game, EffectResult effectResult, final PhysicalCard self, int gameTextSourceCardId) {
+        // Check condition(s)
+        if (TriggerConditions.battleInitiatedAt(game, effectResult, game.getOpponent(playerId), Filters.sameSite(self))
+                && GameConditions.hasReserveDeck(game, playerId)) {
+            final int maxX = Math.min(4, Math.min(
+                    GameConditions.forceAvailableToUse(game, playerId),
+                    game.getGameState().getReserveDeckSize(playerId)));
+            if (maxX > 0) {
+
+                final OptionalGameTextTriggerAction action = new OptionalGameTextTriggerAction(self, gameTextSourceCardId);
+                action.setText("Reveal cards from Reserve Deck");
+                // Pay cost(s) — choose X (1..max), use X Force, then reveal X / deploy battle droids / lose rest
+                action.appendCost(
+                        new PlayoutDecisionEffect(action, playerId,
+                                new IntegerAwaitingDecision("Choose amount of Force to use ", 1, maxX, maxX) {
+                                    @Override
+                                    public void decisionMade(final int x) throws DecisionResultInvalidException {
+                                        action.appendCost(
+                                                new UseForceEffect(action, playerId, x));
+                                        action.setActionMsg("Reveal top " + x + " card" + (x == 1 ? "" : "s") + " of Reserve Deck");
+                                        // Perform result(s)
+                                        action.appendEffect(
+                                                new RevealTopCardsOfReserveDeckEffect(action, playerId, x) {
+                                                    @Override
+                                                    protected void cardsRevealed(List<PhysicalCard> cards) {
+                                                        action.appendEffect(
+                                                                new DeployCardsFromReserveDeckAndLoseTheRestEffect(action, cards,
+                                                                        Filters.battle_droid, true));
+                                                    }
+                                                }
+                                        );
+                                    }
+                                }
+                        )
+                );
+                return Collections.singletonList(action);
+            }
+        }
+        return null;
+    }
+}

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "cardId": "101_1",
     "title": "Death Star: Level 6 Core Shaft Corridor",
@@ -50,7 +50,7 @@
       "REBEL"
     ],
     "lore": "Raised by guardians Owen and Beru Lars on a moisture farm on Tatooine, where Owen wanted him to stay. Nicknamed 'Wormie' by childhood friends Camie and Fixer.",
-    "gameText": "Must deploy on Tatooine, but may move elsewhere. May not be deployed if two or more of opponent's unique (â€¢) characters on table. Your warriors at same site as Luke, or adjacent sites are forfeit +1.",
+    "gameText": "Must deploy on Tatooine, but may move elsewhere. May not be deployed if two or more of opponent's unique (•) characters on table. Your warriors at same site as Luke, or adjacent sites are forfeit +1.",
     "deployCost": 4,
     "destiny": 1,
     "power": 2,
@@ -147,7 +147,7 @@
       "IMPERIAL"
     ],
     "lore": "Sought to extinguish all Jedi. Former student of Obi-Wan Kenobi. Seduced by the dark side of the Force.",
-    "gameText": "Must deploy on Death Star, but may move elsewhere. May not be deployed if two or more of opponent's unique (â€¢) characters on table. If in a losing battle, draw destiny. If destiny > 4, 'choke' (lose) one Imperial present (your choice).",
+    "gameText": "Must deploy on Death Star, but may move elsewhere. May not be deployed if two or more of opponent's unique (•) characters on table. If in a losing battle, draw destiny. If destiny > 4, 'choke' (lose) one Imperial present (your choice).",
     "deployCost": 7,
     "destiny": 1,
     "power": 4,
@@ -586,7 +586,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "At the Battle of Yavin, Dutch led his squadron of outdated but reliable Y-wings in the first wave of the assault against the Death Star.",
-    "gameText": "May add 1 pilot or passenger. Permanent pilot aboard is â€¢Dutch, who provides ability of 2, adds 2 to power and may draw one battle destiny if not able to otherwise.",
+    "gameText": "May add 1 pilot or passenger. Permanent pilot aboard is •Dutch, who provides ability of 2, adds 2 to power and may draw one battle destiny if not able to otherwise.",
     "deployCost": 5,
     "destiny": 2,
     "power": 2,
@@ -636,7 +636,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Called 'Boss' or 'Chief' by his squadron, Garven Dreis was the first pilot to fire proton torpedoes at the Death Star's exhaust port during the Battle of Yavin.",
-    "gameText": "Permanent pilot aboard is â€¢Red Leader, who provides ability of 2, adds 2 to power and may draw one battle destiny if not able to otherwise.",
+    "gameText": "Permanent pilot aboard is •Red Leader, who provides ability of 2, adds 2 to power and may draw one battle destiny if not able to otherwise.",
     "deployCost": 6,
     "destiny": 2,
     "power": 3,
@@ -685,7 +685,7 @@
       "REBEL"
     ],
     "lore": "Loyal Wookiee companion of Captain Han Solo. Co-pilot of the Millennium Falcon. Leia referred to him as a 'walking carpet.'",
-    "gameText": "Must deploy on Hoth, but may move elsewhere. May not be deployed if three or more of opponent's unique (â€¢) characters on table.",
+    "gameText": "Must deploy on Hoth, but may move elsewhere. May not be deployed if three or more of opponent's unique (•) characters on table.",
     "deployCost": 5,
     "destiny": 1,
     "power": 4,
@@ -887,7 +887,7 @@
       "IMPERIAL"
     ],
     "lore": "General of the AT-AT assault armor division sent by Darth Vader to crush the Rebellion on Hoth. Cold and ruthless.",
-    "gameText": "Must deploy on Hoth, but may move elsewhere. May not be deployed if three or more of opponent's unique (â€¢) characters on table. Snowtroopers at same site are forfeit +1.",
+    "gameText": "Must deploy on Hoth, but may move elsewhere. May not be deployed if three or more of opponent's unique (•) characters on table. Snowtroopers at same site are forfeit +1.",
     "deployCost": 4,
     "destiny": 1,
     "power": 2,
@@ -1134,7 +1134,7 @@
     ],
     "cardSubtype": "SQUADRON",
     "lore": "Notoriety gained during the assaults on Ralltiir and Mon Calamari makes this the most feared squadron in the Empire. Defended the Death Star during the Battle of Yavin.",
-    "gameText": "Permanent pilots aboard are â€¢Darth Vader, â€¢DS-61-2 and â€¢DS-61-3, who provide total ability of 10 and add 9 to total power of â€¢Vader's Custom TIE, â€¢Black 2 and â€¢Black 3.",
+    "gameText": "Permanent pilots aboard are •Darth Vader, •DS-61-2 and •DS-61-3, who provide total ability of 10 and add 9 to total power of •Vader's Custom TIE, •Black 2 and •Black 3.",
     "deployCost": 12,
     "destiny": 1,
     "power": 3,
@@ -2179,7 +2179,7 @@
       "REBEL"
     ],
     "lore": "Scoundrel, smuggler, gambler and risk taker. 'Everything's going to be fine. Trust me.'",
-    "gameText": "Adds 3 to power of anything he pilots. Adds one battle destiny if with Luke or Chewie. Permanent weapon is â€¢Han's Heavy Blaster Pistol (may target a character or creature for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value).",
+    "gameText": "Adds 3 to power of anything he pilots. Adds one battle destiny if with Luke or Chewie. Permanent weapon is •Han's Heavy Blaster Pistol (may target a character or creature for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value).",
     "deployCost": 4,
     "destiny": 1,
     "power": 4,
@@ -2232,7 +2232,7 @@
       "REBEL"
     ],
     "lore": "Spirited leader. 'I am not a committee!'",
-    "gameText": "Adds 1 to power of anything she pilots. Adds one battle destiny if with Han. Permanent weapon is â€¢Leia's Blaster Rifle (may target a character or creature for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value).",
+    "gameText": "Adds 1 to power of anything she pilots. Adds one battle destiny if with Han. Permanent weapon is •Leia's Blaster Rifle (may target a character or creature for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value).",
     "deployCost": 4,
     "destiny": 1,
     "power": 3,
@@ -2285,7 +2285,7 @@
       "REBEL"
     ],
     "lore": "'I've taken care of everything.'",
-    "gameText": "Adds 2 to power of anything he pilots. Permanent weapon is â€¢Luke's Lightsaber (may target a character or creature for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
+    "gameText": "Adds 2 to power of anything he pilots. Permanent weapon is •Luke's Lightsaber (may target a character or creature for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
     "deployCost": 5,
     "destiny": 1,
     "power": 5,
@@ -2333,7 +2333,7 @@
       "REBEL"
     ],
     "lore": "'The Force will be with you... always.'",
-    "gameText": "Permanent weapon is â€¢Obi-Wan's Lightsaber (may target a character or creature for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
+    "gameText": "Permanent weapon is •Obi-Wan's Lightsaber (may target a character or creature for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
     "deployCost": 5,
     "destiny": 1,
     "power": 5,
@@ -2377,7 +2377,7 @@
       "ALIEN"
     ],
     "lore": "Notorious bounty hunter. 'As you wish.'",
-    "gameText": "Adds 3 to power of anything he pilots. Adds one battle destiny if with Han or Jabba. Permanent weapon is â€¢Boba Fett's Blaster Rifle (may target a character or creature for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value).",
+    "gameText": "Adds 3 to power of anything he pilots. Adds one battle destiny if with Han or Jabba. Permanent weapon is •Boba Fett's Blaster Rifle (may target a character or creature for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value).",
     "deployCost": 5,
     "destiny": 1,
     "power": 4,
@@ -2429,7 +2429,7 @@
       "IMPERIAL"
     ],
     "lore": "'If you only knew the power of the dark side.'",
-    "gameText": "Adds 3 to power of anything he pilots. Permanent weapon is â€¢Vader's Lightsaber (may target a character or creature for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
+    "gameText": "Adds 3 to power of anything he pilots. Permanent weapon is •Vader's Lightsaber (may target a character or creature for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
     "deployCost": 6,
     "destiny": 1,
     "power": 6,
@@ -2530,7 +2530,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Corellian starfighter. Dengar replaced its passenger capacity and TIE cannons with enhanced targeting systems. Allows Dengar to track and engage multiple enemies at once.",
-    "gameText": "Permanent pilot is â€¢Dengar, who provides ability of 2 and adds 2 to power. When in battle, adds 1 to total battle destiny for each opponent's starship present. Cancels opponent's immunity to attrition here.",
+    "gameText": "Permanent pilot is •Dengar, who provides ability of 2 and adds 2 to power. When in battle, adds 1 to total battle destiny for each opponent's starship present. Cancels opponent's immunity to attrition here.",
     "deployCost": 5,
     "destiny": 1,
     "power": 2,
@@ -2687,7 +2687,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Heavily modified Corellian YT-1300 freighter. 'She's the fastest hunk of junk in the galaxy.'",
-    "gameText": "May add 1 pilot and 2 passengers. Permanent pilot is â€¢Lando, who provides ability of 3 and adds 3 to power. May not be piloted by Han unless he won a hand of sabacc this game. Immune to attrition < 5.",
+    "gameText": "May add 1 pilot and 2 passengers. Permanent pilot is •Lando, who provides ability of 3 and adds 3 to power. May not be piloted by Han unless he won a hand of sabacc this game. Immune to attrition < 5.",
     "deployCost": 5,
     "destiny": 2,
     "power": 3,
@@ -2900,7 +2900,7 @@
       "DROID"
     ],
     "lore": "Accomplished thief and information broker. Modified by Jabba to be an effective bounty hunter. The Hutt often teams 4-LOM with other hired killers.",
-    "gameText": "Adds one battle destiny if with Jabba or Zuckuss. Permanent weapon is â€¢4-LOM's Concussion Rifle (may target a character for free; target may not use its game text for remainder of turn).",
+    "gameText": "Adds one battle destiny if with Jabba or Zuckuss. Permanent weapon is •4-LOM's Concussion Rifle (may target a character for free; target may not use its game text for remainder of turn).",
     "deployCost": 3,
     "destiny": 3,
     "power": 2,
@@ -2982,7 +2982,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Dangerous and deadly starfighter piloted by its notorious owner. Uses combat-grade shields and sensors. Hidden weapons provide lethal surprises for Fett's victims.",
-    "gameText": "May add 3 passengers. Permanent pilot is â€¢Boba Fett, who provides ability of 3, adds 3 to power, adds 2 to maneuver and draws one battle destiny if not able to otherwise. Immune to attrition < 5.",
+    "gameText": "May add 3 passengers. Permanent pilot is •Boba Fett, who provides ability of 3, adds 3 to power, adds 2 to maneuver and draws one battle destiny if not able to otherwise. Immune to attrition < 5.",
     "deployCost": 7,
     "destiny": 1,
     "power": 4,
@@ -3276,7 +3276,7 @@
       "DEVICE"
     ],
     "lore": "Written by Obi-Wan Kenobi. Used by Luke to construct his lightsaber. Contained instructions on building required tools as well. Keyed to self-destruct if not opened by Luke.",
-    "gameText": "Deploy on Luke or Obi-Wan. Your characters present armed with a unique (â€¢) lightsaber Weapon card may not be Disarmed, once per battle may cancel a weapon destiny just drawn, and that lightsaber's Force drain modifiers may not be canceled. Lost if about to be stolen.",
+    "gameText": "Deploy on Luke or Obi-Wan. Your characters present armed with a unique (•) lightsaber Weapon card may not be Disarmed, once per battle may cancel a weapon destiny just drawn, and that lightsaber's Force drain modifiers may not be canceled. Lost if about to be stolen.",
     "destiny": 2,
     "icons": [
       {
@@ -3501,7 +3501,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Owned by legendary Terrik family of smugglers. Used to chase down the pirates who killed Wedge's parents. On Corellian Security's most wanted list. 37.5 meters long.",
-    "gameText": "May add 2 pilots and 6 passengers. May add ability of your (â€¢) unique smuggler aboard to X on Kessel Run targeting that smuggler. When Booster, Mirax or Wedge piloting, Immune to attrition < 5.",
+    "gameText": "May add 2 pilots and 6 passengers. May add ability of your (•) unique smuggler aboard to X on Kessel Run targeting that smuggler. When Booster, Mirax or Wedge piloting, Immune to attrition < 5.",
     "deployCost": 2,
     "destiny": 2,
     "power": 2,
@@ -5221,7 +5221,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Zuckuss is a dangerous adversary, especially when aboard his own starship. Mystical omens enable the Gand to predict enemy maneuvers in starship combat.",
-    "gameText": "May add 1 pilot and 3 passengers. Permanent pilot is â€¢Zuckuss, who provides ability of 4 and adds 2 to power. Unless opponent has total ability > 6 piloting here, opponent's total battle destiny here = zero.",
+    "gameText": "May add 1 pilot and 3 passengers. Permanent pilot is •Zuckuss, who provides ability of 4 and adds 2 to power. Unless opponent has total ability > 6 piloting here, opponent's total battle destiny here = zero.",
     "deployCost": 6,
     "destiny": 1,
     "power": 2,
@@ -5411,7 +5411,7 @@
       "ALIEN"
     ],
     "lore": "Trandoshan bounty hunter. Modified his mortar gun to fire stun cartridges for live captures. Uses non-fragmentary capture rounds to minimize collateral damage.",
-    "gameText": "Adds 2 to power of anything he pilots. Permanent weapon is â€¢Bossk's Mortar Gun (may fire for free; draw destiny; may subtract or add 1 if at same site as a bounty; choose one character with that destiny number present to be captured.)",
+    "gameText": "Adds 2 to power of anything he pilots. Permanent weapon is •Bossk's Mortar Gun (may fire for free; draw destiny; may subtract or add 1 if at same site as a bounty; choose one character with that destiny number present to be captured.)",
     "deployCost": 5,
     "destiny": 1,
     "power": 4,
@@ -5514,7 +5514,7 @@
       "ALIEN"
     ],
     "lore": "Corellian bounty hunter. Skilled athlete. Expert shot. Has worked many times for Jabba the Hutt. Carries a long-standing grudge against Han Solo.",
-    "gameText": "Adds 2 to the power of anything he pilots. Permanent weapon is â€¢Dengar's Blaster Carbine (may target a character, creature or vehicle for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value; may be fired twice per battle).",
+    "gameText": "Adds 2 to the power of anything he pilots. Permanent weapon is •Dengar's Blaster Carbine (may target a character, creature or vehicle for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value; may be fired twice per battle).",
     "deployCost": 5,
     "destiny": 2,
     "power": 3,
@@ -5567,7 +5567,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Starship adapted to the assassin droid's specifications. Flight controls linked directly to processing unit. Real-time relays minimize response time.",
-    "gameText": "May add 2 passengers. Permanent pilot is â€¢IG-88, who adds 2 to power and 3 to maneuver. May initiate battle. When in a battle you initiate, adds one battle destiny. Ion Cannon may deploy aboard.",
+    "gameText": "May add 2 passengers. Permanent pilot is •IG-88, who adds 2 to power and 3 to maneuver. May initiate battle. When in a battle you initiate, adds one battle destiny. Ion Cannon may deploy aboard.",
     "deployCost": 5,
     "destiny": 1,
     "power": 3,
@@ -5919,7 +5919,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "Deploy Hutt Trade Route and a Jabba's Palace site. May deploy Yarna d'al' Gargan. Reveal one unique (â€¢) alien from your deck whose lore specifies its species. This card is your Rep. For remainder of game, your Rep is a leader. Yarna d'al' Gargan is immune to Alter. You may not deploy 'insert' cards or operatives. While a rancor is at Rancor Pit, Trap Door is immune to Bo Shuda. Flip this card if you occupy two battleground sites (must occupy a third with a non-unique alien of your Rep's species if a non-Tatooine location is on table).",
+    "gameText": "Deploy Hutt Trade Route and a Jabba's Palace site. May deploy Yarna d'al' Gargan. Reveal one unique (•) alien from your deck whose lore specifies its species. This card is your Rep. For remainder of game, your Rep is a leader. Yarna d'al' Gargan is immune to Alter. You may not deploy 'insert' cards or operatives. While a rancor is at Rancor Pit, Trap Door is immune to Bo Shuda. Flip this card if you occupy two battleground sites (must occupy a third with a non-unique alien of your Rep's species if a non-Tatooine location is on table).",
     "destiny": 0,
     "icons": [
       {
@@ -6134,7 +6134,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "Deploy Desert Heart and a Jabba's Palace site. May deploy Well Guarded. Reveal one unique (â€¢) alien from your deck whose lore specifies its species. This card is your Rep. For remainder of game, your Rep is a leader. Well Guarded is immune to Alter. You may not deploy 'insert' cards or operatives. While frozen Han on table, Rebels are immune to No Bargain and Bad Feeling Have I. Flip this card if you occupy two battleground sites (must occupy a third with a non-unique alien of your Rep's species if a non-Tatooine location is on table).",
+    "gameText": "Deploy Desert Heart and a Jabba's Palace site. May deploy Well Guarded. Reveal one unique (•) alien from your deck whose lore specifies its species. This card is your Rep. For remainder of game, your Rep is a leader. Well Guarded is immune to Alter. You may not deploy 'insert' cards or operatives. While frozen Han on table, Rebels are immune to No Bargain and Bad Feeling Have I. Flip this card if you occupy two battleground sites (must occupy a third with a non-unique alien of your Rep's species if a non-Tatooine location is on table).",
     "destiny": 0,
     "icons": [
       {
@@ -6188,7 +6188,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Jabba's influence is not easily ignored. Neither are his voracious and vile appetites. Even Jedi soon learn this lesson.",
-    "gameText": "Deploy on table. You may immediately take top card of Lost Pile into hand. Effects, Epic Events, and Objectives are immune to Honor Of The Jedi. At each opponent's â—‡ site, your characters and vehicles are each deploy -3 and your Force generation is +1. (Immune to Alter.)",
+    "gameText": "Deploy on table. You may immediately take top card of Lost Pile into hand. Effects, Epic Events, and Objectives are immune to Honor Of The Jedi. At each opponent's ◇ site, your characters and vehicles are each deploy -3 and your Force generation is +1. (Immune to Alter.)",
     "destiny": 4,
     "icons": [
       {
@@ -6478,7 +6478,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Jabba's decadent behavior makes him susceptible to deception. Leia and Lando exploited this weakness, posing as Jabba's kind of scum.",
-    "gameText": "Deploy on table. You may immediately take top card of Lost Pile into hand. None Shall Pass is unique (â€¢) and a Lost Interrupt. At each opponent's â—‡ site, your characters and vehicles are each deploy -3 and your Force generation is +1. (Immune to Alter.)",
+    "gameText": "Deploy on table. You may immediately take top card of Lost Pile into hand. None Shall Pass is unique (•) and a Lost Interrupt. At each opponent's ◇ site, your characters and vehicles are each deploy -3 and your Force generation is +1. (Immune to Alter.)",
     "destiny": 4,
     "icons": [
       {
@@ -7050,7 +7050,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "With the destruction of the Death Star, the Rebel Alliance received new-found support throughout the galaxy.",
-    "gameText": "Deploy on table. If Death Star 'blown away': Whenever you deploy a unique (â€¢) starship to a system location, retrieve 3 Force; Once per during each of your turns you may deploy (for free) a starship from hand or Reserve Deck and reshuffle. (Immune to Alter.)",
+    "gameText": "Deploy on table. If Death Star 'blown away': Whenever you deploy a unique (•) starship to a system location, retrieve 3 Force; Once per during each of your turns you may deploy (for free) a starship from hand or Reserve Deck and reshuffle. (Immune to Alter.)",
     "destiny": 5,
     "icons": [
       {
@@ -9060,7 +9060,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Tarkin silenced the voices of Alderaan with the power of the Death Star.",
-    "gameText": "Deploy on table. Twice per game may take Commence Primary Ignition into hand from Lost Pile or Reserve Deck; reshuffle. If Alderaan 'blown away,' retrieve 3 Force whenever you deploy a unique (â€¢) Star Destroyer. (Immune to Alter.)",
+    "gameText": "Deploy on table. Twice per game may take Commence Primary Ignition into hand from Lost Pile or Reserve Deck; reshuffle. If Alderaan 'blown away,' retrieve 3 Force whenever you deploy a unique (•) Star Destroyer. (Immune to Alter.)",
     "destiny": 5,
     "icons": [
       {
@@ -11703,7 +11703,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Once begun, the occupation of Naboo was swift, and devastatingly effective.",
-    "gameText": "Deploy on table. Your unique (â€¢) Republicans are forfeit +2 and immune to Goo Nee Tay. Unless Imperial Arrest Order on table, once during your deploy phase, may deploy one docking bay from Reserve Deck; reshuffle. (Immune to Alter.)",
+    "gameText": "Deploy on table. Your unique (•) Republicans are forfeit +2 and immune to Goo Nee Tay. Unless Imperial Arrest Order on table, once during your deploy phase, may deploy one docking bay from Reserve Deck; reshuffle. (Immune to Alter.)",
     "destiny": 4,
     "icons": [
       {
@@ -11735,7 +11735,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Imperial officers are always on the lookout for Rebel espionage.",
-    "gameText": "Deploy on table. Unique (â€¢) Imperials of ability = 3 are forfeit +3. If opponent just retrieved Force using an Interrupt or Utinni Effect, you may place that card here. Opponent's Force retrieval is reduced by X, where X = number of cards here. (Immune to Alter.)",
+    "gameText": "Deploy on table. Unique (•) Imperials of ability = 3 are forfeit +3. If opponent just retrieved Force using an Interrupt or Utinni Effect, you may place that card here. Opponent's Force retrieval is reduced by X, where X = number of cards here. (Immune to Alter.)",
     "destiny": 5,
     "icons": [
       {
@@ -11865,7 +11865,7 @@
       "EFFECT"
     ],
     "cardSubtype": "NORMAL",
-    "gameText": "Deploy on table. Unique (â€¢) Imperials of ability < 3 are forfeit +1. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites only. Once during each of your deploy phases, may deploy one docking bay from Reserve Deck; reshuffle. When opponent retrieves X cards, opponent must first use X Force or that retrieval is canceled. (Immune to Alter.)",
+    "gameText": "Deploy on table. Unique (•) Imperials of ability < 3 are forfeit +1. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites only. Once during each of your deploy phases, may deploy one docking bay from Reserve Deck; reshuffle. When opponent retrieves X cards, opponent must first use X Force or that retrieval is canceled. (Immune to Alter.)",
     "destiny": 5,
     "icons": [
       {
@@ -12551,7 +12551,7 @@
     ],
     "cardSubtype": "USED_OR_STARTING",
     "lore": "'We must move quickly to disrupt all communication down there.'",
-    "gameText": "USED: Use 2 Force to deploy a unique (â€¢) battleground not on table, from Reserve Deck; reshuffle. STARTING: Deploy from your Reserve Deck one Effect which deploys on table (or your side of table) and has no deploy cost; reshuffle. Place Interrupt in Lost Pile.",
+    "gameText": "USED: Use 2 Force to deploy a unique (•) battleground not on table, from Reserve Deck; reshuffle. STARTING: Deploy from your Reserve Deck one Effect which deploys on table (or your side of table) and has no deploy cost; reshuffle. Place Interrupt in Lost Pile.",
     "destiny": 5,
     "icons": [
       {
@@ -12678,7 +12678,7 @@
       "INTERRUPT"
     ],
     "cardSubtype": "USED_OR_LOST",
-    "gameText": "USED: Take one unique (â€¢) unpiloted starfighter into hand from Reserve Deck; reshuffle. LOST: During a battle at a system or sector, if you are about to draw a card for battle destiny, you may instead use the maneuver number of your unique (â€¢) starfighter in that battle.",
+    "gameText": "USED: Take one unique (•) unpiloted starfighter into hand from Reserve Deck; reshuffle. LOST: During a battle at a system or sector, if you are about to draw a card for battle destiny, you may instead use the maneuver number of your unique (•) starfighter in that battle.",
     "destiny": 5,
     "icons": [
       {
@@ -15359,7 +15359,7 @@
       "EFFECT"
     ],
     "cardSubtype": "NORMAL",
-    "gameText": "Deploy on table. Unique (â€¢) Rebels of ability < 3 are forfeit +1. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites only. Once during each of your deploy phases, may deploy one docking bay from Reserve Deck; reshuffle. When opponent retrieves X cards, opponent must first use X Force or that retrieval is canceled. (Immune to Alter.)",
+    "gameText": "Deploy on table. Unique (•) Rebels of ability < 3 are forfeit +1. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites only. Once during each of your deploy phases, may deploy one docking bay from Reserve Deck; reshuffle. When opponent retrieves X cards, opponent must first use X Force or that retrieval is canceled. (Immune to Alter.)",
     "destiny": 5,
     "icons": [
       {
@@ -15455,7 +15455,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Actions borne of the love for one's planet can heavily outweigh those generated from simple battle orders.",
-    "gameText": "Deploy on table. Your unique (â€¢) Republic characters of ability < 4 are forfeit +2. Unless Insurrection on table, once during each of your deploy phases, may deploy one docking bay from Reserve Deck; reshuffle. (Immune to Alter.)",
+    "gameText": "Deploy on table. Your unique (•) Republic characters of ability < 4 are forfeit +2. Unless Insurrection on table, once during each of your deploy phases, may deploy one docking bay from Reserve Deck; reshuffle. (Immune to Alter.)",
     "destiny": 4,
     "icons": [
       {
@@ -15649,7 +15649,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "The Empire, Lando Calrissian, Jabba the Hutt. For Han Solo, it can be very hard to tell when your past is going to catch up with you.",
-    "gameText": "Deploy on table. Unique (â€¢) Rebels of ability = 3 are power and forfeit +1 (or power and forfeit +2 if at a Cloud City or Jabba's Palace site). While Han at a battleground, opponent retrieves no Force from Scum And Villainy. (Immune to Alter.)",
+    "gameText": "Deploy on table. Unique (•) Rebels of ability = 3 are power and forfeit +1 (or power and forfeit +2 if at a Cloud City or Jabba's Palace site). While Han at a battleground, opponent retrieves no Force from Scum And Villainy. (Immune to Alter.)",
     "destiny": 3,
     "icons": [
       {
@@ -15676,7 +15676,7 @@
       "INTERRUPT"
     ],
     "cardSubtype": "USED_OR_LOST",
-    "gameText": "USED: Take one unique (â€¢) unpiloted starfighter into hand from Reserve Deck; reshuffle. LOST: During a battle at a system or sector, if you are about to draw a card for battle destiny, you may instead use the maneuver number of your unique (â€¢) starfighter in that battle.",
+    "gameText": "USED: Take one unique (•) unpiloted starfighter into hand from Reserve Deck; reshuffle. LOST: During a battle at a system or sector, if you are about to draw a card for battle destiny, you may instead use the maneuver number of your unique (•) starfighter in that battle.",
     "destiny": 5,
     "icons": [
       {
@@ -15995,7 +15995,7 @@
     ],
     "cardSubtype": "USED_OR_STARTING",
     "lore": "'But not at the expense of the moment.'",
-    "gameText": "USED: Use 2 Force to deploy a unique (â€¢) battleground not on table, from Reserve Deck; reshuffle. STARTING: Deploy from your Reserve Deck one Effect which deploys on table (or your side of table) and has no deploy cost; reshuffle. Place Interrupt in Lost Pile.",
+    "gameText": "USED: Use 2 Force to deploy a unique (•) battleground not on table, from Reserve Deck; reshuffle. STARTING: Deploy from your Reserve Deck one Effect which deploys on table (or your side of table) and has no deploy cost; reshuffle. Place Interrupt in Lost Pile.",
     "destiny": 5,
     "icons": [
       {
@@ -17158,7 +17158,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "Deploy Watto's Junkyard, City Outskirts, and Credits Will Do Fine. For remainder of game, you may not deploy cards with ability except unique (â€¢) aliens, Republic characters and starships, and [Episode I] Jedi. Your Destiny is suspended. While this side up, once per game may take Coruscant and/or Tatooine system into hand from Reserve Deck; reshuffle. You may not deploy any systems. Maul is immune to attrition. Flip this card if there are 4 or more cards beneath Credits Will Do Fine.",
+    "gameText": "Deploy Watto's Junkyard, City Outskirts, and Credits Will Do Fine. For remainder of game, you may not deploy cards with ability except unique (•) aliens, Republic characters and starships, and [Episode I] Jedi. Your Destiny is suspended. While this side up, once per game may take Coruscant and/or Tatooine system into hand from Reserve Deck; reshuffle. You may not deploy any systems. Maul is immune to attrition. Flip this card if there are 4 or more cards beneath Credits Will Do Fine.",
     "destiny": 0,
     "icons": [
       {
@@ -17188,7 +17188,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "While this side up, your unique (â€¢) Republic characters are power +1 and forfeit +2. Aliens may not have their deploy cost modified and Imperials deploy +1 to Tatooine sites. Whenever you draw battle destiny (unless canceled), may retrieve 1 Force (Force retrieved in this way may be taken into hand.) While Queen's Royal Starship at a planet system, once during each of opponent's control phases may activate up to 2 Force. Once during each of your control phases, opponent loses 1 Force for each battleground site you occupy with a senator.",
+    "gameText": "While this side up, your unique (•) Republic characters are power +1 and forfeit +2. Aliens may not have their deploy cost modified and Imperials deploy +1 to Tatooine sites. Whenever you draw battle destiny (unless canceled), may retrieve 1 Force (Force retrieved in this way may be taken into hand.) While Queen's Royal Starship at a planet system, once during each of opponent's control phases may activate up to 2 Force. Once during each of your control phases, opponent loses 1 Force for each battleground site you occupy with a senator.",
     "destiny": 7,
     "icons": [
       {
@@ -18080,7 +18080,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Although temperamental, this trusty hunk of junk always seems to perform for its proud owner and his Wookiee co-pilot when needed the most.",
-    "gameText": "Permanent pilots are â€¢Han and â€¢Chewie: provide ability of 5, add one battle destiny, and add 5 to power. Immune to attrition < 6, Come With Me, and Lateral Damage. End of your turn: Use 3 Force to maintain OR Place out of play.",
+    "gameText": "Permanent pilots are •Han and •Chewie: provide ability of 5, add one battle destiny, and add 5 to power. Immune to attrition < 6, Come With Me, and Lateral Damage. End of your turn: Use 3 Force to maintain OR Place out of play.",
     "deployCost": 6,
     "destiny": 2,
     "power": 4,
@@ -18721,7 +18721,7 @@
       "DEFENSIVE_SHIELD"
     ],
     "lore": "Jabba's decadent behavior makes him susceptible to deception. Leia and Lando exploited this weakness, posing as Jabba's kind of scum.",
-    "gameText": "Plays on table. At each opponent's â—‡ site, your Rebels are each deploy -2 and your Force generation is +1.",
+    "gameText": "Plays on table. At each opponent's ◇ site, your Rebels are each deploy -2 and your Force generation is +1.",
     "deployCost": 0,
     "destiny": 0,
     "icons": [
@@ -20279,7 +20279,7 @@
       "DEFENSIVE_SHIELD"
     ],
     "lore": "Jabba's influence is not easily ignored. Neither are his voracious and vile appetites. Even Jedi soon learn this lesson.",
-    "gameText": "Plays on table. At opponent's â—‡ site where opponent's creature present, you may deploy without presence or Force icons, and your Force generation there is +1.",
+    "gameText": "Plays on table. At opponent's ◇ site where opponent's creature present, you may deploy without presence or Force icons, and your Force generation there is +1.",
     "deployCost": 0,
     "destiny": 0,
     "icons": [
@@ -23164,7 +23164,7 @@
       "JEDI_MASTER"
     ],
     "lore": "Jedi Master assigned to reveal the mysteries of the Sith. His quest has led him to the planet Naboo",
-    "gameText": "Adds one battle destiny if with Maul. Permanent weapon is â€¢Qui-Gon Jinn's Lightsaber (may target a character or creature for free; draw two destiny; target 'hit,' and its forfeit = 0, if total destiny > defense value).",
+    "gameText": "Adds one battle destiny if with Maul. Permanent weapon is •Qui-Gon Jinn's Lightsaber (may target a character or creature for free; draw two destiny; target 'hit,' and its forfeit = 0, if total destiny > defense value).",
     "deployCost": 7,
     "destiny": 1,
     "power": 6,
@@ -23960,7 +23960,7 @@
     ],
     "cardSubtype": "USED",
     "lore": "'Look! One of ours, out of the main hold!'",
-    "gameText": "Take a unique (â€¢) N-1 starfighter into hand from Reserve Deck; reshuffle. OR If a battle was just initiated at a system where opponent has a droid starfighter, all droid starfighters at that system are power -1 for remainder of turn.",
+    "gameText": "Take a unique (•) N-1 starfighter into hand from Reserve Deck; reshuffle. OR If a battle was just initiated at a system where opponent has a droid starfighter, all droid starfighters at that system are power -1 for remainder of turn.",
     "destiny": 4,
     "icons": [
       {
@@ -25129,7 +25129,7 @@
       "BATTLE"
     ]
   },
-      {
+    {
     "cardId": "14_71",
     "title": "3B3-21",
     "slug": "3b3-21",
@@ -25423,7 +25423,7 @@
       "SITH"
     ],
     "lore": "'Yes, my Master.'",
-    "gameText": "Permanent weapon is â€¢Maul's Double-Bladed Lightsaber (twice per battle, may target a character for free; draw two destiny; target 'hit,' and its forfeit = 0, if total destiny > defense value).",
+    "gameText": "Permanent weapon is •Maul's Double-Bladed Lightsaber (twice per battle, may target a character for free; draw two destiny; target 'hit,' and its forfeit = 0, if total destiny > defense value).",
     "deployCost": 7,
     "destiny": 1,
     "power": 7,
@@ -29728,7 +29728,7 @@
       "ALIEN"
     ],
     "lore": "Female H'nemthe, a species whose females ritually kill their mates. Stranded on Tatooine due to questionable passage tax. Razor-sharp tongue. M'iiyoom means, 'nightlilly'.",
-    "gameText": "Once during each of your control phases, may reveal opponent's hand by using X Force, where X = number of cards in opponent's hand. All unique (â€¢) male Rebels and unique (â€¢) male aliens there are lost.",
+    "gameText": "Once during each of your control phases, may reveal opponent's hand by using X Force, where X = number of cards in opponent's hand. All unique (•) male Rebels and unique (•) male aliens there are lost.",
     "deployCost": 3,
     "destiny": 3,
     "power": 1,
@@ -36175,7 +36175,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Aratech Corporation sent support staff to various Imperial outposts and garrisons. Gave advanced briefings and training to biker scout personnel.",
-    "gameText": "Deploy on table. AT-STs and speeder bikes are power and forfeit +1. During your deploy phase, may reveal an AT-ST or Speeder Bike from hand to [upload] a unique (â€¢) [Endor] Imperial pilot of ability < 3 (or vice versa) and deploy both simultaneously. (Immune to Alter.)",
+    "gameText": "Deploy on table. AT-STs and speeder bikes are power and forfeit +1. During your deploy phase, may reveal an AT-ST or Speeder Bike from hand to [upload] a unique (•) [Endor] Imperial pilot of ability < 3 (or vice versa) and deploy both simultaneously. (Immune to Alter.)",
     "destiny": 4,
     "icons": [
       {
@@ -36237,7 +36237,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Being stationed at Endor during the construction of the second Death Star allows Imperial pilots time to train in the latest starfighter combat techniques.",
-    "gameText": "Deploy on table. Tallon Roll is canceled. Once per turn, may reveal an unpiloted starfighter from hand to [upload] its matching pilot character (or vice versa) and deploy both simultaneously. Your unique (â€¢) TIEs (except Scythe Squadron TIEs) at systems may use 1 Force to relocate (as a regular move) to system within 3 parsecs. [Immune to Alter]",
+    "gameText": "Deploy on table. Tallon Roll is canceled. Once per turn, may reveal an unpiloted starfighter from hand to [upload] its matching pilot character (or vice versa) and deploy both simultaneously. Your unique (•) TIEs (except Scythe Squadron TIEs) at systems may use 1 Force to relocate (as a regular move) to system within 3 parsecs. [Immune to Alter]",
     "destiny": 5,
     "icons": [
       {
@@ -36483,7 +36483,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Company that produces current generation of Star Destroyers, as well as Nebulon-B Frigates. Ship yards are extremely well defended.",
-    "gameText": "Deploy on table. Unique (â€¢) Imperial-class Star Destroyers draw one battle destiny if unable to otherwise and are immune to attrition < 4. During your deploy phase, may use 2 Force to [download] a battleground system. We're In Attack Position Now is canceled. Immune to Alter.",
+    "gameText": "Deploy on table. Unique (•) Imperial-class Star Destroyers draw one battle destiny if unable to otherwise and are immune to attrition < 4. During your deploy phase, may use 2 Force to [download] a battleground system. We're In Attack Position Now is canceled. Immune to Alter.",
     "destiny": 3,
     "icons": [
       {
@@ -37273,7 +37273,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Dangerous and deadly starfighter piloted by its notorious owner. Uses combat-grade shields and sensors. Hidden weapons provide lethal surprises for Fett's victims.",
-    "gameText": "Permanent pilot is â€¢Boba Fett, who provides ability of 3. Draws one battle destiny if unable to otherwise. Slave I's power may not be reduced by opponent. Immune to Eject! Eject! and attrition < 5.",
+    "gameText": "Permanent pilot is •Boba Fett, who provides ability of 3. Draws one battle destiny if unable to otherwise. Slave I's power may not be reduced by opponent. Immune to Eject! Eject! and attrition < 5.",
     "deployCost": 6,
     "destiny": 1,
     "power": 7,
@@ -37333,7 +37333,7 @@
     ],
     "cardSubtype": "CAPITAL",
     "lore": "Bossk once said of his ship, 'Greeezeg uut nikek!'",
-    "gameText": "Permanent pilot is â€¢Bossk, who provides ability of 2. During battle with opponent's [Independent] starship (or Falcon), may add one destiny to total power or attrition. Immune to attrition < 4.",
+    "gameText": "Permanent pilot is •Bossk, who provides ability of 2. During battle with opponent's [Independent] starship (or Falcon), may add one destiny to total power or attrition. Immune to attrition < 4.",
     "deployCost": 4,
     "destiny": 1,
     "power": 6,
@@ -37396,7 +37396,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Designed to emulate Rebel starfighter advantages. Production began shortly before the Battle of Endor. Armed with laser cannons, ion cannons and missile launchers.",
-    "gameText": "May deploy as a 'react'. Permanent pilot is â€¢Jendon, who provides ability of 2. When deployed, may [download] a weapon on Onyx 1. Adds one battle destiny if with Onyx 2. Immune to attrition < 4.",
+    "gameText": "May deploy as a 'react'. Permanent pilot is •Jendon, who provides ability of 2. When deployed, may [download] a weapon on Onyx 1. Adds one battle destiny if with Onyx 2. Immune to attrition < 4.",
     "deployCost": 4,
     "destiny": 2,
     "power": 5,
@@ -37508,7 +37508,7 @@
       "STARSHIP"
     ],
     "cardSubtype": "STARFIGHTER",
-    "gameText": "May add 1 pilot and 3 passengers. Permanent pilot is â€¢Elis, who provides ability of 2. Once per game, may use 1 Force to [download] a smuggler aboard. Immune to attrition < 5.",
+    "gameText": "May add 1 pilot and 3 passengers. Permanent pilot is •Elis, who provides ability of 2. Once per game, may use 1 Force to [download] a smuggler aboard. Immune to attrition < 5.",
     "deployCost": 4,
     "destiny": 2,
     "power": 4,
@@ -38844,7 +38844,7 @@
       "REPUBLIC"
     ],
     "lore": "Leader. Clone trooper.",
-    "gameText": "Your clones deploy -1 here. While at an [Episode 1] battleground site, adds one battle destiny. Permanent weapon is â€¢Twin Blasters (may target a character for free; draw two destiny; target hit and forfeit -3 if total destiny -2 > defense value).",
+    "gameText": "Your clones deploy -1 here. While at an [Episode 1] battleground site, adds one battle destiny. Permanent weapon is •Twin Blasters (may target a character for free; draw two destiny; target hit and forfeit -3 if total destiny -2 > defense value).",
     "deployCost": 4,
     "destiny": 2,
     "power": 3,
@@ -39029,7 +39029,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Symbol for the Cloud City Miner's Guild (not affiliated with the Galactic Miner's Guild). Named after the beldons, giant creatures who generate Tibanna gas.",
-    "gameText": "Deploy on table. Your [Independent] starships are defense value +2 at Bespin locations. Once per game, if Quiet Mining Colony on table, may simultaneously deploy a unique (â€¢) [Independent] starfighter and matching pilot (for -1 Force each) from your hand and/or Reserve Deck; reshuffle. [Immune to Alter]",
+    "gameText": "Deploy on table. Your [Independent] starships are defense value +2 at Bespin locations. Once per game, if Quiet Mining Colony on table, may simultaneously deploy a unique (•) [Independent] starfighter and matching pilot (for -1 Force each) from your hand and/or Reserve Deck; reshuffle. [Immune to Alter]",
     "destiny": 6,
     "icons": [
       {
@@ -39983,7 +39983,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Owned by legendary Terrik family of smugglers. Used to chase down the pirates who killed Wedge's parents. On Corellian Security's most wanted list. 37.5 meters long.",
-    "gameText": "May add 1 pilot and 6 passengers. Permanent pilot is â€¢Booster, who provides ability of 3. Once per game, may [download] Mirax here. Immune to Lateral Damage and attrition < 5.",
+    "gameText": "May add 1 pilot and 6 passengers. Permanent pilot is •Booster, who provides ability of 3. Once per game, may [download] Mirax here. Immune to Lateral Damage and attrition < 5.",
     "deployCost": 4,
     "destiny": 2,
     "power": 4,
@@ -40105,7 +40105,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "At the Battle of Yavin, Dutch led his squadron of outdated but reliable Y-wings in the first wave of the assault against the Death Star.",
-    "gameText": "May add 1 pilot or passenger. Permanent pilot aboard is â€¢Dutch, who provides ability of 2. Opponent may not 'react' to here and must first use 1 Force to draw a card for battle destiny here.",
+    "gameText": "May add 1 pilot or passenger. Permanent pilot aboard is •Dutch, who provides ability of 2. Opponent may not 'react' to here and must first use 1 Force to draw a card for battle destiny here.",
     "deployCost": 3,
     "destiny": 2,
     "power": 4,
@@ -40164,7 +40164,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Optimized for diplomatic missions with sensor-proof pods that have ejection capabilities. Easily identified by its red coloration.",
-    "gameText": "May add 1 pilot and 2 passengers. Permanent pilot is â€¢Madakor, who provides ability of 2. Opponent's starships may not 'cloak' (or reset your total battle destiny) here. Immune to attrition < 4.",
+    "gameText": "May add 1 pilot and 2 passengers. Permanent pilot is •Madakor, who provides ability of 2. Opponent's starships may not 'cloak' (or reset your total battle destiny) here. Immune to attrition < 4.",
     "deployCost": 5,
     "destiny": 2,
     "power": 6,
@@ -40273,7 +40273,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Lead fighter of Red Squadron at Battle of Yavin. Flown by Garven Dreis. Also served at main Rebel base on Dantooine.",
-    "gameText": "May add Red Leader as pilot. X-wings are immune to Tallon Roll. Once per turn, may use 1 Force to [upload] a unique (â€¢) Red Squadron X-wing (except Red 5). Immune to attrition < 5.",
+    "gameText": "May add Red Leader as pilot. X-wings are immune to Tallon Roll. Once per turn, may use 1 Force to [upload] a unique (•) Red Squadron X-wing (except Red 5). Immune to attrition < 5.",
     "deployCost": 2,
     "destiny": 2,
     "power": 3,
@@ -40381,7 +40381,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Flown by Wedge Antilles as Red 2 at the Battle of Yavin. Redesignated at Endor. Rugged Incom fighter. Victory markers show it role in the attack on the first Death Star.",
-    "gameText": "Permanent pilot is â€¢Wedge, who provides ability of 3. During a battle with opponent's [Independent] starship, may add one destiny to total power or attrition. Immune to Come With Me, Tallon Roll, and attrition < 4.",
+    "gameText": "Permanent pilot is •Wedge, who provides ability of 3. During a battle with opponent's [Independent] starship, may add one destiny to total power or attrition. Immune to Come With Me, Tallon Roll, and attrition < 4.",
     "deployCost": 4,
     "destiny": 2,
     "power": 6,
@@ -40560,7 +40560,7 @@
       "DROID"
     ],
     "lore": "Accomplished thief and information broker. Modified by Jabba to be an effective bounty hunter. The Hutt often teams 4-LOM with other hired killers.",
-    "gameText": "Permanent weapon is â€¢4-LOM's Concussion Rifle (may target a character for free; target is power -1 until end of turn). Once per turn, may place a card from hand on bottom of Used Pile to draw top card from Reserve Deck.",
+    "gameText": "Permanent weapon is •4-LOM's Concussion Rifle (may target a character for free; target is power -1 until end of turn). Once per turn, may place a card from hand on bottom of Used Pile to draw top card from Reserve Deck.",
     "deployCost": 3,
     "destiny": 3,
     "power": 2,
@@ -40662,7 +40662,7 @@
       "IMPERIAL"
     ],
     "lore": "Senior Navy Commander of Death Star. Believes in technology. Ridiculed the Force. Ambitious leader. Promoted due to support of New Order, not military skills. Hates Vader.",
-    "gameText": "[Pilot] 2. Chiraneau may not modify your Force drains. Kuat Drive Yards is immune to Alter. Unless your Senate on table, unique (â€¢) Star Destroyers are power +2 and immunity to attrition +1. Once per game, may [download] non-[Set 0] Kuat Drive Yards.",
+    "gameText": "[Pilot] 2. Chiraneau may not modify your Force drains. Kuat Drive Yards is immune to Alter. Unless your Senate on table, unique (•) Star Destroyers are power +2 and immunity to attrition +1. Once per game, may [download] non-[Set 0] Kuat Drive Yards.",
     "deployCost": 3,
     "destiny": 1,
     "power": 3,
@@ -40964,7 +40964,7 @@
       "ALIEN"
     ],
     "lore": "Corellian bounty hunter. Skilled athlete. Expert shot. Has worked many times for Jabba the Hutt. Carries a long-standing grudge against Han Solo.",
-    "gameText": "While opponent's [Reflection II icon] objective on table, adds one battle destiny. Permanent weapon is â€¢Dengar's Blaster Carbine (may target a character, creature or vehicle for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value; may be fired twice per battle).",
+    "gameText": "While opponent's [Reflection II icon] objective on table, adds one battle destiny. Permanent weapon is •Dengar's Blaster Carbine (may target a character, creature or vehicle for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value; may be fired twice per battle).",
     "deployCost": 4,
     "destiny": 2,
     "power": 3,
@@ -41382,7 +41382,7 @@
       "ALIEN"
     ],
     "lore": "Ordered to kill Luke Skywalker. Assumed the identity of a dancer named 'Arica' in order to sneak into Jabba's Palace.",
-    "gameText": "With Luke or Emperor on table, power +1 and she moves for free. Permanent weapon is â€¢Mara Jade's Lightsaber (may target a character or creature for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
+    "gameText": "With Luke or Emperor on table, power +1 and she moves for free. Permanent weapon is •Mara Jade's Lightsaber (may target a character or creature for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
     "deployCost": 5,
     "destiny": 1,
     "power": 4,
@@ -42149,7 +42149,7 @@
       "STARSHIP"
     ],
     "cardSubtype": "STARFIGHTER",
-    "gameText": "Permanent pilot is â€¢Green Leader, who provides ability of 2. Adds one battle destiny with a Rebel snub fighter. During battle, may cancel immunity to attrition of any starship here; this A-wing is 'hit'.",
+    "gameText": "Permanent pilot is •Green Leader, who provides ability of 2. Adds one battle destiny with a Rebel snub fighter. During battle, may cancel immunity to attrition of any starship here; this A-wing is 'hit'.",
     "deployCost": 4,
     "destiny": 2,
     "power": 5,
@@ -42313,7 +42313,7 @@
     ],
     "cardSubtype": "COMBAT",
     "lore": "Enclosed.",
-    "gameText": "May add 1 pilot. Permanent pilot is â€¢Dash, who provides ability of 3. Unless 'hit', your other vehicles here may not be targeted by weapons, High-Speed Tactics, or Crash Landing. Immune to attrition < 4.",
+    "gameText": "May add 1 pilot. Permanent pilot is •Dash, who provides ability of 3. Unless 'hit', your other vehicles here may not be targeted by weapons, High-Speed Tactics, or Crash Landing. Immune to attrition < 4.",
     "deployCost": 3,
     "destiny": 2,
     "power": 5,
@@ -44137,7 +44137,7 @@
       "STARSHIP"
     ],
     "cardSubtype": "STARFIGHTER",
-    "gameText": "Permanent pilot is â€¢Corran Horn, who provides ability of 4. Weapon destiny draws are -2 here. While with a snub fighter, attrition against opponent is +1 here. Immune to attrition < 4.",
+    "gameText": "Permanent pilot is •Corran Horn, who provides ability of 4. Weapon destiny draws are -2 here. While with a snub fighter, attrition against opponent is +1 here. Immune to attrition < 4.",
     "deployCost": 5,
     "destiny": 1,
     "power": 5,
@@ -45104,7 +45104,7 @@
       "ALIEN"
     ],
     "lore": "Gamorrean in charge of the Gamorreans at Jabba's palace. Posted to stand guard at the entrance cavern. Assigned by Jabba to keep an eye on Tessek.",
-    "gameText": "Permanent weapon is â€¢Ortugg's Ax (may target a character or creature for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value). While Ortugg is your Rep, your non-unique Gamorreans are deploy -1 and forfeit +3.",
+    "gameText": "Permanent weapon is •Ortugg's Ax (may target a character or creature for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value). While Ortugg is your Rep, your non-unique Gamorreans are deploy -1 and forfeit +3.",
     "deployCost": 3,
     "destiny": 3,
     "power": 4,
@@ -47254,7 +47254,7 @@
       "ALIEN"
     ],
     "lore": "Wookiee smuggler.",
-    "gameText": "Deploys -1 to Falcon. While 'hit', draws one battle destiny if unable to otherwise. Permanent weapon is â€¢Chewbacca's Bowcaster (may target a character or vehicle for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
+    "gameText": "Deploys -1 to Falcon. While 'hit', draws one battle destiny if unable to otherwise. Permanent weapon is •Chewbacca's Bowcaster (may target a character or vehicle for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
     "deployCost": 5,
     "destiny": 1,
     "power": 6,
@@ -48391,7 +48391,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Flown by Tycho Celchu at the Battle of Endor. Modified canopy improves pilot vision in tight confines. Assigned to fly top cover for Millennium Falcon.",
-    "gameText": "May deploy as a 'react'. Permanent pilot is â€¢Tycho, who provides ability of 2 and adds 3 to his [Death Star II] Epic Event destiny draws. During battle, may target a starfighter; target's immunity to attrition is canceled.",
+    "gameText": "May deploy as a 'react'. Permanent pilot is •Tycho, who provides ability of 2 and adds 3 to his [Death Star II] Epic Event destiny draws. During battle, may target a starfighter; target's immunity to attrition is canceled.",
     "deployCost": 3,
     "destiny": 2,
     "power": 3,
@@ -48924,7 +48924,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "TIE bomber repaired after being struck by an asteroid in the Anoat system. Stationed aboard second Death Star battle station.",
-    "gameText": "Permanent pilot is â€¢Jonus, who provides ability of 2. This starship's missile weapon destiny draws are +1. If at a system you control, your total power at related sites is +1.",
+    "gameText": "Permanent pilot is •Jonus, who provides ability of 2. This starship's missile weapon destiny draws are +1. If at a system you control, your total power at related sites is +1.",
     "deployCost": 2,
     "destiny": 2,
     "power": 4,
@@ -49235,7 +49235,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Although temperamental, this trusty hunk of junk always seems to perform for its proud owner and his Wookiee co-pilot when needed the most.",
-    "gameText": "Permanent pilots are â€¢Han and â€¢Chewie, who provide ability of 5. If in battle, add one destiny to total power. Immune to Come With Me, Life Debt and attrition < 6.",
+    "gameText": "Permanent pilots are •Han and •Chewie, who provide ability of 5. If in battle, add one destiny to total power. Immune to Come With Me, Life Debt and attrition < 6.",
     "deployCost": 6,
     "destiny": 2,
     "power": 8,
@@ -49350,7 +49350,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Chromium-plated, sleek transport ship used by the royalty of the Naboo. Spaceframe was designed around a J-type configuration.",
-    "gameText": "May add 1 pilot and 5 passengers. Permanent pilot is â€¢Ric, who provides ability of 3. R2-D2 deploys -2 aboard. While We'll Need A New One on table, adds one battle destiny. Immune to attrition < 5.",
+    "gameText": "May add 1 pilot and 5 passengers. Permanent pilot is •Ric, who provides ability of 3. R2-D2 deploys -2 aboard. While We'll Need A New One on table, adds one battle destiny. Immune to attrition < 5.",
     "deployCost": 5,
     "destiny": 2,
     "power": 6,
@@ -50029,7 +50029,7 @@
     "cardTypes": [
       "REBEL"
     ],
-    "gameText": "If about to be lost, may fire Baze's Cannon. Permanent weapon is â€¢Baze's Cannon (may target a character for free; draw destiny; add 1 if targeting a character of ability < 3; target hit, and its forfeit = 0, if total destiny + 1 > defense value).",
+    "gameText": "If about to be lost, may fire Baze's Cannon. Permanent weapon is •Baze's Cannon (may target a character for free; draw destiny; add 1 if targeting a character of ability < 3; target hit, and its forfeit = 0, if total destiny + 1 > defense value).",
     "deployCost": 4,
     "destiny": 2,
     "power": 4,
@@ -51589,7 +51589,7 @@
     "cardTypes": [
       "EPIC_EVENT"
     ],
-    "gameText": "If Yavin 4 on table, deploy on table. If you just initiated a Force drain at a battleground system (except a 'liberated' system), may draw destiny. Add 1 for each piloted unique (â€¢) snub fighter present at that system. If total destiny > 5, opponent loses 1 Force and stacks lost card face down there (while that card stacked there, system is 'liberated'). If opponent Force drains at a 'liberated' system, place stacked card in owner's Used Pile. At each 'liberated' system, your Force drains are +1 and opponent's starships are deploy +1.",
+    "gameText": "If Yavin 4 on table, deploy on table. If you just initiated a Force drain at a battleground system (except a 'liberated' system), may draw destiny. Add 1 for each piloted unique (•) snub fighter present at that system. If total destiny > 5, opponent loses 1 Force and stacks lost card face down there (while that card stacked there, system is 'liberated'). If opponent Force drains at a 'liberated' system, place stacked card in owner's Used Pile. At each 'liberated' system, your Force drains are +1 and opponent's starships are deploy +1.",
     "deployCost": 0,
     "destiny": 0,
     "icons": [
@@ -51998,7 +51998,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "While this side up, during battle at sites related to systems you occupy, for each piloted unique (â€¢) snub fighter present at that system, your total power is +2. Once during your draw phase, if a system is 'liberated', may place a card from your Lost Pile out of play to retrieve 1 Force. Flip this card if you do not occupy two battlegrounds (unless four Rebels are on table).",
+    "gameText": "While this side up, during battle at sites related to systems you occupy, for each piloted unique (•) snub fighter present at that system, your total power is +2. Once during your draw phase, if a system is 'liberated', may place a card from your Lost Pile out of play to retrieve 1 Force. Flip this card if you do not occupy two battlegrounds (unless four Rebels are on table).",
     "destiny": 7,
     "icons": [
       {
@@ -52407,7 +52407,7 @@
       "SITH"
     ],
     "lore": "Trade Federation.",
-    "gameText": "Permanent weapon is â€¢Maul's Lightsaber (may add 1 to Force drain where present; adds 1 to your battle destiny draws here; may target a character for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
+    "gameText": "Permanent weapon is •Maul's Lightsaber (may add 1 to Force drain where present; adds 1 to your battle destiny draws here; may target a character for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
     "deployCost": 6,
     "destiny": 1,
     "power": 7,
@@ -52884,7 +52884,7 @@
     ],
     "cardSubtype": "USED_OR_LOST",
     "lore": "Oouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioo-",
-    "gameText": "USED: [Upload] Downtown Plaza or a prison. LOST: [Upload] one unique (â€¢) bounty. OR Target an alien. For remainder of turn, target is power and forfeit -1 (-3 if Chewie).",
+    "gameText": "USED: [Upload] Downtown Plaza or a prison. LOST: [Upload] one unique (•) bounty. OR Target an alien. For remainder of turn, target is power and forfeit -1 (-3 if Chewie).",
     "destiny": 4,
     "icons": [
       {
@@ -53434,7 +53434,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "Deploy Tuanul Village, any other [Episode VII] location, and I Will Finish What You Started. Opponent may reveal a unique (â€¢) character with ability (except Luke or a Jedi) from Reserve Deck; that card is a Resistance Agent. Otherwise, Luke is a Resistance Agent and loses immunity to attrition. For remainder of game, non-[Episode VII] Dark Jedi are lost and Resistance Agents are immune to Set For Stun. Flip this card if your First Order characters control two battlegrounds and a Resistance Agent is not present at a battleground site.",
+    "gameText": "Deploy Tuanul Village, any other [Episode VII] location, and I Will Finish What You Started. Opponent may reveal a unique (•) character with ability (except Luke or a Jedi) from Reserve Deck; that card is a Resistance Agent. Otherwise, Luke is a Resistance Agent and loses immunity to attrition. For remainder of game, non-[Episode VII] Dark Jedi are lost and Resistance Agents are immune to Set For Stun. Flip this card if your First Order characters control two battlegrounds and a Resistance Agent is not present at a battleground site.",
     "destiny": 0,
     "icons": [
       {
@@ -53495,7 +53495,7 @@
       "STARSHIP"
     ],
     "cardSubtype": "STARFIGHTER",
-    "gameText": "May add 1 pilot and 2 passengers. Permanent pilot is â€¢Mara Jade, who provides ability of 5. While alone and piloted by an Imperial, adds one battle destiny. Immune to attrition < 4.",
+    "gameText": "May add 1 pilot and 2 passengers. Permanent pilot is •Mara Jade, who provides ability of 5. While alone and piloted by an Imperial, adds one battle destiny. Immune to attrition < 4.",
     "deployCost": 5,
     "destiny": 2,
     "power": 5,
@@ -53802,7 +53802,7 @@
       "RESISTANCE"
     ],
     "lore": "Female.",
-    "gameText": "[Pilot] 2. Permanent weapon is â€¢Anakin's Lightsaber (may target a character for free; draw two destiny; target hit, its forfeit = 0, and you may retrieve 1 Force, if total destiny > defense value).",
+    "gameText": "[Pilot] 2. Permanent weapon is •Anakin's Lightsaber (may target a character for free; draw two destiny; target hit, its forfeit = 0, and you may retrieve 1 Force, if total destiny > defense value).",
     "deployCost": 5,
     "destiny": 1,
     "power": 5,
@@ -55049,7 +55049,7 @@
       "FIRST_ORDER"
     ],
     "lore": "Leader.",
-    "gameText": "[Pilot] 2. Permanent weapon is â€¢Kylo's Lightsaber (may target a character for free; draw two destiny; target hit, its forfeit = 0, and opponent loses 1 Force, if total destiny > defense value; otherwise you lose 1 Force).",
+    "gameText": "[Pilot] 2. Permanent weapon is •Kylo's Lightsaber (may target a character for free; draw two destiny; target hit, its forfeit = 0, and opponent loses 1 Force, if total destiny > defense value; otherwise you lose 1 Force).",
     "deployCost": 5,
     "destiny": 1,
     "power": 6,
@@ -55392,7 +55392,7 @@
     "cardTypes": [
       "EPIC_EVENT"
     ],
-    "gameText": "Once per game, deploy on Death Star; it is hyperspeed = 2. Superlaser may not target planet systems. Once during your control phase, may fire Superlaser as follows: Prepare Single Reactor Ignition: If Death Star orbiting Jedha or Scarif, target your related unique (â€¢) battleground site, even if converted (regardless of objective restrictions). Fire!: Draw destiny. It's Beautiful: If destiny +X > 8, site is 'blown away,' and opponent loses 3 Force. X = number of Death Star sites on table.",
+    "gameText": "Once per game, deploy on Death Star; it is hyperspeed = 2. Superlaser may not target planet systems. Once during your control phase, may fire Superlaser as follows: Prepare Single Reactor Ignition: If Death Star orbiting Jedha or Scarif, target your related unique (•) battleground site, even if converted (regardless of objective restrictions). Fire!: Draw destiny. It's Beautiful: If destiny +X > 8, site is 'blown away,' and opponent loses 3 Force. X = number of Death Star sites on table.",
     "deployCost": 0,
     "destiny": 0,
     "icons": [
@@ -56573,7 +56573,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "Deploy City Outskirts, Watto's Junkyard, and Credits Will Do Fine. For remainder of game, you may not deploy cards with ability except unique (â€¢) aliens, Republic characters, [Republic] starships, and [Episode I] Jedi. Your Destiny is suspended. You lose no Force from [Reflections II] objectives. While this side up, once per game, may take into hand from Reserve Deck an [Episode I] system. Unless present with Qui-Gon, Maul is immune to attrition. Flip this card if there are four or more cards beneath Credits Will Do Fine.",
+    "gameText": "Deploy City Outskirts, Watto's Junkyard, and Credits Will Do Fine. For remainder of game, you may not deploy cards with ability except unique (•) aliens, Republic characters, [Republic] starships, and [Episode I] Jedi. Your Destiny is suspended. You lose no Force from [Reflections II] objectives. While this side up, once per game, may take into hand from Reserve Deck an [Episode I] system. Unless present with Qui-Gon, Maul is immune to attrition. Flip this card if there are four or more cards beneath Credits Will Do Fine.",
     "destiny": 0,
     "icons": [
       {
@@ -56608,7 +56608,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "While this side up, your unique (â€¢) Republic characters are power +1 and forfeit +2. Aliens may not have their deploy cost modified to Tatooine locations. Whenever you complete a non-substituted battle destiny draw, may retrieve 1 Force (Force retrieved in this way may be taken into hand). Once during opponent's turn, if Queen's Royal Starship at a system, may activate up to 2 Force. During your control phase, opponent loses 1 Force for each battleground occupied by Amidala or Jar Jar.",
+    "gameText": "While this side up, your unique (•) Republic characters are power +1 and forfeit +2. Aliens may not have their deploy cost modified to Tatooine locations. Whenever you complete a non-substituted battle destiny draw, may retrieve 1 Force (Force retrieved in this way may be taken into hand). Once during opponent's turn, if Queen's Royal Starship at a system, may activate up to 2 Force. During your control phase, opponent loses 1 Force for each battleground occupied by Amidala or Jar Jar.",
     "destiny": 7,
     "icons": [
       {
@@ -57002,7 +57002,7 @@
     ],
     "cardSubtype": "COMBAT",
     "lore": "Enclosed. Death Squadron.",
-    "gameText": "May add 1 pilot. Permanent pilot is â€¢Marquand, who provides ability of 2. Cards Blizzard 6 hits are power and forfeit -2 and may not apply ability towards drawing battle destiny. Immune to attrition < 4.",
+    "gameText": "May add 1 pilot. Permanent pilot is •Marquand, who provides ability of 2. Cards Blizzard 6 hits are power and forfeit -2 and may not apply ability towards drawing battle destiny. Immune to attrition < 4.",
     "deployCost": 6,
     "destiny": 1,
     "power": 6,
@@ -57601,7 +57601,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "On her assignment to kill Sharad Hett, Aurra used her patience and cunning to help track down the Jedi Master.",
-    "gameText": "Deploy on table. While alone, assassins are power +1. Once per game, may reveal up to two unique (â€¢) aliens from hand and/or Reserve Deck (reshuffle); for remainder of game, those cards are assassins and, if your [Reflections II] objective on table, Black Sun agents. [Immune to Alter.]",
+    "gameText": "Deploy on table. While alone, assassins are power +1. Once per game, may reveal up to two unique (•) aliens from hand and/or Reserve Deck (reshuffle); for remainder of game, those cards are assassins and, if your [Reflections II] objective on table, Black Sun agents. [Immune to Alter.]",
     "destiny": 4,
     "icons": [
       {
@@ -58455,7 +58455,7 @@
       "STARSHIP"
     ],
     "cardSubtype": "STARFIGHTER",
-    "gameText": "May add 1 pilot. Permanent astromech aboard is â€¢BB-8. If Poe piloting, may lose 1 Force to cancel a just drawn weapon destiny targeting this starship. Immune to attrition < 4.",
+    "gameText": "May add 1 pilot. Permanent astromech aboard is •BB-8. If Poe piloting, may lose 1 Force to cancel a just drawn weapon destiny targeting this starship. Immune to attrition < 4.",
     "deployCost": 3,
     "destiny": 3.1415927,
     "power": 4,
@@ -58772,7 +58772,7 @@
       "STARSHIP"
     ],
     "cardSubtype": "STARFIGHTER",
-    "gameText": "Permanent pilot is â€¢Tallie, who provides ability of 2. May move as a 'react' to same location as your [Episode VII] character. Characters here may not have their forfeit increased beyond their printed value.",
+    "gameText": "Permanent pilot is •Tallie, who provides ability of 2. May move as a 'react' to same location as your [Episode VII] character. Characters here may not have their forfeit increased beyond their printed value.",
     "deployCost": 3,
     "destiny": 3,
     "power": 4,
@@ -58858,7 +58858,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "Immediately place Luke out of play (ignore [Death Star II] objective restrictions, if any). For remainder of battle, weapons may not be fired. While this side up, opponent's immunity to attrition is limited to < 6. Once during your turn, may peek at the top card of your Force Pile and Reserve Deck; place both cards (in any order) on top of one of those piles. Where you have two unique (â€¢) Resistance characters, your Force drains are +1 and, once per turn during battle, may cancel an opponent's just drawn destiny to cause a redraw.",
+    "gameText": "Immediately place Luke out of play (ignore [Death Star II] objective restrictions, if any). For remainder of battle, weapons may not be fired. While this side up, opponent's immunity to attrition is limited to < 6. Once during your turn, may peek at the top card of your Force Pile and Reserve Deck; place both cards (in any order) on top of one of those piles. Where you have two unique (•) Resistance characters, your Force drains are +1 and, once per turn during battle, may cancel an opponent's just drawn destiny to cause a redraw.",
     "destiny": 7,
     "icons": [
       {
@@ -61168,7 +61168,7 @@
       "LOCATION"
     ],
     "cardSubtype": "SITE",
-    "locationDarkSideGameText": "While your unique (â€¢) alien here, your Force generation is +1 here (+2 if Margo).",
+    "locationDarkSideGameText": "While your unique (•) alien here, your Force generation is +1 here (+2 if Margo).",
     "locationLightSideGameText": "Force drain -1 here (if your smuggler here, Force drain +1 instead).",
     "deployCost": 0,
     "destiny": 0,
@@ -63970,7 +63970,7 @@
     ],
     "cardSubtype": "SITE",
     "locationDarkSideGameText": "Total ability of 6 or more required for you to draw battle destiny here.",
-    "locationLightSideGameText": "Once per turn, if you occupy with a Wookiee, may [download]â–¼ a Kashyyyk location.",
+    "locationLightSideGameText": "Once per turn, if you occupy with a Wookiee, may [download]▼ a Kashyyyk location.",
     "deployCost": 0,
     "destiny": 0,
     "icons": [
@@ -64091,7 +64091,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "Deploy Central Core, A Power Loss, Detention Block Corridor (with [A New Hope] Leia imprisoned there), and Trash Compactor. For remainder of game, your Death Star sites generate +1 Force for you. You may not deploy Luke of ability > 4 or [Episode I] (or [Episode VII]) Jedi. If Leia is about to leave table (for any reason, even if inactive), imprison her in Detention Block Corridor (cards on her are placed in owner's Used Pile). Once per turn, may â–¼ a Death Star site. Flip this card if Leia occupies a Death Star site and A Power Loss is 'shut down.'",
+    "gameText": "Deploy Central Core, A Power Loss, Detention Block Corridor (with [A New Hope] Leia imprisoned there), and Trash Compactor. For remainder of game, your Death Star sites generate +1 Force for you. You may not deploy Luke of ability > 4 or [Episode I] (or [Episode VII]) Jedi. If Leia is about to leave table (for any reason, even if inactive), imprison her in Detention Block Corridor (cards on her are placed in owner's Used Pile). Once per turn, may ▼ a Death Star site. Flip this card if Leia occupies a Death Star site and A Power Loss is 'shut down.'",
     "destiny": 0,
     "icons": [
       {
@@ -66904,7 +66904,7 @@
     ],
     "cardSubtype": "SITE",
     "locationDarkSideGameText": "Once per turn, may [download] a starfighter with 'Vader' in title here.",
-    "locationLightSideGameText": "Your docking bay transit to or from here requires +4 Force (+6 Force if Vader or VaneÃ© here).",
+    "locationLightSideGameText": "Your docking bay transit to or from here requires +4 Force (+6 Force if Vader or Vaneé here).",
     "deployCost": 0,
     "destiny": 0,
     "icons": [
@@ -67769,7 +67769,7 @@
       "EFFECT"
     ],
     "cardSubtype": "NORMAL",
-    "gameText": "Deploy on table. Your unique (â€¢) Republic characters (and your unique (â€¢) Gungans) of ability < 4 are forfeit +1. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites only. Once per turn, may [download] a docking bay. Once during opponent's turn, if Jar Jar or your [Episode I] leader occupies an [Episode I] battleground, may activate 1 Force. [Immune to Alter.]",
+    "gameText": "Deploy on table. Your unique (•) Republic characters (and your unique (•) Gungans) of ability < 4 are forfeit +1. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites only. Once per turn, may [download] a docking bay. Once during opponent's turn, if Jar Jar or your [Episode I] leader occupies an [Episode I] battleground, may activate 1 Force. [Immune to Alter.]",
     "destiny": 4,
     "icons": [
       {
@@ -67832,7 +67832,7 @@
       "EFFECT"
     ],
     "cardSubtype": "NORMAL",
-    "gameText": "Deploy on table. Your unique (â€¢) Republic characters of ability < 4 and your [Trade Federation] starships are forfeit +2. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites only. Once per turn, may deploy an [Episode I] (or Coruscant) docking bay from Reserve Deck; reshuffle. While you occupy Naboo system with a [Trade Federation] starship, your Force generation is +1 there. [Immune to Alter.]",
+    "gameText": "Deploy on table. Your unique (•) Republic characters of ability < 4 and your [Trade Federation] starships are forfeit +2. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites only. Once per turn, may deploy an [Episode I] (or Coruscant) docking bay from Reserve Deck; reshuffle. While you occupy Naboo system with a [Trade Federation] starship, your Force generation is +1 there. [Immune to Alter.]",
     "destiny": 4,
     "icons": [
       {
@@ -68944,7 +68944,7 @@
       "IMPERIAL"
     ],
     "lore": "ISB leader.",
-    "gameText": "During your deploy phase, a unique (â€¢) Imperial of ability < 3 here may make a regular move. When deployed, may place a unique (â€¢) ISB agent here in Used Pile to deploy (for free) a non-Tarkin ISB agent with a different title here from Used Pile; reshuffle.",
+    "gameText": "During your deploy phase, a unique (•) Imperial of ability < 3 here may make a regular move. When deployed, may place a unique (•) ISB agent here in Used Pile to deploy (for free) a non-Tarkin ISB agent with a different title here from Used Pile; reshuffle.",
     "deployCost": 3,
     "destiny": 2,
     "power": 3,
@@ -69853,7 +69853,7 @@
       "JEDI_MASTER"
     ],
     "lore": "",
-    "gameText": "Permanent weapon is â€¢Qui-Gon Jinn's Lightsaber (may target a character or creature for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
+    "gameText": "Permanent weapon is •Qui-Gon Jinn's Lightsaber (may target a character or creature for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
     "deployCost": 6,
     "destiny": 1,
     "power": 6,
@@ -70525,7 +70525,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Jabba's influence is not easily ignored. Neither are his voracious and vile appetites. Even Jedi soon learn this lesson.",
-    "gameText": "Deploy on table. When deployed, may take the top card of Lost Pile into hand. During your move phase, may cancel Landing Claw. If Landing Claw was just lost, place it out of play. Elis Helrot and Nabrun Leids are unique (â€¢) and are Lost Interrupts. [Immune to Alter.]",
+    "gameText": "Deploy on table. When deployed, may take the top card of Lost Pile into hand. During your move phase, may cancel Landing Claw. If Landing Claw was just lost, place it out of play. Elis Helrot and Nabrun Leids are unique (•) and are Lost Interrupts. [Immune to Alter.]",
     "destiny": 4,
     "icons": [
       {
@@ -70940,7 +70940,7 @@
       "ALIEN"
     ],
     "lore": "Crolute scavenger and thief.",
-    "gameText": "Your battle destiny draws here are +Â¼ for each device, droid, starship, vehicle, or weapon card here. During battle with an opponent's droid, adds one destiny to total power. Once per game, may retrieve a device or character weapon.",
+    "gameText": "Your battle destiny draws here are +¼ for each device, droid, starship, vehicle, or weapon card here. During battle with an opponent's droid, adds one destiny to total power. Once per game, may retrieve a device or character weapon.",
     "deployCost": 2,
     "destiny": 4,
     "power": 2,
@@ -71201,7 +71201,7 @@
       "ALIEN"
     ],
     "lore": "Female Alderaanian. Gambler. Trooper.",
-    "gameText": " If Alderaan has been 'blown away,' Force drain +1 here. Permanent weapon is â€¢Cara's Heavy Blaster Rifle (twice per battle, may target a character or vehicle; draw destiny; target hit, and its forfeit is cumulatively -3, if destiny +1 > defense value).",
+    "gameText": " If Alderaan has been 'blown away,' Force drain +1 here. Permanent weapon is •Cara's Heavy Blaster Rifle (twice per battle, may target a character or vehicle; draw destiny; target hit, and its forfeit is cumulatively -3, if destiny +1 > defense value).",
     "deployCost": 4,
     "destiny": 2,
     "power": 4,
@@ -71914,7 +71914,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "The metal rods extending from the bottom of Cloud City are part of the city's flotation system. Sensors detect the velocity of wind and the content of local clouds.",
-    "gameText": "Deploy on table. Unless this card upright, characters here are lost. If you just Force drained or initiated battle, rotate this card 90Â° clockwise; if now upright, retrieve any one card. If opponent just initiated battle, unless this card upright, rotate it 90Â° counterclockwise.",
+    "gameText": "Deploy on table. Unless this card upright, characters here are lost. If you just Force drained or initiated battle, rotate this card 90° clockwise; if now upright, retrieve any one card. If opponent just initiated battle, unless this card upright, rotate it 90° counterclockwise.",
     "destiny": 4,
     "icons": [
       {
@@ -72623,7 +72623,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Customized transport of Lord Vader. Employs advanced sensor jamming gear. Modified with enhanced tactical displays constructed to the Dark Lord's specifications.",
-    "gameText": "Deploys -2 to Mustafar. May add 1 pilot and 3 passengers. Permanent pilot is â€¢Jendon, who provides ability of 2. If Vader armed with a lightsaber weapon card at a battleground, Force drain +1 here.",
+    "gameText": "Deploys -2 to Mustafar. May add 1 pilot and 3 passengers. Permanent pilot is •Jendon, who provides ability of 2. If Vader armed with a lightsaber weapon card at a battleground, Force drain +1 here.",
     "deployCost": 5,
     "destiny": 3,
     "power": 5,
@@ -73614,7 +73614,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Sandtroopers commanded by Governor Aryon do not enjoy their assignment. They find a means of venting their frustrations by harassing the local inhabitants.",
-    "gameText": "Deploy on table. During your control phase, if you occupy Tatooine system, opponent loses 1 Force for each Tatooine battleground site you occupy with a unique (â€¢) trooper. While you have three troopers on Tatooine, immune to Alter and Endor Celebration.",
+    "gameText": "Deploy on table. During your control phase, if you occupy Tatooine system, opponent loses 1 Force for each Tatooine battleground site you occupy with a unique (•) trooper. While you have three troopers on Tatooine, immune to Alter and Endor Celebration.",
     "destiny": 4,
     "icons": [
       {
@@ -74039,7 +74039,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Commissioned by a group of Gand venture capitalists headed by Zuckuss. Manufactured by Byblos Drive Yards. Uses repulsorlift technology developed for combat cloud cars.",
-    "gameText": "May 1 pilot. Permanent pilots are â€¢Zuckuss, who provides ability of 4, and â€¢4-LOM. Players may not add power destinies or draw more than one battle destiny here. Immune to attrition < 5.",
+    "gameText": "May 1 pilot. Permanent pilots are •Zuckuss, who provides ability of 4, and •4-LOM. Players may not add power destinies or draw more than one battle destiny here. Immune to attrition < 5.",
     "deployCost": 5,
     "destiny": 2,
     "power": 5,
@@ -74907,7 +74907,7 @@
       "EFFECT"
     ],
     "cardSubtype": "NORMAL",
-    "gameText": "Deploy on table. Unique (â€¢) [Clone Army] capital starships are deploy -1 and immunity to attrition +1. Once per turn, may reveal a [Clone Army] starship from hand to take an [Episode I] pilot character from Reserve Deck (or vice versa) and deploy both simultaneously; reshuffle. [Immune to Alter.]",
+    "gameText": "Deploy on table. Unique (•) [Clone Army] capital starships are deploy -1 and immunity to attrition +1. Once per turn, may reveal a [Clone Army] starship from hand to take an [Episode I] pilot character from Reserve Deck (or vice versa) and deploy both simultaneously; reshuffle. [Immune to Alter.]",
     "destiny": 5,
     "icons": [
       {
@@ -75808,7 +75808,7 @@
       "STARSHIP"
     ],
     "cardSubtype": "STARFIGHTER",
-    "gameText": "May add 1 pilot and 3 passengers. Permanent pilot is â€¢Kuruk, who provides ability of 3. Kylo and Knights of Ren deploy -1 to same and related locations. Immune to attrition < 4.",
+    "gameText": "May add 1 pilot and 3 passengers. Permanent pilot is •Kuruk, who provides ability of 3. Kylo and Knights of Ren deploy -1 to same and related locations. Immune to attrition < 4.",
     "deployCost": 4,
     "destiny": 2,
     "power": 4,
@@ -76550,7 +76550,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "While this side up, cancels Hoth Sentry, Sunsdown, and the game text of your Admiral's Orders and unique (â€¢) characters (except gunners, pilots, and troopers) on table. Cards 'hit' by your artillery or vehicle weapons may not be used to satisfy attrition. If you just initiated battle, may peek at top X cards of your Used Pile, where X = number of Hoth battlegrounds you occupy; take one into hand and shuffle your Used Pile.Flip this card if opponent does not occupy your Hoth location.",
+    "gameText": "While this side up, cancels Hoth Sentry, Sunsdown, and the game text of your Admiral's Orders and unique (•) characters (except gunners, pilots, and troopers) on table. Cards 'hit' by your artillery or vehicle weapons may not be used to satisfy attrition. If you just initiated battle, may peek at top X cards of your Used Pile, where X = number of Hoth battlegrounds you occupy; take one into hand and shuffle your Used Pile.Flip this card if opponent does not occupy your Hoth location.",
     "destiny": 7,
     "icons": [
       {
@@ -76804,7 +76804,7 @@
       "ALIEN"
     ],
     "lore": "Notorious bounty hunter. 'As you wish.'",
-    "gameText": "[Pilot] 2. Permanent weapon is â€¢Boba Fett's Blaster Rifle (may target a character for free; draw destiny; if destiny > defense value, target captured; otherwise, if destiny +2 > defense value, target hit, is forfeit -3, and opponent loses 1 Force; may not be retargeted).",
+    "gameText": "[Pilot] 2. Permanent weapon is •Boba Fett's Blaster Rifle (may target a character for free; draw destiny; if destiny > defense value, target captured; otherwise, if destiny +2 > defense value, target hit, is forfeit -3, and opponent loses 1 Force; may not be retargeted).",
     "deployCost": 4,
     "destiny": 1,
     "power": 5,
@@ -77107,7 +77107,7 @@
     ],
     "cardSubtype": "CAPITAL",
     "lore": "",
-    "gameText": "May add 2 pilots, and 2 passengers. Permanent pilot is â€¢Vanto, who provides ability of 3. Immune to attrition < 4 (< 6 while piloted by Thrawn or while a 'probed' or 'liberated' system on table).",
+    "gameText": "May add 2 pilots, and 2 passengers. Permanent pilot is •Vanto, who provides ability of 3. Immune to attrition < 4 (< 6 while piloted by Thrawn or while a 'probed' or 'liberated' system on table).",
     "deployCost": 4,
     "destiny": 1,
     "power": 5,
@@ -77318,7 +77318,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Maul's Sith Infiltrator.",
-    "gameText": "May add 1 pilot. Permanent pilot is â€¢Maul, who provides ability of 6. Once per battle, may lose 1 Force to 'cloak' (either add one destiny to total power or make this starship immune to attrition < 6).",
+    "gameText": "May add 1 pilot. Permanent pilot is •Maul, who provides ability of 6. Once per battle, may lose 1 Force to 'cloak' (either add one destiny to total power or make this starship immune to attrition < 6).",
     "deployCost": 4,
     "destiny": 4,
     "power": 4,
@@ -77828,7 +77828,7 @@
       "ALIEN"
     ],
     "lore": "Gand bounty hunter and scout.",
-    "gameText": "[Pilot] 2. Once per game, may peek at top card of any Reserve Deck. Permanent weapon is â€¢Zuckuss' Snare Rifle (may target a character for free; draw destiny; target excluded from battle if destiny +1 > target's power).",
+    "gameText": "[Pilot] 2. Once per game, may peek at top card of any Reserve Deck. Permanent weapon is •Zuckuss' Snare Rifle (may target a character for free; draw destiny; target excluded from battle if destiny +1 > target's power).",
     "deployCost": 4,
     "destiny": 1,
     "power": 2,
@@ -79629,7 +79629,7 @@
     ],
     "cardSubtype": "COMBAT",
     "lore": "Enclosed. First snowspeeder to be successfully adapted to Hoth's environment. Piloted by Zev Senesca. Led team in search of Captain Solo and Commander Skywalker.",
-    "gameText": "Deploys -2 to Hoth. May add 1 pilot. Permanent pilot is â€¢Zev, who provides ability of 2. Draws one battle destiny if unable to otherwise. May move as a 'react' to Hoth sites. Vehicle weapons deploy free aboard.",
+    "gameText": "Deploys -2 to Hoth. May add 1 pilot. Permanent pilot is •Zev, who provides ability of 2. Draws one battle destiny if unable to otherwise. May move as a 'react' to Hoth sites. Vehicle weapons deploy free aboard.",
     "deployCost": 6,
     "destiny": 2,
     "power": 6,
@@ -79954,7 +79954,7 @@
       "INTERRUPT"
     ],
     "cardSubtype": "USED_OR_LOST",
-    "gameText": "USED: [Upload] a unique (â€¢) unpiloted starfighter. LOST: During battle at a system or sector, if you are about to draw a card for battle destiny, target your participating starship to instead use the ability number of its highest-ability pilot. OR Once per game, if Alderaan 'blown away' (or if opponent has deployed two battleground systems and no battleground sites), deploy a non-unique Corellian Corvette from outside your deck.",
+    "gameText": "USED: [Upload] a unique (•) unpiloted starfighter. LOST: During battle at a system or sector, if you are about to draw a card for battle destiny, target your participating starship to instead use the ability number of its highest-ability pilot. OR Once per game, if Alderaan 'blown away' (or if opponent has deployed two battleground systems and no battleground sites), deploy a non-unique Corellian Corvette from outside your deck.",
     "destiny": 5,
     "icons": [
       {
@@ -80191,7 +80191,7 @@
       "FIRST_ORDER"
     ],
     "lore": "Knight of Ren.",
-    "gameText": "[Pilot] 2. While an [Episode VII] objective on table, draws one battle destiny if unable to otherwise. Permanent weapon is â€¢Arm Cannon (may target a character for free; draw destiny; target hit, and its forfeit = 0, if destiny + 1 > defense value).",
+    "gameText": "[Pilot] 2. While an [Episode VII] objective on table, draws one battle destiny if unable to otherwise. Permanent weapon is •Arm Cannon (may target a character for free; draw destiny; target hit, and its forfeit = 0, if destiny + 1 > defense value).",
     "deployCost": 4,
     "destiny": 2,
     "power": 4,
@@ -81854,7 +81854,7 @@
       "ALIEN"
     ],
     "lore": "Works every time. Smuggler.",
-    "gameText": "[Pilot] 2. Permanent weapon is â€¢Lando's Blaster Rifle (may target a character for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value). During battle, if your total battle destiny is odd, may retrieve 1 Force (2 if total is 11).",
+    "gameText": "[Pilot] 2. Permanent weapon is •Lando's Blaster Rifle (may target a character for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value). During battle, if your total battle destiny is odd, may retrieve 1 Force (2 if total is 11).",
     "deployCost": 3,
     "destiny": 1,
     "power": 3,
@@ -82940,7 +82940,7 @@
       "JEDI_MASTER"
     ],
     "lore": "Wookiee.",
-    "gameText": "Once per turn, if Wookiee Homestead on table, may place a card from hand on top of Force Pile to draw bottom card from Force Pile. Once per game, may [download] a unique (â€¢) Forest. Immune to Wookiee Strangle and You Are Beaten.",
+    "gameText": "Once per turn, if Wookiee Homestead on table, may place a card from hand on top of Force Pile to draw bottom card from Force Pile. Once per game, may [download] a unique (•) Forest. Immune to Wookiee Strangle and You Are Beaten.",
     "deployCost": 5,
     "destiny": 2,
     "power": 5,
@@ -83231,7 +83231,7 @@
       "ALIEN"
     ],
     "lore": "Female mechanic and scavenger.",
-    "gameText": "While at Starship Graveyard, a docking bay, or on Tatooine, power +3 and may cancel Iâ€™ve Lost Artoo! or Lateral Damage (or Restraining Bolt here). During your control phase, if at a battleground with a Jawa, landed starfighter or Grogu, may retrieve 1 Force.",
+    "gameText": "While at Starship Graveyard, a docking bay, or on Tatooine, power +3 and may cancel I’ve Lost Artoo! or Lateral Damage (or Restraining Bolt here). During your control phase, if at a battleground with a Jawa, landed starfighter or Grogu, may retrieve 1 Force.",
     "deployCost": 2,
     "destiny": 2,
     "power": 1,
@@ -83529,7 +83529,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "'I'm sorry, too.'",
-    "gameText": "If your [Cloud City] objective on table, deploy on table. Elis Helrot, Stunning Leader, and Surreptitious Glance may not be played. Once per turn, may [download] an interior Cloud City site. Your unique (â€¢) characters with printed forfeit < 5 are forfeit +2 (limit +2). [Immune to Alter.]",
+    "gameText": "If your [Cloud City] objective on table, deploy on table. Elis Helrot, Stunning Leader, and Surreptitious Glance may not be played. Once per turn, may [download] an interior Cloud City site. Your unique (•) characters with printed forfeit < 5 are forfeit +2 (limit +2). [Immune to Alter.]",
     "destiny": 5,
     "icons": [
       {
@@ -84679,7 +84679,7 @@
     ],
     "cardSubtype": "IMMEDIATE",
     "lore": "Dianogas use their seven tentacles for both locomotion and catching food. The few survivors of such attacks claim that a dianoga tentacle has the strength of a hydro-clamp.",
-    "gameText": "If opponent just played an Interrupt, use 1 Force to deploy on table and stack that Interrupt here. All Interrupts of that title are unique (â€¢). (Immune to Control.)",
+    "gameText": "If opponent just played an Interrupt, use 1 Force to deploy on table and stack that Interrupt here. All Interrupts of that title are unique (•). (Immune to Control.)",
     "destiny": 5,
     "icons": [
       {
@@ -86566,7 +86566,7 @@
     ],
     "cardSubtype": "IMMEDIATE",
     "lore": "Stormtrooper utility belts contain basic tools such as a grappling hook to grab onto protrusions. The hook can also be used to ensnare escaping targets.",
-    "gameText": "If opponent just played an Interrupt, use 1 Force to deploy on table and stack that Interrupt here. All Interrupts of that title are unique (â€¢). (Immune to Control.)",
+    "gameText": "If opponent just played an Interrupt, use 1 Force to deploy on table and stack that Interrupt here. All Interrupts of that title are unique (•). (Immune to Control.)",
     "destiny": 5,
     "icons": [
       {
@@ -89123,7 +89123,7 @@
       "REPUBLIC"
     ],
     "lore": "Female Togruta Padawan",
-    "gameText": "Power +1 with Anakin. Permanent weapon is â€¢Ahsoka's Lightsabers (may target a character for free, or target two characters using 1 Force; draw two destiny; target(s) hit and forfeit -2 if total destiny > total defense value).",
+    "gameText": "Power +1 with Anakin. Permanent weapon is •Ahsoka's Lightsabers (may target a character for free, or target two characters using 1 Force; draw two destiny; target(s) hit and forfeit -2 if total destiny > total defense value).",
     "deployCost": 5,
     "destiny": 1,
     "power": 4,
@@ -89247,7 +89247,7 @@
       "SITH"
     ],
     "lore": "Female Dathomirian assassin",
-    "gameText": "Power +1 with Dooku. Permanent weapon is â€¢Asajj's Lightsabers (may target a character for free, or target two characters using 1 Force; draw two destiny; target(s) hit and forfeit -2 if total destiny > total defense value).",
+    "gameText": "Power +1 with Dooku. Permanent weapon is •Asajj's Lightsabers (may target a character for free, or target two characters using 1 Force; draw two destiny; target(s) hit and forfeit -2 if total destiny > total defense value).",
     "deployCost": 5,
     "destiny": 1,
     "power": 4,
@@ -95904,7 +95904,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Like nerf herders herding nerfs, Imperial commanders often use TIE fighters to drive fleeing Rebel ships into tractor beam range.",
-    "gameText": "Deploy on one opponent's unique (â€¢) starship at a location you do not occupy. When starship is targeted by any tractor beam or ion cannon, subtract 2 from maneuver. If starship is captured or lost, lose Effect and opponent must lose 3 Force (5 if Falcon).",
+    "gameText": "Deploy on one opponent's unique (•) starship at a location you do not occupy. When starship is targeted by any tractor beam or ion cannon, subtract 2 from maneuver. If starship is captured or lost, lose Effect and opponent must lose 3 Force (5 if Falcon).",
     "destiny": 4,
     "icons": [
       {
@@ -101092,7 +101092,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Careless abuse of the Force by a young Jedi trainee can have dire consequences. When hanging from the weather vane of Cloud City, Luke's balance was his only hope.",
-    "gameText": "Deploy on table. If a unique (â€¢) card is drawn for destiny and a duplicate is on table, destiny card is lost (destiny = 0). If duplicated card is a character, it loses immunity to attrition for rest of turn and player must lose 2 Force or lose that character. (Immune to Alter.)",
+    "gameText": "Deploy on table. If a unique (•) card is drawn for destiny and a duplicate is on table, destiny card is lost (destiny = 0). If duplicated card is a character, it loses immunity to attrition for rest of turn and player must lose 2 Force or lose that character. (Immune to Alter.)",
     "destiny": 4,
     "icons": [
       {
@@ -103383,7 +103383,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "At Cloud City, Luke came face to face with his own destiny. Looking into the abyss, he made his decision.",
-    "gameText": "Deploy on table. If a unique (â€¢) card is drawn for destiny and a duplicate is on table, destiny card is lost (destiny = 0). If duplicated card is a character, it loses immunity to attrition for rest of turn and player must lose 2 Force or lose that character. (Immune to Alter.)",
+    "gameText": "Deploy on table. If a unique (•) card is drawn for destiny and a duplicate is on table, destiny card is lost (destiny = 0). If duplicated card is a character, it loses immunity to attrition for rest of turn and player must lose 2 Force or lose that character. (Immune to Alter.)",
     "destiny": 4,
     "icons": [
       {
@@ -103652,7 +103652,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "The face that launched a thousand starships.",
-    "gameText": "Deploy on Leia. While at any Rebel Base site, your Rebels, except unique (â€¢) Rebels, are deploy -2 and power +2 at same and adjacent sites. While at any system, your starfighters, except unique (â€¢) starfighters, are deploy -2 there.",
+    "gameText": "Deploy on Leia. While at any Rebel Base site, your Rebels, except unique (•) Rebels, are deploy -2 and power +2 at same and adjacent sites. While at any system, your starfighters, except unique (•) starfighters, are deploy -2 there.",
     "destiny": 3,
     "icons": [
       {
@@ -107673,7 +107673,7 @@
       "ALIEN"
     ],
     "lore": "Male Jawa. Leader of a large tribe of Jawas. Plotting with Jabba to take control of a neighboring tribe's territory.",
-    "gameText": "Deploys only on Tatooine. Your Jawa Pack is not unique(â€¢), is doubled, deploys free (or for 6 Force from each player) and cummulatively affects your Jawas' forfeit. While at Audience Chamber or Jawa Camp, all your other Jawas are power +2.",
+    "gameText": "Deploys only on Tatooine. Your Jawa Pack is not unique(•), is doubled, deploys free (or for 6 Force from each player) and cummulatively affects your Jawas' forfeit. While at Audience Chamber or Jawa Camp, all your other Jawas are power +2.",
     "deployCost": 3,
     "destiny": 2,
     "power": 2,
@@ -109535,7 +109535,7 @@
       "ALIEN"
     ],
     "lore": "Jawa leader. Seeking to peacefully settle a long-standing disagreement with his rival, Wittin. Wants Jabba to mediate their talks.",
-    "gameText": "Deploys only on Tatooine. Your Jawa Siesta is not unique(â€¢), is doubled, deploys free (or for 6 Force from each player) and cummulatively affects your Jawas' forfeit. While at Audience Chamber or Jawa Camp, all your other Jawas are power +2.",
+    "gameText": "Deploys only on Tatooine. Your Jawa Siesta is not unique(•), is doubled, deploys free (or for 6 Force from each player) and cummulatively affects your Jawas' forfeit. While at Audience Chamber or Jawa Camp, all your other Jawas are power +2.",
     "deployCost": 3,
     "destiny": 2,
     "power": 2,
@@ -109806,7 +109806,7 @@
       "ALIEN"
     ],
     "lore": "Female Twi'lek musician. Became a dancer to live a life of luxury. Has worked for Jabba for only two days. Desperate to escape.",
-    "gameText": "During your control phase, may cause opponent to reveal entire hand by using X Force, where X = number of cards in opponent's hand. All unique (â€¢) male Imperials or unique (â€¢) male aliens there are placed in opponent's Used Pile.",
+    "gameText": "During your control phase, may cause opponent to reveal entire hand by using X Force, where X = number of cards in opponent's hand. All unique (•) male Imperials or unique (•) male aliens there are placed in opponent's Used Pile.",
     "deployCost": 2,
     "destiny": 3,
     "power": 1,
@@ -111007,7 +111007,7 @@
     ],
     "cardSubtype": "LOST",
     "lore": "Reaching out with the Force, Luke rendered Ortugg unconscious without doing the Gamorrean any actual harm.",
-    "gameText": "During your control phase, cancel the game text of one unique (â€¢) alien for remainder of turn. OR If you just forfeited an alien, cancel all remaining attrition against you.",
+    "gameText": "During your control phase, cancel the game text of one unique (•) alien for remainder of turn. OR If you just forfeited an alien, cancel all remaining attrition against you.",
     "destiny": 4,
     "icons": [
       {
@@ -113562,7 +113562,7 @@
     ],
     "cardSubtype": "SITE",
     "locationDarkSideGameText": "May not be deployed to Bespin, Dagobah, Endor, Hoth, Kashyyyk or Yavin 4. Imperials are power -1 here.",
-    "locationLightSideGameText": "May not be deployed to Bespin, Dagobah, Endor, Hoth, Kashyyyk or Yavin 4. During your move phase, may move free between here and any related â—‡ spaceport site.",
+    "locationLightSideGameText": "May not be deployed to Bespin, Dagobah, Endor, Hoth, Kashyyyk or Yavin 4. During your move phase, may move free between here and any related ◇ spaceport site.",
     "deployCost": 0,
     "destiny": 0,
     "icons": [
@@ -114040,7 +114040,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "Deploy any planet system and one â—‡ site to that system. This system is the Subjugated planet. While this side up, once during each of your deploy phases, you may deploy one â—‡ site to the Subjugated planet from Reserve Deck; reshuffle. Flip this card if your matching operatives control at least three battleground sites related to the Subjugated planet.",
+    "gameText": "Deploy any planet system and one ◇ site to that system. This system is the Subjugated planet. While this side up, once during each of your deploy phases, you may deploy one ◇ site to the Subjugated planet from Reserve Deck; reshuffle. Flip this card if your matching operatives control at least three battleground sites related to the Subjugated planet.",
     "destiny": 0,
     "icons": [
       {
@@ -114168,7 +114168,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "While this side up, for opponent to initiate a Force drain, opponent must use +1 Force. During battle, opponent's unique (â€¢) characters, vehicles and starships lost from table are placed out of play; Leia adds one battle destiny; attrition against opponent is +2; and Imperials, Dark Jedi and Imperial starships lose all immunity to attrition. Flip this card if Leia is captured.",
+    "gameText": "While this side up, for opponent to initiate a Force drain, opponent must use +1 Force. During battle, opponent's unique (•) characters, vehicles and starships lost from table are placed out of play; Leia adds one battle destiny; attrition against opponent is +2; and Imperials, Dark Jedi and Imperial starships lose all immunity to attrition. Flip this card if Leia is captured.",
     "destiny": 7,
     "icons": [
       {
@@ -115639,7 +115639,7 @@
       "IMPERIAL"
     ],
     "lore": "Death Star trooper who witnessed Leia's interrogation. Senior tactical advisor to Sergeant Major Enfield. Coordinates security duty assignments for Detention Block AA-23.",
-    "gameText": "While Grenwick is on Death Star, your Death Star Sentry is not unique (â€¢), is doubled, deploys free, applies all three of its modifiers and is immune to Alter. Power -1 when not on Death Star.",
+    "gameText": "While Grenwick is on Death Star, your Death Star Sentry is not unique (•), is doubled, deploys free, applies all three of its modifiers and is immune to Alter. Power -1 when not on Death Star.",
     "deployCost": 1,
     "destiny": 3,
     "power": 2,
@@ -116012,7 +116012,7 @@
       "REBEL"
     ],
     "lore": "Commander from Ralltiir. Fled from his homeworld after its occupation by the Empire. Was instrumental in the establishment of the new Rebel base on Hoth.",
-    "gameText": "While McQuarrie is on Hoth, your Hoth Sentry is not unique (â€¢), is doubled, deploys free, applies all of its modifiers and is immune to Alter. Power -1 when not on Hoth.",
+    "gameText": "While McQuarrie is on Hoth, your Hoth Sentry is not unique (•), is doubled, deploys free, applies all of its modifiers and is immune to Alter. Power -1 when not on Hoth.",
     "deployCost": 2,
     "destiny": 3,
     "power": 2,
@@ -116404,7 +116404,7 @@
       "REBEL"
     ],
     "lore": "Formerly belonged to the Corellian militia. Popular musician before the Empire blacklisted his songs for their political content. Joined the Alliance with his wife, Duriet.",
-    "gameText": "While Grondorn is on Yavin 4, your Yavin Sentry is not unique (â€¢), is doubled, deploys free, applies all three of its modifiers and is immune to Alter. Power -1 when not on Yavin 4.",
+    "gameText": "While Grondorn is on Yavin 4, your Yavin Sentry is not unique (•), is doubled, deploys free, applies all three of its modifiers and is immune to Alter. Power -1 when not on Yavin 4.",
     "deployCost": 3,
     "destiny": 2,
     "power": 2,
@@ -117796,7 +117796,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Vader was nearly killed when Han damaged his TIE fighter during a surprise attack in the Death Star trench.",
-    "gameText": "Deploy on your side of table. During a battle, you may place out of play from hand a copy of any unique (â€¢) card participating in that battle to reduce attrition against you by that card's forfeit value. (Immune to Alter while you occupy a battleground.)",
+    "gameText": "Deploy on your side of table. During a battle, you may place out of play from hand a copy of any unique (•) card participating in that battle to reduce attrition against you by that card's forfeit value. (Immune to Alter while you occupy a battleground.)",
     "destiny": 2,
     "icons": [
       {
@@ -120309,7 +120309,7 @@
       "LOCATION"
     ],
     "cardSubtype": "SITE",
-    "locationDarkSideGameText": "May not deploy to Bespin, Dagobah, Endor, Hoth, Kashyyyk or Yavin 4. During your move phase, may move free between here and any related â—‡ spaceport site.",
+    "locationDarkSideGameText": "May not deploy to Bespin, Dagobah, Endor, Hoth, Kashyyyk or Yavin 4. During your move phase, may move free between here and any related ◇ spaceport site.",
     "locationLightSideGameText": "May not deploy to Bespin, Dagobah, Endor, Hoth, Kashyyyk or Yavin 4. Rebels are power -1 here.",
     "deployCost": 0,
     "destiny": 0,
@@ -120615,7 +120615,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "Deploy any planet system and one â—‡ site to that system. This system is the Renegade planet. While this side up, once during each of your deploy phases, you may deploy one â—‡ site to the Renegade planet from Reserve Deck; reshuffle. Flip this card if your matching operatives control at least three battleground sites related to the Renegade planet.",
+    "gameText": "Deploy any planet system and one ◇ site to that system. This system is the Renegade planet. While this side up, once during each of your deploy phases, you may deploy one ◇ site to the Renegade planet from Reserve Deck; reshuffle. Flip this card if your matching operatives control at least three battleground sites related to the Renegade planet.",
     "destiny": 0,
     "icons": [
       {
@@ -120755,7 +120755,7 @@
       "REBEL"
     ],
     "lore": "Former Imperial pilot. Joined the Alliance shortly after the Battle of Yavin. Flew cover for Bright Hope during the evacuation of Hoth. Expert marksman.",
-    "gameText": "Deploys -1 aboard your unique (â€¢) Rebel starfighter. Adds 2 to power of anything he pilots. When starfighter he pilots fires a starship weapon, characters aboard target are forfeit = 0 for remainder of turn.",
+    "gameText": "Deploys -1 aboard your unique (•) Rebel starfighter. Adds 2 to power of anything he pilots. When starfighter he pilots fires a starship weapon, characters aboard target are forfeit = 0 for remainder of turn.",
     "deployCost": 2,
     "destiny": 3,
     "power": 1,
@@ -120844,7 +120844,7 @@
     ],
     "cardSubtype": "CAPITAL",
     "lore": "Bossk once said of his ship, 'Greeezeg uut nikek!'",
-    "gameText": "May add 6 passengers and 1 vehicle. Permanent pilot is â€¢Bossk, who provides ability of 2, adds 2 to power and adds one battle destiny. Deploys and moves like a starfighter. Has ship-docking capability.",
+    "gameText": "May add 6 passengers and 1 vehicle. Permanent pilot is •Bossk, who provides ability of 2, adds 2 to power and adds one battle destiny. Deploys and moves like a starfighter. Has ship-docking capability.",
     "deployCost": 8,
     "destiny": 1,
     "power": 5,
@@ -120961,7 +120961,7 @@
     ],
     "cardSubtype": "SQUADRON",
     "lore": "Notoriety gained during the assaults on Ralltiir and Mon Calamari makes this the most feared squadron in the Empire. Defended the Death Star during the Battle of Yavin.",
-    "gameText": "Permanent pilots aboard are â€¢Darth Vader, â€¢DS-61-2 and â€¢DS-61-3, who provide total ability of 10 and add 9 to total power of â€¢Vader's Custom TIE, â€¢Black 2 and â€¢Black 3.",
+    "gameText": "Permanent pilots aboard are •Darth Vader, •DS-61-2 and •DS-61-3, who provide total ability of 10 and add 9 to total power of •Vader's Custom TIE, •Black 2 and •Black 3.",
     "deployCost": 12,
     "destiny": 1,
     "power": 3,
@@ -121066,7 +121066,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Lead starfighter of Obsidian Squadron. Flown by Cive Rashon. Call sign 'Howlrunner.' She served in an elite TIE squadron aboard the Star Destroyer Avenger.",
-    "gameText": "Deploy -1 and power +3 at a cloud sector. Permanent pilot is â€¢OS-72-1, who provides ability of 2, adds 2 to power and, at a cloud sector, may draw one battle destiny if not able to otherwise.",
+    "gameText": "Deploy -1 and power +3 at a cloud sector. Permanent pilot is •OS-72-1, who provides ability of 2, adds 2 to power and, at a cloud sector, may draw one battle destiny if not able to otherwise.",
     "deployCost": 5,
     "destiny": 2,
     "power": 2,
@@ -121109,7 +121109,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Piloted by Dodson Makraven, wingman of Cive Rashon. Experienced TIE pilot with many kills in atmospheric combat. Nicknamed 'Night Beast' for his many curfew violations.",
-    "gameText": "Deploy -1 and power +3 at a cloud sector. Permanent pilot is â€¢OS-72-2, who provides ability of 2, adds 2 to power and, at a cloud sector, may draw one battle destiny if not able to otherwise.",
+    "gameText": "Deploy -1 and power +3 at a cloud sector. Permanent pilot is •OS-72-2, who provides ability of 2, adds 2 to power and, at a cloud sector, may draw one battle destiny if not able to otherwise.",
     "deployCost": 4,
     "destiny": 3,
     "power": 1,
@@ -122766,7 +122766,7 @@
       "CREATURE"
     ],
     "lore": "Considered to be a nuisance. Feeds on garbage. Its only defense is its speed. Nasty bite attack when surprised or cornered. Grow as big as 1.2 meters long.",
-    "gameText": "Habitat: planet sites. Landspeed = 2. Ferocity +2 when present at Mos Eisley or any â—‡ spaceport site.",
+    "gameText": "Habitat: planet sites. Landspeed = 2. Ferocity +2 when present at Mos Eisley or any ◇ spaceport site.",
     "deployCost": 2,
     "destiny": 5,
     "forfeit": 0,
@@ -123257,7 +123257,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Company responsible for design of the rugged Y-wing snub fighter. Maintains sales offices on many planets. Koensayr parts often find their way into a variety of ships.",
-    "gameText": "Deploy on Ralltiir system. Once during each of your control phases, you may retrieve one Y-wing. Also Special Modifications is not unique (â€¢) and makes its target immune to attrition < 4. Suspended while opponent controls Ralltiir. (Immune to Alter.)",
+    "gameText": "Deploy on Ralltiir system. Once during each of your control phases, you may retrieve one Y-wing. Also Special Modifications is not unique (•) and makes its target immune to attrition < 4. Suspended while opponent controls Ralltiir. (Immune to Alter.)",
     "destiny": 4,
     "icons": [
       {
@@ -123443,7 +123443,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Luke barely escaped being crushed by the AT-AT's massive footpad during the Battle of Hoth.",
-    "gameText": "Deploy on your side of table. During a battle, you may place out of play from hand a copy of any unique (â€¢) card participating in that battle to reduce attrition against you by that card's forfeit value. (Immune to Alter while you occupy a battleground.)",
+    "gameText": "Deploy on your side of table. During a battle, you may place out of play from hand a copy of any unique (•) card participating in that battle to reduce attrition against you by that card's forfeit value. (Immune to Alter while you occupy a battleground.)",
     "destiny": 2,
     "icons": [
       {
@@ -124753,7 +124753,7 @@
       "ALIEN"
     ],
     "lore": "Ewok sentries Scout the perimeter of their domain. Their watchful eyes search for both predatory animals and invading stormtroopers.",
-    "gameText": "Deploys only on Endor. Power and forfeit +1 for each Light side icon at same Endor site. May deploy as a 'react'. May move as a 'react' (for free) to a battle where you have a unique (â€¢) Ewok.",
+    "gameText": "Deploys only on Endor. Power and forfeit +1 for each Light side icon at same Endor site. May deploy as a 'react'. May move as a 'react' (for free) to a battle where you have a unique (•) Ewok.",
     "deployCost": 1,
     "destiny": 3,
     "power": 0,
@@ -125330,7 +125330,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "When an Imperial blockade raises the alert level, all independent ships are scanned and any suspicious characters on planet are detained and interrogated.",
-    "gameText": "Deploy on table. Unique (â€¢) Imperials of ability < 3 are forfeit +2. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites. Once during each of your deploy phases, may deploy one docking bay from Reserve Deck; reshuffle. (Immune to Alter.)",
+    "gameText": "Deploy on table. Unique (•) Imperials of ability < 3 are forfeit +2. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites. Once during each of your deploy phases, may deploy one docking bay from Reserve Deck; reshuffle. (Immune to Alter.)",
     "destiny": 5,
     "icons": [
       {
@@ -125659,7 +125659,7 @@
     ],
     "cardSubtype": "USED_OR_STARTING",
     "lore": "Imperial troops prepared for quick deployment to seize valuable terrain.",
-    "gameText": "USED: If a battle was just initiated, draw destiny and activate up to that much Force. STARTING: If you have not deployed an Objective, deploy from Reserve Deck one battleground site (or two â—‡ sites) related to your starting location. Place Interrupt in Reserve Deck.",
+    "gameText": "USED: If a battle was just initiated, draw destiny and activate up to that much Force. STARTING: If you have not deployed an Objective, deploy from Reserve Deck one battleground site (or two ◇ sites) related to your starting location. Place Interrupt in Reserve Deck.",
     "destiny": 5,
     "icons": [
       {
@@ -126171,7 +126171,7 @@
     ],
     "cardSubtype": "USED_OR_LOST",
     "lore": "Imperial training allows scouts to use speed and stealth to their advantage. On Endor, they were also backed up by Commander Igar's ATSTs.",
-    "gameText": "USED: If all of your ability in a battle is provided by scouts and/or spies, they each add 1 to your total battle destiny (limit +6). LOST: For remainder of turn, your unique (â€¢) scouts and unique (â€¢) spies are each power +1 (or +2 while being attacked by a creature).",
+    "gameText": "USED: If all of your ability in a battle is provided by scouts and/or spies, they each add 1 to your total battle destiny (limit +6). LOST: For remainder of turn, your unique (•) scouts and unique (•) spies are each power +1 (or +2 while being attacked by a creature).",
     "destiny": 4,
     "icons": [
       {
@@ -128287,7 +128287,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Rebel insurgents and local activists are the first step in breaking the Imperial stranglehold on a world.",
-    "gameText": "Deploy on table. Unique (â€¢) Rebels of ability < 3 are forfeit +2. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites. Once during each of your deploy phases, may deploy one docking bay from Reserve Deck; reshuffle. (Immune to Alter.)",
+    "gameText": "Deploy on table. Unique (•) Rebels of ability < 3 are forfeit +2. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites. Once during each of your deploy phases, may deploy one docking bay from Reserve Deck; reshuffle. (Immune to Alter.)",
     "destiny": 5,
     "icons": [
       {
@@ -128405,7 +128405,7 @@
     ],
     "cardSubtype": "USED_OR_STARTING",
     "lore": "Alliance troops on planet must plan ahead to achieve success in military operations.",
-    "gameText": "USED: If a battle was just initiated, draw destiny and activate up to that much Force. STARTING: If you have not deployed an Objective, deploy from Reserve Deck one battleground site (or two â—‡ sites) related to your starting location. Place Interrupt in Reserve Deck.",
+    "gameText": "USED: If a battle was just initiated, draw destiny and activate up to that much Force. STARTING: If you have not deployed an Objective, deploy from Reserve Deck one battleground site (or two ◇ sites) related to your starting location. Place Interrupt in Reserve Deck.",
     "destiny": 5,
     "icons": [
       {
@@ -128908,7 +128908,7 @@
     ],
     "cardSubtype": "USED_OR_LOST",
     "lore": "The ability to think and act independently gave the Rebels an advantage over their Imperial foes.",
-    "gameText": "USED: If all of your ability in a battle is provided by scouts and/or spies, they each add 1 to your total battle destiny (limit +6). LOST: For remainder of turn, your unique (â€¢) scouts and unique (â€¢) spies are each power +1 (or +2 while being attacked by a creature).",
+    "gameText": "USED: If all of your ability in a battle is provided by scouts and/or spies, they each add 1 to your total battle destiny (limit +6). LOST: For remainder of turn, your unique (•) scouts and unique (•) spies are each power +1 (or +2 while being attacked by a creature).",
     "destiny": 3,
     "icons": [
       {
@@ -130948,7 +130948,7 @@
       "IMPERIAL"
     ],
     "lore": "Wingman of Major Phennir. Earned promotion to Fel's squadron by scoring 12 kills at Mon Calamari. Repeatedly refused further promotion so that he could remain in the 181st.",
-    "gameText": "Adds 3 to power of any TIE he pilots. Once during each of your deploy phases, you may take one unique (â€¢) TIE Interceptor into hand from Reserve Deck; reshuffle.",
+    "gameText": "Adds 3 to power of any TIE he pilots. Once during each of your deploy phases, you may take one unique (•) TIE Interceptor into hand from Reserve Deck; reshuffle.",
     "deployCost": 2,
     "destiny": 4,
     "power": 2,
@@ -134129,7 +134129,7 @@
       "REBEL"
     ],
     "lore": "Rescued from an Imperial detention center by Wedge Antilles. Rogue Squadron veteran. Assigned to Red Squadron at the Battle of Endor. Coordinates with Rebellion procurement.",
-    "gameText": "Adds 2 to the power of anything he pilots. When at a system, sector, or docking bay, once during each of your deploy phases, subtracts 2 from deploy cost of your unique (â€¢) X-wing deploying here.",
+    "gameText": "Adds 2 to the power of anything he pilots. When at a system, sector, or docking bay, once during each of your deploy phases, subtracts 2 from deploy cost of your unique (•) X-wing deploying here.",
     "deployCost": 2,
     "destiny": 3,
     "power": 2,
@@ -134197,7 +134197,7 @@
       "REBEL"
     ],
     "lore": "Rogue Squadron pilot. Assigned as gunner aboard Colonel Salm's Y-wing at Battle of Endor, as part of Gray Squadron. Former member of Aggressor Squadron.",
-    "gameText": "Adds 1 to power of anything he pilots. While aboard your starship, adds 2 to each of its weapon destiny draws. While aboard a unique (â€¢) Gray Squadron Y-wing at a system or sector, adds 1 to each of your Force drains there.",
+    "gameText": "Adds 1 to power of anything he pilots. While aboard your starship, adds 2 to each of its weapon destiny draws. While aboard a unique (•) Gray Squadron Y-wing at a system or sector, adds 1 to each of your Force drains there.",
     "deployCost": 2,
     "destiny": 3,
     "power": 2,
@@ -134331,7 +134331,7 @@
       "REBEL"
     ],
     "lore": "One of only four attackers who survived the raid on the Imperial Academy at Carida. Gray Squadron pilot.",
-    "gameText": "Adds 2 to power of anything he pilots. When at a system, sector or docking bay, once during each of your deploy phases, subtracts 2 from deploy cost of your unique (â€¢) Y-wing deploying there.",
+    "gameText": "Adds 2 to power of anything he pilots. When at a system, sector or docking bay, once during each of your deploy phases, subtracts 2 from deploy cost of your unique (•) Y-wing deploying there.",
     "deployCost": 2,
     "destiny": 3,
     "power": 2,
@@ -134978,7 +134978,7 @@
     "cardTypes": [
       "ADMIRALS_ORDER"
     ],
-    "gameText": "Unique (â€¢) starfighters without permanent pilots are immune to attrition < 4 (or add 2 to immunity if starfighter already has immunity). Starships without pilot characters aboard are power -2. At docking bays related to systems you occupy, your Force drains are +1. Once per turn, your starfighter just lost from a system may be relocated to a related docking bay.",
+    "gameText": "Unique (•) starfighters without permanent pilots are immune to attrition < 4 (or add 2 to immunity if starfighter already has immunity). Starships without pilot characters aboard are power -2. At docking bays related to systems you occupy, your Force drains are +1. Once per turn, your starfighter just lost from a system may be relocated to a related docking bay.",
     "deployCost": 0,
     "destiny": 6,
     "icons": [
@@ -135063,7 +135063,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Admiral Ackbar's hit-and-fade tactics force the Imperial Navy to spread throughout the galaxy in a futile attempt to engage the Rebels.",
-    "gameText": "Deploy on table. While you control a battleground site, your Force drain may not be modified or canceled at a system where you have a Star Cruiser or unique(â€¢) starfighter, except by a 'react.' Place Effect in Used Pile if you lose a battle at a system.",
+    "gameText": "Deploy on table. While you control a battleground site, your Force drain may not be modified or canceled at a system where you have a Star Cruiser or unique(•) starfighter, except by a 'react.' Place Effect in Used Pile if you lose a battle at a system.",
     "destiny": 5,
     "icons": [
       {
@@ -135317,7 +135317,7 @@
     ],
     "cardSubtype": "USED",
     "lore": "'And see if you can get a few of those TIE fighters to follow you.'",
-    "gameText": "If your piloted unique (â€¢) starfighter is present with opponent's piloted starfighter during your move phase at a non-cloud sector, relocate both to related system. OR Target your starfighter in battle. During this battle, your other starships may not be targeted by weapons.",
+    "gameText": "If your piloted unique (•) starfighter is present with opponent's piloted starfighter during your move phase at a non-cloud sector, relocate both to related system. OR Target your starfighter in battle. During this battle, your other starships may not be targeted by weapons.",
     "destiny": 5,
     "icons": [
       {
@@ -137386,7 +137386,7 @@
     "cardTypes": [
       "ADMIRALS_ORDER"
     ],
-    "gameText": "Unique (â€¢) starfighters without permanent pilots are immune to attrition < 4 (or add 2 to immunity if starfighter already has immunity). Starships without pilot characters aboard are power -2. At docking bays related to systems you occupy, your Force drains are +1. Once per turn, your starfighter just lost from a system may be relocated to a related docking bay.",
+    "gameText": "Unique (•) starfighters without permanent pilots are immune to attrition < 4 (or add 2 to immunity if starfighter already has immunity). Starships without pilot characters aboard are power -2. At docking bays related to systems you occupy, your Force drains are +1. Once per turn, your starfighter just lost from a system may be relocated to a related docking bay.",
     "deployCost": 0,
     "destiny": 6,
     "icons": [

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database.json
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     "cardId": "101_1",
     "title": "Death Star: Level 6 Core Shaft Corridor",
@@ -50,7 +50,7 @@
       "REBEL"
     ],
     "lore": "Raised by guardians Owen and Beru Lars on a moisture farm on Tatooine, where Owen wanted him to stay. Nicknamed 'Wormie' by childhood friends Camie and Fixer.",
-    "gameText": "Must deploy on Tatooine, but may move elsewhere. May not be deployed if two or more of opponent's unique (•) characters on table. Your warriors at same site as Luke, or adjacent sites are forfeit +1.",
+    "gameText": "Must deploy on Tatooine, but may move elsewhere. May not be deployed if two or more of opponent's unique (â€¢) characters on table. Your warriors at same site as Luke, or adjacent sites are forfeit +1.",
     "deployCost": 4,
     "destiny": 1,
     "power": 2,
@@ -147,7 +147,7 @@
       "IMPERIAL"
     ],
     "lore": "Sought to extinguish all Jedi. Former student of Obi-Wan Kenobi. Seduced by the dark side of the Force.",
-    "gameText": "Must deploy on Death Star, but may move elsewhere. May not be deployed if two or more of opponent's unique (•) characters on table. If in a losing battle, draw destiny. If destiny > 4, 'choke' (lose) one Imperial present (your choice).",
+    "gameText": "Must deploy on Death Star, but may move elsewhere. May not be deployed if two or more of opponent's unique (â€¢) characters on table. If in a losing battle, draw destiny. If destiny > 4, 'choke' (lose) one Imperial present (your choice).",
     "deployCost": 7,
     "destiny": 1,
     "power": 4,
@@ -586,7 +586,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "At the Battle of Yavin, Dutch led his squadron of outdated but reliable Y-wings in the first wave of the assault against the Death Star.",
-    "gameText": "May add 1 pilot or passenger. Permanent pilot aboard is •Dutch, who provides ability of 2, adds 2 to power and may draw one battle destiny if not able to otherwise.",
+    "gameText": "May add 1 pilot or passenger. Permanent pilot aboard is â€¢Dutch, who provides ability of 2, adds 2 to power and may draw one battle destiny if not able to otherwise.",
     "deployCost": 5,
     "destiny": 2,
     "power": 2,
@@ -636,7 +636,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Called 'Boss' or 'Chief' by his squadron, Garven Dreis was the first pilot to fire proton torpedoes at the Death Star's exhaust port during the Battle of Yavin.",
-    "gameText": "Permanent pilot aboard is •Red Leader, who provides ability of 2, adds 2 to power and may draw one battle destiny if not able to otherwise.",
+    "gameText": "Permanent pilot aboard is â€¢Red Leader, who provides ability of 2, adds 2 to power and may draw one battle destiny if not able to otherwise.",
     "deployCost": 6,
     "destiny": 2,
     "power": 3,
@@ -685,7 +685,7 @@
       "REBEL"
     ],
     "lore": "Loyal Wookiee companion of Captain Han Solo. Co-pilot of the Millennium Falcon. Leia referred to him as a 'walking carpet.'",
-    "gameText": "Must deploy on Hoth, but may move elsewhere. May not be deployed if three or more of opponent's unique (•) characters on table.",
+    "gameText": "Must deploy on Hoth, but may move elsewhere. May not be deployed if three or more of opponent's unique (â€¢) characters on table.",
     "deployCost": 5,
     "destiny": 1,
     "power": 4,
@@ -887,7 +887,7 @@
       "IMPERIAL"
     ],
     "lore": "General of the AT-AT assault armor division sent by Darth Vader to crush the Rebellion on Hoth. Cold and ruthless.",
-    "gameText": "Must deploy on Hoth, but may move elsewhere. May not be deployed if three or more of opponent's unique (•) characters on table. Snowtroopers at same site are forfeit +1.",
+    "gameText": "Must deploy on Hoth, but may move elsewhere. May not be deployed if three or more of opponent's unique (â€¢) characters on table. Snowtroopers at same site are forfeit +1.",
     "deployCost": 4,
     "destiny": 1,
     "power": 2,
@@ -1134,7 +1134,7 @@
     ],
     "cardSubtype": "SQUADRON",
     "lore": "Notoriety gained during the assaults on Ralltiir and Mon Calamari makes this the most feared squadron in the Empire. Defended the Death Star during the Battle of Yavin.",
-    "gameText": "Permanent pilots aboard are •Darth Vader, •DS-61-2 and •DS-61-3, who provide total ability of 10 and add 9 to total power of •Vader's Custom TIE, •Black 2 and •Black 3.",
+    "gameText": "Permanent pilots aboard are â€¢Darth Vader, â€¢DS-61-2 and â€¢DS-61-3, who provide total ability of 10 and add 9 to total power of â€¢Vader's Custom TIE, â€¢Black 2 and â€¢Black 3.",
     "deployCost": 12,
     "destiny": 1,
     "power": 3,
@@ -2179,7 +2179,7 @@
       "REBEL"
     ],
     "lore": "Scoundrel, smuggler, gambler and risk taker. 'Everything's going to be fine. Trust me.'",
-    "gameText": "Adds 3 to power of anything he pilots. Adds one battle destiny if with Luke or Chewie. Permanent weapon is •Han's Heavy Blaster Pistol (may target a character or creature for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value).",
+    "gameText": "Adds 3 to power of anything he pilots. Adds one battle destiny if with Luke or Chewie. Permanent weapon is â€¢Han's Heavy Blaster Pistol (may target a character or creature for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value).",
     "deployCost": 4,
     "destiny": 1,
     "power": 4,
@@ -2232,7 +2232,7 @@
       "REBEL"
     ],
     "lore": "Spirited leader. 'I am not a committee!'",
-    "gameText": "Adds 1 to power of anything she pilots. Adds one battle destiny if with Han. Permanent weapon is •Leia's Blaster Rifle (may target a character or creature for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value).",
+    "gameText": "Adds 1 to power of anything she pilots. Adds one battle destiny if with Han. Permanent weapon is â€¢Leia's Blaster Rifle (may target a character or creature for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value).",
     "deployCost": 4,
     "destiny": 1,
     "power": 3,
@@ -2285,7 +2285,7 @@
       "REBEL"
     ],
     "lore": "'I've taken care of everything.'",
-    "gameText": "Adds 2 to power of anything he pilots. Permanent weapon is •Luke's Lightsaber (may target a character or creature for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
+    "gameText": "Adds 2 to power of anything he pilots. Permanent weapon is â€¢Luke's Lightsaber (may target a character or creature for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
     "deployCost": 5,
     "destiny": 1,
     "power": 5,
@@ -2333,7 +2333,7 @@
       "REBEL"
     ],
     "lore": "'The Force will be with you... always.'",
-    "gameText": "Permanent weapon is •Obi-Wan's Lightsaber (may target a character or creature for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
+    "gameText": "Permanent weapon is â€¢Obi-Wan's Lightsaber (may target a character or creature for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
     "deployCost": 5,
     "destiny": 1,
     "power": 5,
@@ -2377,7 +2377,7 @@
       "ALIEN"
     ],
     "lore": "Notorious bounty hunter. 'As you wish.'",
-    "gameText": "Adds 3 to power of anything he pilots. Adds one battle destiny if with Han or Jabba. Permanent weapon is •Boba Fett's Blaster Rifle (may target a character or creature for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value).",
+    "gameText": "Adds 3 to power of anything he pilots. Adds one battle destiny if with Han or Jabba. Permanent weapon is â€¢Boba Fett's Blaster Rifle (may target a character or creature for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value).",
     "deployCost": 5,
     "destiny": 1,
     "power": 4,
@@ -2429,7 +2429,7 @@
       "IMPERIAL"
     ],
     "lore": "'If you only knew the power of the dark side.'",
-    "gameText": "Adds 3 to power of anything he pilots. Permanent weapon is •Vader's Lightsaber (may target a character or creature for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
+    "gameText": "Adds 3 to power of anything he pilots. Permanent weapon is â€¢Vader's Lightsaber (may target a character or creature for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
     "deployCost": 6,
     "destiny": 1,
     "power": 6,
@@ -2530,7 +2530,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Corellian starfighter. Dengar replaced its passenger capacity and TIE cannons with enhanced targeting systems. Allows Dengar to track and engage multiple enemies at once.",
-    "gameText": "Permanent pilot is •Dengar, who provides ability of 2 and adds 2 to power. When in battle, adds 1 to total battle destiny for each opponent's starship present. Cancels opponent's immunity to attrition here.",
+    "gameText": "Permanent pilot is â€¢Dengar, who provides ability of 2 and adds 2 to power. When in battle, adds 1 to total battle destiny for each opponent's starship present. Cancels opponent's immunity to attrition here.",
     "deployCost": 5,
     "destiny": 1,
     "power": 2,
@@ -2687,7 +2687,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Heavily modified Corellian YT-1300 freighter. 'She's the fastest hunk of junk in the galaxy.'",
-    "gameText": "May add 1 pilot and 2 passengers. Permanent pilot is •Lando, who provides ability of 3 and adds 3 to power. May not be piloted by Han unless he won a hand of sabacc this game. Immune to attrition < 5.",
+    "gameText": "May add 1 pilot and 2 passengers. Permanent pilot is â€¢Lando, who provides ability of 3 and adds 3 to power. May not be piloted by Han unless he won a hand of sabacc this game. Immune to attrition < 5.",
     "deployCost": 5,
     "destiny": 2,
     "power": 3,
@@ -2900,7 +2900,7 @@
       "DROID"
     ],
     "lore": "Accomplished thief and information broker. Modified by Jabba to be an effective bounty hunter. The Hutt often teams 4-LOM with other hired killers.",
-    "gameText": "Adds one battle destiny if with Jabba or Zuckuss. Permanent weapon is •4-LOM's Concussion Rifle (may target a character for free; target may not use its game text for remainder of turn).",
+    "gameText": "Adds one battle destiny if with Jabba or Zuckuss. Permanent weapon is â€¢4-LOM's Concussion Rifle (may target a character for free; target may not use its game text for remainder of turn).",
     "deployCost": 3,
     "destiny": 3,
     "power": 2,
@@ -2982,7 +2982,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Dangerous and deadly starfighter piloted by its notorious owner. Uses combat-grade shields and sensors. Hidden weapons provide lethal surprises for Fett's victims.",
-    "gameText": "May add 3 passengers. Permanent pilot is •Boba Fett, who provides ability of 3, adds 3 to power, adds 2 to maneuver and draws one battle destiny if not able to otherwise. Immune to attrition < 5.",
+    "gameText": "May add 3 passengers. Permanent pilot is â€¢Boba Fett, who provides ability of 3, adds 3 to power, adds 2 to maneuver and draws one battle destiny if not able to otherwise. Immune to attrition < 5.",
     "deployCost": 7,
     "destiny": 1,
     "power": 4,
@@ -3276,7 +3276,7 @@
       "DEVICE"
     ],
     "lore": "Written by Obi-Wan Kenobi. Used by Luke to construct his lightsaber. Contained instructions on building required tools as well. Keyed to self-destruct if not opened by Luke.",
-    "gameText": "Deploy on Luke or Obi-Wan. Your characters present armed with a unique (•) lightsaber Weapon card may not be Disarmed, once per battle may cancel a weapon destiny just drawn, and that lightsaber's Force drain modifiers may not be canceled. Lost if about to be stolen.",
+    "gameText": "Deploy on Luke or Obi-Wan. Your characters present armed with a unique (â€¢) lightsaber Weapon card may not be Disarmed, once per battle may cancel a weapon destiny just drawn, and that lightsaber's Force drain modifiers may not be canceled. Lost if about to be stolen.",
     "destiny": 2,
     "icons": [
       {
@@ -3501,7 +3501,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Owned by legendary Terrik family of smugglers. Used to chase down the pirates who killed Wedge's parents. On Corellian Security's most wanted list. 37.5 meters long.",
-    "gameText": "May add 2 pilots and 6 passengers. May add ability of your (•) unique smuggler aboard to X on Kessel Run targeting that smuggler. When Booster, Mirax or Wedge piloting, Immune to attrition < 5.",
+    "gameText": "May add 2 pilots and 6 passengers. May add ability of your (â€¢) unique smuggler aboard to X on Kessel Run targeting that smuggler. When Booster, Mirax or Wedge piloting, Immune to attrition < 5.",
     "deployCost": 2,
     "destiny": 2,
     "power": 2,
@@ -5221,7 +5221,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Zuckuss is a dangerous adversary, especially when aboard his own starship. Mystical omens enable the Gand to predict enemy maneuvers in starship combat.",
-    "gameText": "May add 1 pilot and 3 passengers. Permanent pilot is •Zuckuss, who provides ability of 4 and adds 2 to power. Unless opponent has total ability > 6 piloting here, opponent's total battle destiny here = zero.",
+    "gameText": "May add 1 pilot and 3 passengers. Permanent pilot is â€¢Zuckuss, who provides ability of 4 and adds 2 to power. Unless opponent has total ability > 6 piloting here, opponent's total battle destiny here = zero.",
     "deployCost": 6,
     "destiny": 1,
     "power": 2,
@@ -5411,7 +5411,7 @@
       "ALIEN"
     ],
     "lore": "Trandoshan bounty hunter. Modified his mortar gun to fire stun cartridges for live captures. Uses non-fragmentary capture rounds to minimize collateral damage.",
-    "gameText": "Adds 2 to power of anything he pilots. Permanent weapon is •Bossk's Mortar Gun (may fire for free; draw destiny; may subtract or add 1 if at same site as a bounty; choose one character with that destiny number present to be captured.)",
+    "gameText": "Adds 2 to power of anything he pilots. Permanent weapon is â€¢Bossk's Mortar Gun (may fire for free; draw destiny; may subtract or add 1 if at same site as a bounty; choose one character with that destiny number present to be captured.)",
     "deployCost": 5,
     "destiny": 1,
     "power": 4,
@@ -5514,7 +5514,7 @@
       "ALIEN"
     ],
     "lore": "Corellian bounty hunter. Skilled athlete. Expert shot. Has worked many times for Jabba the Hutt. Carries a long-standing grudge against Han Solo.",
-    "gameText": "Adds 2 to the power of anything he pilots. Permanent weapon is •Dengar's Blaster Carbine (may target a character, creature or vehicle for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value; may be fired twice per battle).",
+    "gameText": "Adds 2 to the power of anything he pilots. Permanent weapon is â€¢Dengar's Blaster Carbine (may target a character, creature or vehicle for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value; may be fired twice per battle).",
     "deployCost": 5,
     "destiny": 2,
     "power": 3,
@@ -5567,7 +5567,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Starship adapted to the assassin droid's specifications. Flight controls linked directly to processing unit. Real-time relays minimize response time.",
-    "gameText": "May add 2 passengers. Permanent pilot is •IG-88, who adds 2 to power and 3 to maneuver. May initiate battle. When in a battle you initiate, adds one battle destiny. Ion Cannon may deploy aboard.",
+    "gameText": "May add 2 passengers. Permanent pilot is â€¢IG-88, who adds 2 to power and 3 to maneuver. May initiate battle. When in a battle you initiate, adds one battle destiny. Ion Cannon may deploy aboard.",
     "deployCost": 5,
     "destiny": 1,
     "power": 3,
@@ -5919,7 +5919,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "Deploy Hutt Trade Route and a Jabba's Palace site. May deploy Yarna d'al' Gargan. Reveal one unique (•) alien from your deck whose lore specifies its species. This card is your Rep. For remainder of game, your Rep is a leader. Yarna d'al' Gargan is immune to Alter. You may not deploy 'insert' cards or operatives. While a rancor is at Rancor Pit, Trap Door is immune to Bo Shuda. Flip this card if you occupy two battleground sites (must occupy a third with a non-unique alien of your Rep's species if a non-Tatooine location is on table).",
+    "gameText": "Deploy Hutt Trade Route and a Jabba's Palace site. May deploy Yarna d'al' Gargan. Reveal one unique (â€¢) alien from your deck whose lore specifies its species. This card is your Rep. For remainder of game, your Rep is a leader. Yarna d'al' Gargan is immune to Alter. You may not deploy 'insert' cards or operatives. While a rancor is at Rancor Pit, Trap Door is immune to Bo Shuda. Flip this card if you occupy two battleground sites (must occupy a third with a non-unique alien of your Rep's species if a non-Tatooine location is on table).",
     "destiny": 0,
     "icons": [
       {
@@ -6134,7 +6134,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "Deploy Desert Heart and a Jabba's Palace site. May deploy Well Guarded. Reveal one unique (•) alien from your deck whose lore specifies its species. This card is your Rep. For remainder of game, your Rep is a leader. Well Guarded is immune to Alter. You may not deploy 'insert' cards or operatives. While frozen Han on table, Rebels are immune to No Bargain and Bad Feeling Have I. Flip this card if you occupy two battleground sites (must occupy a third with a non-unique alien of your Rep's species if a non-Tatooine location is on table).",
+    "gameText": "Deploy Desert Heart and a Jabba's Palace site. May deploy Well Guarded. Reveal one unique (â€¢) alien from your deck whose lore specifies its species. This card is your Rep. For remainder of game, your Rep is a leader. Well Guarded is immune to Alter. You may not deploy 'insert' cards or operatives. While frozen Han on table, Rebels are immune to No Bargain and Bad Feeling Have I. Flip this card if you occupy two battleground sites (must occupy a third with a non-unique alien of your Rep's species if a non-Tatooine location is on table).",
     "destiny": 0,
     "icons": [
       {
@@ -6188,7 +6188,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Jabba's influence is not easily ignored. Neither are his voracious and vile appetites. Even Jedi soon learn this lesson.",
-    "gameText": "Deploy on table. You may immediately take top card of Lost Pile into hand. Effects, Epic Events, and Objectives are immune to Honor Of The Jedi. At each opponent's ◇ site, your characters and vehicles are each deploy -3 and your Force generation is +1. (Immune to Alter.)",
+    "gameText": "Deploy on table. You may immediately take top card of Lost Pile into hand. Effects, Epic Events, and Objectives are immune to Honor Of The Jedi. At each opponent's â—‡ site, your characters and vehicles are each deploy -3 and your Force generation is +1. (Immune to Alter.)",
     "destiny": 4,
     "icons": [
       {
@@ -6478,7 +6478,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Jabba's decadent behavior makes him susceptible to deception. Leia and Lando exploited this weakness, posing as Jabba's kind of scum.",
-    "gameText": "Deploy on table. You may immediately take top card of Lost Pile into hand. None Shall Pass is unique (•) and a Lost Interrupt. At each opponent's ◇ site, your characters and vehicles are each deploy -3 and your Force generation is +1. (Immune to Alter.)",
+    "gameText": "Deploy on table. You may immediately take top card of Lost Pile into hand. None Shall Pass is unique (â€¢) and a Lost Interrupt. At each opponent's â—‡ site, your characters and vehicles are each deploy -3 and your Force generation is +1. (Immune to Alter.)",
     "destiny": 4,
     "icons": [
       {
@@ -7050,7 +7050,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "With the destruction of the Death Star, the Rebel Alliance received new-found support throughout the galaxy.",
-    "gameText": "Deploy on table. If Death Star 'blown away': Whenever you deploy a unique (•) starship to a system location, retrieve 3 Force; Once per during each of your turns you may deploy (for free) a starship from hand or Reserve Deck and reshuffle. (Immune to Alter.)",
+    "gameText": "Deploy on table. If Death Star 'blown away': Whenever you deploy a unique (â€¢) starship to a system location, retrieve 3 Force; Once per during each of your turns you may deploy (for free) a starship from hand or Reserve Deck and reshuffle. (Immune to Alter.)",
     "destiny": 5,
     "icons": [
       {
@@ -9060,7 +9060,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Tarkin silenced the voices of Alderaan with the power of the Death Star.",
-    "gameText": "Deploy on table. Twice per game may take Commence Primary Ignition into hand from Lost Pile or Reserve Deck; reshuffle. If Alderaan 'blown away,' retrieve 3 Force whenever you deploy a unique (•) Star Destroyer. (Immune to Alter.)",
+    "gameText": "Deploy on table. Twice per game may take Commence Primary Ignition into hand from Lost Pile or Reserve Deck; reshuffle. If Alderaan 'blown away,' retrieve 3 Force whenever you deploy a unique (â€¢) Star Destroyer. (Immune to Alter.)",
     "destiny": 5,
     "icons": [
       {
@@ -11703,7 +11703,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Once begun, the occupation of Naboo was swift, and devastatingly effective.",
-    "gameText": "Deploy on table. Your unique (•) Republicans are forfeit +2 and immune to Goo Nee Tay. Unless Imperial Arrest Order on table, once during your deploy phase, may deploy one docking bay from Reserve Deck; reshuffle. (Immune to Alter.)",
+    "gameText": "Deploy on table. Your unique (â€¢) Republicans are forfeit +2 and immune to Goo Nee Tay. Unless Imperial Arrest Order on table, once during your deploy phase, may deploy one docking bay from Reserve Deck; reshuffle. (Immune to Alter.)",
     "destiny": 4,
     "icons": [
       {
@@ -11735,7 +11735,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Imperial officers are always on the lookout for Rebel espionage.",
-    "gameText": "Deploy on table. Unique (•) Imperials of ability = 3 are forfeit +3. If opponent just retrieved Force using an Interrupt or Utinni Effect, you may place that card here. Opponent's Force retrieval is reduced by X, where X = number of cards here. (Immune to Alter.)",
+    "gameText": "Deploy on table. Unique (â€¢) Imperials of ability = 3 are forfeit +3. If opponent just retrieved Force using an Interrupt or Utinni Effect, you may place that card here. Opponent's Force retrieval is reduced by X, where X = number of cards here. (Immune to Alter.)",
     "destiny": 5,
     "icons": [
       {
@@ -11865,7 +11865,7 @@
       "EFFECT"
     ],
     "cardSubtype": "NORMAL",
-    "gameText": "Deploy on table. Unique (•) Imperials of ability < 3 are forfeit +1. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites only. Once during each of your deploy phases, may deploy one docking bay from Reserve Deck; reshuffle. When opponent retrieves X cards, opponent must first use X Force or that retrieval is canceled. (Immune to Alter.)",
+    "gameText": "Deploy on table. Unique (â€¢) Imperials of ability < 3 are forfeit +1. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites only. Once during each of your deploy phases, may deploy one docking bay from Reserve Deck; reshuffle. When opponent retrieves X cards, opponent must first use X Force or that retrieval is canceled. (Immune to Alter.)",
     "destiny": 5,
     "icons": [
       {
@@ -12551,7 +12551,7 @@
     ],
     "cardSubtype": "USED_OR_STARTING",
     "lore": "'We must move quickly to disrupt all communication down there.'",
-    "gameText": "USED: Use 2 Force to deploy a unique (•) battleground not on table, from Reserve Deck; reshuffle. STARTING: Deploy from your Reserve Deck one Effect which deploys on table (or your side of table) and has no deploy cost; reshuffle. Place Interrupt in Lost Pile.",
+    "gameText": "USED: Use 2 Force to deploy a unique (â€¢) battleground not on table, from Reserve Deck; reshuffle. STARTING: Deploy from your Reserve Deck one Effect which deploys on table (or your side of table) and has no deploy cost; reshuffle. Place Interrupt in Lost Pile.",
     "destiny": 5,
     "icons": [
       {
@@ -12678,7 +12678,7 @@
       "INTERRUPT"
     ],
     "cardSubtype": "USED_OR_LOST",
-    "gameText": "USED: Take one unique (•) unpiloted starfighter into hand from Reserve Deck; reshuffle. LOST: During a battle at a system or sector, if you are about to draw a card for battle destiny, you may instead use the maneuver number of your unique (•) starfighter in that battle.",
+    "gameText": "USED: Take one unique (â€¢) unpiloted starfighter into hand from Reserve Deck; reshuffle. LOST: During a battle at a system or sector, if you are about to draw a card for battle destiny, you may instead use the maneuver number of your unique (â€¢) starfighter in that battle.",
     "destiny": 5,
     "icons": [
       {
@@ -15359,7 +15359,7 @@
       "EFFECT"
     ],
     "cardSubtype": "NORMAL",
-    "gameText": "Deploy on table. Unique (•) Rebels of ability < 3 are forfeit +1. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites only. Once during each of your deploy phases, may deploy one docking bay from Reserve Deck; reshuffle. When opponent retrieves X cards, opponent must first use X Force or that retrieval is canceled. (Immune to Alter.)",
+    "gameText": "Deploy on table. Unique (â€¢) Rebels of ability < 3 are forfeit +1. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites only. Once during each of your deploy phases, may deploy one docking bay from Reserve Deck; reshuffle. When opponent retrieves X cards, opponent must first use X Force or that retrieval is canceled. (Immune to Alter.)",
     "destiny": 5,
     "icons": [
       {
@@ -15455,7 +15455,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Actions borne of the love for one's planet can heavily outweigh those generated from simple battle orders.",
-    "gameText": "Deploy on table. Your unique (•) Republic characters of ability < 4 are forfeit +2. Unless Insurrection on table, once during each of your deploy phases, may deploy one docking bay from Reserve Deck; reshuffle. (Immune to Alter.)",
+    "gameText": "Deploy on table. Your unique (â€¢) Republic characters of ability < 4 are forfeit +2. Unless Insurrection on table, once during each of your deploy phases, may deploy one docking bay from Reserve Deck; reshuffle. (Immune to Alter.)",
     "destiny": 4,
     "icons": [
       {
@@ -15649,7 +15649,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "The Empire, Lando Calrissian, Jabba the Hutt. For Han Solo, it can be very hard to tell when your past is going to catch up with you.",
-    "gameText": "Deploy on table. Unique (•) Rebels of ability = 3 are power and forfeit +1 (or power and forfeit +2 if at a Cloud City or Jabba's Palace site). While Han at a battleground, opponent retrieves no Force from Scum And Villainy. (Immune to Alter.)",
+    "gameText": "Deploy on table. Unique (â€¢) Rebels of ability = 3 are power and forfeit +1 (or power and forfeit +2 if at a Cloud City or Jabba's Palace site). While Han at a battleground, opponent retrieves no Force from Scum And Villainy. (Immune to Alter.)",
     "destiny": 3,
     "icons": [
       {
@@ -15676,7 +15676,7 @@
       "INTERRUPT"
     ],
     "cardSubtype": "USED_OR_LOST",
-    "gameText": "USED: Take one unique (•) unpiloted starfighter into hand from Reserve Deck; reshuffle. LOST: During a battle at a system or sector, if you are about to draw a card for battle destiny, you may instead use the maneuver number of your unique (•) starfighter in that battle.",
+    "gameText": "USED: Take one unique (â€¢) unpiloted starfighter into hand from Reserve Deck; reshuffle. LOST: During a battle at a system or sector, if you are about to draw a card for battle destiny, you may instead use the maneuver number of your unique (â€¢) starfighter in that battle.",
     "destiny": 5,
     "icons": [
       {
@@ -15995,7 +15995,7 @@
     ],
     "cardSubtype": "USED_OR_STARTING",
     "lore": "'But not at the expense of the moment.'",
-    "gameText": "USED: Use 2 Force to deploy a unique (•) battleground not on table, from Reserve Deck; reshuffle. STARTING: Deploy from your Reserve Deck one Effect which deploys on table (or your side of table) and has no deploy cost; reshuffle. Place Interrupt in Lost Pile.",
+    "gameText": "USED: Use 2 Force to deploy a unique (â€¢) battleground not on table, from Reserve Deck; reshuffle. STARTING: Deploy from your Reserve Deck one Effect which deploys on table (or your side of table) and has no deploy cost; reshuffle. Place Interrupt in Lost Pile.",
     "destiny": 5,
     "icons": [
       {
@@ -17158,7 +17158,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "Deploy Watto's Junkyard, City Outskirts, and Credits Will Do Fine. For remainder of game, you may not deploy cards with ability except unique (•) aliens, Republic characters and starships, and [Episode I] Jedi. Your Destiny is suspended. While this side up, once per game may take Coruscant and/or Tatooine system into hand from Reserve Deck; reshuffle. You may not deploy any systems. Maul is immune to attrition. Flip this card if there are 4 or more cards beneath Credits Will Do Fine.",
+    "gameText": "Deploy Watto's Junkyard, City Outskirts, and Credits Will Do Fine. For remainder of game, you may not deploy cards with ability except unique (â€¢) aliens, Republic characters and starships, and [Episode I] Jedi. Your Destiny is suspended. While this side up, once per game may take Coruscant and/or Tatooine system into hand from Reserve Deck; reshuffle. You may not deploy any systems. Maul is immune to attrition. Flip this card if there are 4 or more cards beneath Credits Will Do Fine.",
     "destiny": 0,
     "icons": [
       {
@@ -17188,7 +17188,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "While this side up, your unique (•) Republic characters are power +1 and forfeit +2. Aliens may not have their deploy cost modified and Imperials deploy +1 to Tatooine sites. Whenever you draw battle destiny (unless canceled), may retrieve 1 Force (Force retrieved in this way may be taken into hand.) While Queen's Royal Starship at a planet system, once during each of opponent's control phases may activate up to 2 Force. Once during each of your control phases, opponent loses 1 Force for each battleground site you occupy with a senator.",
+    "gameText": "While this side up, your unique (â€¢) Republic characters are power +1 and forfeit +2. Aliens may not have their deploy cost modified and Imperials deploy +1 to Tatooine sites. Whenever you draw battle destiny (unless canceled), may retrieve 1 Force (Force retrieved in this way may be taken into hand.) While Queen's Royal Starship at a planet system, once during each of opponent's control phases may activate up to 2 Force. Once during each of your control phases, opponent loses 1 Force for each battleground site you occupy with a senator.",
     "destiny": 7,
     "icons": [
       {
@@ -18080,7 +18080,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Although temperamental, this trusty hunk of junk always seems to perform for its proud owner and his Wookiee co-pilot when needed the most.",
-    "gameText": "Permanent pilots are •Han and •Chewie: provide ability of 5, add one battle destiny, and add 5 to power. Immune to attrition < 6, Come With Me, and Lateral Damage. End of your turn: Use 3 Force to maintain OR Place out of play.",
+    "gameText": "Permanent pilots are â€¢Han and â€¢Chewie: provide ability of 5, add one battle destiny, and add 5 to power. Immune to attrition < 6, Come With Me, and Lateral Damage. End of your turn: Use 3 Force to maintain OR Place out of play.",
     "deployCost": 6,
     "destiny": 2,
     "power": 4,
@@ -18721,7 +18721,7 @@
       "DEFENSIVE_SHIELD"
     ],
     "lore": "Jabba's decadent behavior makes him susceptible to deception. Leia and Lando exploited this weakness, posing as Jabba's kind of scum.",
-    "gameText": "Plays on table. At each opponent's ◇ site, your Rebels are each deploy -2 and your Force generation is +1.",
+    "gameText": "Plays on table. At each opponent's â—‡ site, your Rebels are each deploy -2 and your Force generation is +1.",
     "deployCost": 0,
     "destiny": 0,
     "icons": [
@@ -20279,7 +20279,7 @@
       "DEFENSIVE_SHIELD"
     ],
     "lore": "Jabba's influence is not easily ignored. Neither are his voracious and vile appetites. Even Jedi soon learn this lesson.",
-    "gameText": "Plays on table. At opponent's ◇ site where opponent's creature present, you may deploy without presence or Force icons, and your Force generation there is +1.",
+    "gameText": "Plays on table. At opponent's â—‡ site where opponent's creature present, you may deploy without presence or Force icons, and your Force generation there is +1.",
     "deployCost": 0,
     "destiny": 0,
     "icons": [
@@ -23164,7 +23164,7 @@
       "JEDI_MASTER"
     ],
     "lore": "Jedi Master assigned to reveal the mysteries of the Sith. His quest has led him to the planet Naboo",
-    "gameText": "Adds one battle destiny if with Maul. Permanent weapon is •Qui-Gon Jinn's Lightsaber (may target a character or creature for free; draw two destiny; target 'hit,' and its forfeit = 0, if total destiny > defense value).",
+    "gameText": "Adds one battle destiny if with Maul. Permanent weapon is â€¢Qui-Gon Jinn's Lightsaber (may target a character or creature for free; draw two destiny; target 'hit,' and its forfeit = 0, if total destiny > defense value).",
     "deployCost": 7,
     "destiny": 1,
     "power": 6,
@@ -23960,7 +23960,7 @@
     ],
     "cardSubtype": "USED",
     "lore": "'Look! One of ours, out of the main hold!'",
-    "gameText": "Take a unique (•) N-1 starfighter into hand from Reserve Deck; reshuffle. OR If a battle was just initiated at a system where opponent has a droid starfighter, all droid starfighters at that system are power -1 for remainder of turn.",
+    "gameText": "Take a unique (â€¢) N-1 starfighter into hand from Reserve Deck; reshuffle. OR If a battle was just initiated at a system where opponent has a droid starfighter, all droid starfighters at that system are power -1 for remainder of turn.",
     "destiny": 4,
     "icons": [
       {
@@ -25129,6 +25129,54 @@
       "BATTLE"
     ]
   },
+      {
+    "cardId": "14_71",
+    "title": "3B3-21",
+    "slug": "3b3-21",
+    "slugWithSetName": "3b3-21-theed-palace",
+    "side": "DARK",
+    "uniqueness": "UNIQUE",
+    "expansionSet": "THEED_PALACE",
+    "rarity": "U",
+    "cardCategory": "CHARACTER",
+    "cardTypes": [
+      "DROID"
+    ],
+    "lore": "Infantry battle droid equipped with command programs to call reinforcements into his patrol zone when needed. Assigned to escort Amidala soon after her capture.",
+    "gameText": "If opponent just initiated a battle at same site, may use X Force to reveal the top X cards of your Reserve Deck. (maximum 4). Any battle droids revealed this way may deploy for free; all other cards are lost.",
+    "deployCost": 3,
+    "destiny": 2,
+    "power": 3,
+    "ability": 0,
+    "forfeit": 3,
+    "armor": 4,
+    "landspeed": 1,
+    "politics": 0,
+    "icons": [
+      {
+        "icon": "THEED_PALACE",
+        "count": 1
+      },
+      {
+        "icon": "DROID",
+        "count": 1
+      },
+      {
+        "icon": "PRESENCE",
+        "count": 1
+      },
+      {
+        "icon": "EPISODE_I",
+        "count": 1
+      }
+    ],
+    "keywords": [
+      "INFANTRY_BATTLE_DROID"
+    ],
+    "modelTypes": [
+      "BATTLE"
+    ]
+  },
   {
     "cardId": "14_72",
     "title": "3B3-888",
@@ -25375,7 +25423,7 @@
       "SITH"
     ],
     "lore": "'Yes, my Master.'",
-    "gameText": "Permanent weapon is •Maul's Double-Bladed Lightsaber (twice per battle, may target a character for free; draw two destiny; target 'hit,' and its forfeit = 0, if total destiny > defense value).",
+    "gameText": "Permanent weapon is â€¢Maul's Double-Bladed Lightsaber (twice per battle, may target a character for free; draw two destiny; target 'hit,' and its forfeit = 0, if total destiny > defense value).",
     "deployCost": 7,
     "destiny": 1,
     "power": 7,
@@ -29680,7 +29728,7 @@
       "ALIEN"
     ],
     "lore": "Female H'nemthe, a species whose females ritually kill their mates. Stranded on Tatooine due to questionable passage tax. Razor-sharp tongue. M'iiyoom means, 'nightlilly'.",
-    "gameText": "Once during each of your control phases, may reveal opponent's hand by using X Force, where X = number of cards in opponent's hand. All unique (•) male Rebels and unique (•) male aliens there are lost.",
+    "gameText": "Once during each of your control phases, may reveal opponent's hand by using X Force, where X = number of cards in opponent's hand. All unique (â€¢) male Rebels and unique (â€¢) male aliens there are lost.",
     "deployCost": 3,
     "destiny": 3,
     "power": 1,
@@ -36127,7 +36175,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Aratech Corporation sent support staff to various Imperial outposts and garrisons. Gave advanced briefings and training to biker scout personnel.",
-    "gameText": "Deploy on table. AT-STs and speeder bikes are power and forfeit +1. During your deploy phase, may reveal an AT-ST or Speeder Bike from hand to [upload] a unique (•) [Endor] Imperial pilot of ability < 3 (or vice versa) and deploy both simultaneously. (Immune to Alter.)",
+    "gameText": "Deploy on table. AT-STs and speeder bikes are power and forfeit +1. During your deploy phase, may reveal an AT-ST or Speeder Bike from hand to [upload] a unique (â€¢) [Endor] Imperial pilot of ability < 3 (or vice versa) and deploy both simultaneously. (Immune to Alter.)",
     "destiny": 4,
     "icons": [
       {
@@ -36189,7 +36237,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Being stationed at Endor during the construction of the second Death Star allows Imperial pilots time to train in the latest starfighter combat techniques.",
-    "gameText": "Deploy on table. Tallon Roll is canceled. Once per turn, may reveal an unpiloted starfighter from hand to [upload] its matching pilot character (or vice versa) and deploy both simultaneously. Your unique (•) TIEs (except Scythe Squadron TIEs) at systems may use 1 Force to relocate (as a regular move) to system within 3 parsecs. [Immune to Alter]",
+    "gameText": "Deploy on table. Tallon Roll is canceled. Once per turn, may reveal an unpiloted starfighter from hand to [upload] its matching pilot character (or vice versa) and deploy both simultaneously. Your unique (â€¢) TIEs (except Scythe Squadron TIEs) at systems may use 1 Force to relocate (as a regular move) to system within 3 parsecs. [Immune to Alter]",
     "destiny": 5,
     "icons": [
       {
@@ -36435,7 +36483,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Company that produces current generation of Star Destroyers, as well as Nebulon-B Frigates. Ship yards are extremely well defended.",
-    "gameText": "Deploy on table. Unique (•) Imperial-class Star Destroyers draw one battle destiny if unable to otherwise and are immune to attrition < 4. During your deploy phase, may use 2 Force to [download] a battleground system. We're In Attack Position Now is canceled. Immune to Alter.",
+    "gameText": "Deploy on table. Unique (â€¢) Imperial-class Star Destroyers draw one battle destiny if unable to otherwise and are immune to attrition < 4. During your deploy phase, may use 2 Force to [download] a battleground system. We're In Attack Position Now is canceled. Immune to Alter.",
     "destiny": 3,
     "icons": [
       {
@@ -37225,7 +37273,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Dangerous and deadly starfighter piloted by its notorious owner. Uses combat-grade shields and sensors. Hidden weapons provide lethal surprises for Fett's victims.",
-    "gameText": "Permanent pilot is •Boba Fett, who provides ability of 3. Draws one battle destiny if unable to otherwise. Slave I's power may not be reduced by opponent. Immune to Eject! Eject! and attrition < 5.",
+    "gameText": "Permanent pilot is â€¢Boba Fett, who provides ability of 3. Draws one battle destiny if unable to otherwise. Slave I's power may not be reduced by opponent. Immune to Eject! Eject! and attrition < 5.",
     "deployCost": 6,
     "destiny": 1,
     "power": 7,
@@ -37285,7 +37333,7 @@
     ],
     "cardSubtype": "CAPITAL",
     "lore": "Bossk once said of his ship, 'Greeezeg uut nikek!'",
-    "gameText": "Permanent pilot is •Bossk, who provides ability of 2. During battle with opponent's [Independent] starship (or Falcon), may add one destiny to total power or attrition. Immune to attrition < 4.",
+    "gameText": "Permanent pilot is â€¢Bossk, who provides ability of 2. During battle with opponent's [Independent] starship (or Falcon), may add one destiny to total power or attrition. Immune to attrition < 4.",
     "deployCost": 4,
     "destiny": 1,
     "power": 6,
@@ -37348,7 +37396,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Designed to emulate Rebel starfighter advantages. Production began shortly before the Battle of Endor. Armed with laser cannons, ion cannons and missile launchers.",
-    "gameText": "May deploy as a 'react'. Permanent pilot is •Jendon, who provides ability of 2. When deployed, may [download] a weapon on Onyx 1. Adds one battle destiny if with Onyx 2. Immune to attrition < 4.",
+    "gameText": "May deploy as a 'react'. Permanent pilot is â€¢Jendon, who provides ability of 2. When deployed, may [download] a weapon on Onyx 1. Adds one battle destiny if with Onyx 2. Immune to attrition < 4.",
     "deployCost": 4,
     "destiny": 2,
     "power": 5,
@@ -37460,7 +37508,7 @@
       "STARSHIP"
     ],
     "cardSubtype": "STARFIGHTER",
-    "gameText": "May add 1 pilot and 3 passengers. Permanent pilot is •Elis, who provides ability of 2. Once per game, may use 1 Force to [download] a smuggler aboard. Immune to attrition < 5.",
+    "gameText": "May add 1 pilot and 3 passengers. Permanent pilot is â€¢Elis, who provides ability of 2. Once per game, may use 1 Force to [download] a smuggler aboard. Immune to attrition < 5.",
     "deployCost": 4,
     "destiny": 2,
     "power": 4,
@@ -38796,7 +38844,7 @@
       "REPUBLIC"
     ],
     "lore": "Leader. Clone trooper.",
-    "gameText": "Your clones deploy -1 here. While at an [Episode 1] battleground site, adds one battle destiny. Permanent weapon is •Twin Blasters (may target a character for free; draw two destiny; target hit and forfeit -3 if total destiny -2 > defense value).",
+    "gameText": "Your clones deploy -1 here. While at an [Episode 1] battleground site, adds one battle destiny. Permanent weapon is â€¢Twin Blasters (may target a character for free; draw two destiny; target hit and forfeit -3 if total destiny -2 > defense value).",
     "deployCost": 4,
     "destiny": 2,
     "power": 3,
@@ -38981,7 +39029,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Symbol for the Cloud City Miner's Guild (not affiliated with the Galactic Miner's Guild). Named after the beldons, giant creatures who generate Tibanna gas.",
-    "gameText": "Deploy on table. Your [Independent] starships are defense value +2 at Bespin locations. Once per game, if Quiet Mining Colony on table, may simultaneously deploy a unique (•) [Independent] starfighter and matching pilot (for -1 Force each) from your hand and/or Reserve Deck; reshuffle. [Immune to Alter]",
+    "gameText": "Deploy on table. Your [Independent] starships are defense value +2 at Bespin locations. Once per game, if Quiet Mining Colony on table, may simultaneously deploy a unique (â€¢) [Independent] starfighter and matching pilot (for -1 Force each) from your hand and/or Reserve Deck; reshuffle. [Immune to Alter]",
     "destiny": 6,
     "icons": [
       {
@@ -39935,7 +39983,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Owned by legendary Terrik family of smugglers. Used to chase down the pirates who killed Wedge's parents. On Corellian Security's most wanted list. 37.5 meters long.",
-    "gameText": "May add 1 pilot and 6 passengers. Permanent pilot is •Booster, who provides ability of 3. Once per game, may [download] Mirax here. Immune to Lateral Damage and attrition < 5.",
+    "gameText": "May add 1 pilot and 6 passengers. Permanent pilot is â€¢Booster, who provides ability of 3. Once per game, may [download] Mirax here. Immune to Lateral Damage and attrition < 5.",
     "deployCost": 4,
     "destiny": 2,
     "power": 4,
@@ -40057,7 +40105,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "At the Battle of Yavin, Dutch led his squadron of outdated but reliable Y-wings in the first wave of the assault against the Death Star.",
-    "gameText": "May add 1 pilot or passenger. Permanent pilot aboard is •Dutch, who provides ability of 2. Opponent may not 'react' to here and must first use 1 Force to draw a card for battle destiny here.",
+    "gameText": "May add 1 pilot or passenger. Permanent pilot aboard is â€¢Dutch, who provides ability of 2. Opponent may not 'react' to here and must first use 1 Force to draw a card for battle destiny here.",
     "deployCost": 3,
     "destiny": 2,
     "power": 4,
@@ -40116,7 +40164,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Optimized for diplomatic missions with sensor-proof pods that have ejection capabilities. Easily identified by its red coloration.",
-    "gameText": "May add 1 pilot and 2 passengers. Permanent pilot is •Madakor, who provides ability of 2. Opponent's starships may not 'cloak' (or reset your total battle destiny) here. Immune to attrition < 4.",
+    "gameText": "May add 1 pilot and 2 passengers. Permanent pilot is â€¢Madakor, who provides ability of 2. Opponent's starships may not 'cloak' (or reset your total battle destiny) here. Immune to attrition < 4.",
     "deployCost": 5,
     "destiny": 2,
     "power": 6,
@@ -40225,7 +40273,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Lead fighter of Red Squadron at Battle of Yavin. Flown by Garven Dreis. Also served at main Rebel base on Dantooine.",
-    "gameText": "May add Red Leader as pilot. X-wings are immune to Tallon Roll. Once per turn, may use 1 Force to [upload] a unique (•) Red Squadron X-wing (except Red 5). Immune to attrition < 5.",
+    "gameText": "May add Red Leader as pilot. X-wings are immune to Tallon Roll. Once per turn, may use 1 Force to [upload] a unique (â€¢) Red Squadron X-wing (except Red 5). Immune to attrition < 5.",
     "deployCost": 2,
     "destiny": 2,
     "power": 3,
@@ -40333,7 +40381,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Flown by Wedge Antilles as Red 2 at the Battle of Yavin. Redesignated at Endor. Rugged Incom fighter. Victory markers show it role in the attack on the first Death Star.",
-    "gameText": "Permanent pilot is •Wedge, who provides ability of 3. During a battle with opponent's [Independent] starship, may add one destiny to total power or attrition. Immune to Come With Me, Tallon Roll, and attrition < 4.",
+    "gameText": "Permanent pilot is â€¢Wedge, who provides ability of 3. During a battle with opponent's [Independent] starship, may add one destiny to total power or attrition. Immune to Come With Me, Tallon Roll, and attrition < 4.",
     "deployCost": 4,
     "destiny": 2,
     "power": 6,
@@ -40512,7 +40560,7 @@
       "DROID"
     ],
     "lore": "Accomplished thief and information broker. Modified by Jabba to be an effective bounty hunter. The Hutt often teams 4-LOM with other hired killers.",
-    "gameText": "Permanent weapon is •4-LOM's Concussion Rifle (may target a character for free; target is power -1 until end of turn). Once per turn, may place a card from hand on bottom of Used Pile to draw top card from Reserve Deck.",
+    "gameText": "Permanent weapon is â€¢4-LOM's Concussion Rifle (may target a character for free; target is power -1 until end of turn). Once per turn, may place a card from hand on bottom of Used Pile to draw top card from Reserve Deck.",
     "deployCost": 3,
     "destiny": 3,
     "power": 2,
@@ -40614,7 +40662,7 @@
       "IMPERIAL"
     ],
     "lore": "Senior Navy Commander of Death Star. Believes in technology. Ridiculed the Force. Ambitious leader. Promoted due to support of New Order, not military skills. Hates Vader.",
-    "gameText": "[Pilot] 2. Chiraneau may not modify your Force drains. Kuat Drive Yards is immune to Alter. Unless your Senate on table, unique (•) Star Destroyers are power +2 and immunity to attrition +1. Once per game, may [download] non-[Set 0] Kuat Drive Yards.",
+    "gameText": "[Pilot] 2. Chiraneau may not modify your Force drains. Kuat Drive Yards is immune to Alter. Unless your Senate on table, unique (â€¢) Star Destroyers are power +2 and immunity to attrition +1. Once per game, may [download] non-[Set 0] Kuat Drive Yards.",
     "deployCost": 3,
     "destiny": 1,
     "power": 3,
@@ -40916,7 +40964,7 @@
       "ALIEN"
     ],
     "lore": "Corellian bounty hunter. Skilled athlete. Expert shot. Has worked many times for Jabba the Hutt. Carries a long-standing grudge against Han Solo.",
-    "gameText": "While opponent's [Reflection II icon] objective on table, adds one battle destiny. Permanent weapon is •Dengar's Blaster Carbine (may target a character, creature or vehicle for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value; may be fired twice per battle).",
+    "gameText": "While opponent's [Reflection II icon] objective on table, adds one battle destiny. Permanent weapon is â€¢Dengar's Blaster Carbine (may target a character, creature or vehicle for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value; may be fired twice per battle).",
     "deployCost": 4,
     "destiny": 2,
     "power": 3,
@@ -41334,7 +41382,7 @@
       "ALIEN"
     ],
     "lore": "Ordered to kill Luke Skywalker. Assumed the identity of a dancer named 'Arica' in order to sneak into Jabba's Palace.",
-    "gameText": "With Luke or Emperor on table, power +1 and she moves for free. Permanent weapon is •Mara Jade's Lightsaber (may target a character or creature for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
+    "gameText": "With Luke or Emperor on table, power +1 and she moves for free. Permanent weapon is â€¢Mara Jade's Lightsaber (may target a character or creature for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
     "deployCost": 5,
     "destiny": 1,
     "power": 4,
@@ -42101,7 +42149,7 @@
       "STARSHIP"
     ],
     "cardSubtype": "STARFIGHTER",
-    "gameText": "Permanent pilot is •Green Leader, who provides ability of 2. Adds one battle destiny with a Rebel snub fighter. During battle, may cancel immunity to attrition of any starship here; this A-wing is 'hit'.",
+    "gameText": "Permanent pilot is â€¢Green Leader, who provides ability of 2. Adds one battle destiny with a Rebel snub fighter. During battle, may cancel immunity to attrition of any starship here; this A-wing is 'hit'.",
     "deployCost": 4,
     "destiny": 2,
     "power": 5,
@@ -42265,7 +42313,7 @@
     ],
     "cardSubtype": "COMBAT",
     "lore": "Enclosed.",
-    "gameText": "May add 1 pilot. Permanent pilot is •Dash, who provides ability of 3. Unless 'hit', your other vehicles here may not be targeted by weapons, High-Speed Tactics, or Crash Landing. Immune to attrition < 4.",
+    "gameText": "May add 1 pilot. Permanent pilot is â€¢Dash, who provides ability of 3. Unless 'hit', your other vehicles here may not be targeted by weapons, High-Speed Tactics, or Crash Landing. Immune to attrition < 4.",
     "deployCost": 3,
     "destiny": 2,
     "power": 5,
@@ -44089,7 +44137,7 @@
       "STARSHIP"
     ],
     "cardSubtype": "STARFIGHTER",
-    "gameText": "Permanent pilot is •Corran Horn, who provides ability of 4. Weapon destiny draws are -2 here. While with a snub fighter, attrition against opponent is +1 here. Immune to attrition < 4.",
+    "gameText": "Permanent pilot is â€¢Corran Horn, who provides ability of 4. Weapon destiny draws are -2 here. While with a snub fighter, attrition against opponent is +1 here. Immune to attrition < 4.",
     "deployCost": 5,
     "destiny": 1,
     "power": 5,
@@ -45056,7 +45104,7 @@
       "ALIEN"
     ],
     "lore": "Gamorrean in charge of the Gamorreans at Jabba's palace. Posted to stand guard at the entrance cavern. Assigned by Jabba to keep an eye on Tessek.",
-    "gameText": "Permanent weapon is •Ortugg's Ax (may target a character or creature for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value). While Ortugg is your Rep, your non-unique Gamorreans are deploy -1 and forfeit +3.",
+    "gameText": "Permanent weapon is â€¢Ortugg's Ax (may target a character or creature for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value). While Ortugg is your Rep, your non-unique Gamorreans are deploy -1 and forfeit +3.",
     "deployCost": 3,
     "destiny": 3,
     "power": 4,
@@ -47206,7 +47254,7 @@
       "ALIEN"
     ],
     "lore": "Wookiee smuggler.",
-    "gameText": "Deploys -1 to Falcon. While 'hit', draws one battle destiny if unable to otherwise. Permanent weapon is •Chewbacca's Bowcaster (may target a character or vehicle for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
+    "gameText": "Deploys -1 to Falcon. While 'hit', draws one battle destiny if unable to otherwise. Permanent weapon is â€¢Chewbacca's Bowcaster (may target a character or vehicle for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
     "deployCost": 5,
     "destiny": 1,
     "power": 6,
@@ -48343,7 +48391,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Flown by Tycho Celchu at the Battle of Endor. Modified canopy improves pilot vision in tight confines. Assigned to fly top cover for Millennium Falcon.",
-    "gameText": "May deploy as a 'react'. Permanent pilot is •Tycho, who provides ability of 2 and adds 3 to his [Death Star II] Epic Event destiny draws. During battle, may target a starfighter; target's immunity to attrition is canceled.",
+    "gameText": "May deploy as a 'react'. Permanent pilot is â€¢Tycho, who provides ability of 2 and adds 3 to his [Death Star II] Epic Event destiny draws. During battle, may target a starfighter; target's immunity to attrition is canceled.",
     "deployCost": 3,
     "destiny": 2,
     "power": 3,
@@ -48876,7 +48924,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "TIE bomber repaired after being struck by an asteroid in the Anoat system. Stationed aboard second Death Star battle station.",
-    "gameText": "Permanent pilot is •Jonus, who provides ability of 2. This starship's missile weapon destiny draws are +1. If at a system you control, your total power at related sites is +1.",
+    "gameText": "Permanent pilot is â€¢Jonus, who provides ability of 2. This starship's missile weapon destiny draws are +1. If at a system you control, your total power at related sites is +1.",
     "deployCost": 2,
     "destiny": 2,
     "power": 4,
@@ -49187,7 +49235,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Although temperamental, this trusty hunk of junk always seems to perform for its proud owner and his Wookiee co-pilot when needed the most.",
-    "gameText": "Permanent pilots are •Han and •Chewie, who provide ability of 5. If in battle, add one destiny to total power. Immune to Come With Me, Life Debt and attrition < 6.",
+    "gameText": "Permanent pilots are â€¢Han and â€¢Chewie, who provide ability of 5. If in battle, add one destiny to total power. Immune to Come With Me, Life Debt and attrition < 6.",
     "deployCost": 6,
     "destiny": 2,
     "power": 8,
@@ -49302,7 +49350,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Chromium-plated, sleek transport ship used by the royalty of the Naboo. Spaceframe was designed around a J-type configuration.",
-    "gameText": "May add 1 pilot and 5 passengers. Permanent pilot is •Ric, who provides ability of 3. R2-D2 deploys -2 aboard. While We'll Need A New One on table, adds one battle destiny. Immune to attrition < 5.",
+    "gameText": "May add 1 pilot and 5 passengers. Permanent pilot is â€¢Ric, who provides ability of 3. R2-D2 deploys -2 aboard. While We'll Need A New One on table, adds one battle destiny. Immune to attrition < 5.",
     "deployCost": 5,
     "destiny": 2,
     "power": 6,
@@ -49981,7 +50029,7 @@
     "cardTypes": [
       "REBEL"
     ],
-    "gameText": "If about to be lost, may fire Baze's Cannon. Permanent weapon is •Baze's Cannon (may target a character for free; draw destiny; add 1 if targeting a character of ability < 3; target hit, and its forfeit = 0, if total destiny + 1 > defense value).",
+    "gameText": "If about to be lost, may fire Baze's Cannon. Permanent weapon is â€¢Baze's Cannon (may target a character for free; draw destiny; add 1 if targeting a character of ability < 3; target hit, and its forfeit = 0, if total destiny + 1 > defense value).",
     "deployCost": 4,
     "destiny": 2,
     "power": 4,
@@ -51541,7 +51589,7 @@
     "cardTypes": [
       "EPIC_EVENT"
     ],
-    "gameText": "If Yavin 4 on table, deploy on table. If you just initiated a Force drain at a battleground system (except a 'liberated' system), may draw destiny. Add 1 for each piloted unique (•) snub fighter present at that system. If total destiny > 5, opponent loses 1 Force and stacks lost card face down there (while that card stacked there, system is 'liberated'). If opponent Force drains at a 'liberated' system, place stacked card in owner's Used Pile. At each 'liberated' system, your Force drains are +1 and opponent's starships are deploy +1.",
+    "gameText": "If Yavin 4 on table, deploy on table. If you just initiated a Force drain at a battleground system (except a 'liberated' system), may draw destiny. Add 1 for each piloted unique (â€¢) snub fighter present at that system. If total destiny > 5, opponent loses 1 Force and stacks lost card face down there (while that card stacked there, system is 'liberated'). If opponent Force drains at a 'liberated' system, place stacked card in owner's Used Pile. At each 'liberated' system, your Force drains are +1 and opponent's starships are deploy +1.",
     "deployCost": 0,
     "destiny": 0,
     "icons": [
@@ -51950,7 +51998,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "While this side up, during battle at sites related to systems you occupy, for each piloted unique (•) snub fighter present at that system, your total power is +2. Once during your draw phase, if a system is 'liberated', may place a card from your Lost Pile out of play to retrieve 1 Force. Flip this card if you do not occupy two battlegrounds (unless four Rebels are on table).",
+    "gameText": "While this side up, during battle at sites related to systems you occupy, for each piloted unique (â€¢) snub fighter present at that system, your total power is +2. Once during your draw phase, if a system is 'liberated', may place a card from your Lost Pile out of play to retrieve 1 Force. Flip this card if you do not occupy two battlegrounds (unless four Rebels are on table).",
     "destiny": 7,
     "icons": [
       {
@@ -52359,7 +52407,7 @@
       "SITH"
     ],
     "lore": "Trade Federation.",
-    "gameText": "Permanent weapon is •Maul's Lightsaber (may add 1 to Force drain where present; adds 1 to your battle destiny draws here; may target a character for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
+    "gameText": "Permanent weapon is â€¢Maul's Lightsaber (may add 1 to Force drain where present; adds 1 to your battle destiny draws here; may target a character for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
     "deployCost": 6,
     "destiny": 1,
     "power": 7,
@@ -52836,7 +52884,7 @@
     ],
     "cardSubtype": "USED_OR_LOST",
     "lore": "Oouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioo-",
-    "gameText": "USED: [Upload] Downtown Plaza or a prison. LOST: [Upload] one unique (•) bounty. OR Target an alien. For remainder of turn, target is power and forfeit -1 (-3 if Chewie).",
+    "gameText": "USED: [Upload] Downtown Plaza or a prison. LOST: [Upload] one unique (â€¢) bounty. OR Target an alien. For remainder of turn, target is power and forfeit -1 (-3 if Chewie).",
     "destiny": 4,
     "icons": [
       {
@@ -53386,7 +53434,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "Deploy Tuanul Village, any other [Episode VII] location, and I Will Finish What You Started. Opponent may reveal a unique (•) character with ability (except Luke or a Jedi) from Reserve Deck; that card is a Resistance Agent. Otherwise, Luke is a Resistance Agent and loses immunity to attrition. For remainder of game, non-[Episode VII] Dark Jedi are lost and Resistance Agents are immune to Set For Stun. Flip this card if your First Order characters control two battlegrounds and a Resistance Agent is not present at a battleground site.",
+    "gameText": "Deploy Tuanul Village, any other [Episode VII] location, and I Will Finish What You Started. Opponent may reveal a unique (â€¢) character with ability (except Luke or a Jedi) from Reserve Deck; that card is a Resistance Agent. Otherwise, Luke is a Resistance Agent and loses immunity to attrition. For remainder of game, non-[Episode VII] Dark Jedi are lost and Resistance Agents are immune to Set For Stun. Flip this card if your First Order characters control two battlegrounds and a Resistance Agent is not present at a battleground site.",
     "destiny": 0,
     "icons": [
       {
@@ -53447,7 +53495,7 @@
       "STARSHIP"
     ],
     "cardSubtype": "STARFIGHTER",
-    "gameText": "May add 1 pilot and 2 passengers. Permanent pilot is •Mara Jade, who provides ability of 5. While alone and piloted by an Imperial, adds one battle destiny. Immune to attrition < 4.",
+    "gameText": "May add 1 pilot and 2 passengers. Permanent pilot is â€¢Mara Jade, who provides ability of 5. While alone and piloted by an Imperial, adds one battle destiny. Immune to attrition < 4.",
     "deployCost": 5,
     "destiny": 2,
     "power": 5,
@@ -53754,7 +53802,7 @@
       "RESISTANCE"
     ],
     "lore": "Female.",
-    "gameText": "[Pilot] 2. Permanent weapon is •Anakin's Lightsaber (may target a character for free; draw two destiny; target hit, its forfeit = 0, and you may retrieve 1 Force, if total destiny > defense value).",
+    "gameText": "[Pilot] 2. Permanent weapon is â€¢Anakin's Lightsaber (may target a character for free; draw two destiny; target hit, its forfeit = 0, and you may retrieve 1 Force, if total destiny > defense value).",
     "deployCost": 5,
     "destiny": 1,
     "power": 5,
@@ -55001,7 +55049,7 @@
       "FIRST_ORDER"
     ],
     "lore": "Leader.",
-    "gameText": "[Pilot] 2. Permanent weapon is •Kylo's Lightsaber (may target a character for free; draw two destiny; target hit, its forfeit = 0, and opponent loses 1 Force, if total destiny > defense value; otherwise you lose 1 Force).",
+    "gameText": "[Pilot] 2. Permanent weapon is â€¢Kylo's Lightsaber (may target a character for free; draw two destiny; target hit, its forfeit = 0, and opponent loses 1 Force, if total destiny > defense value; otherwise you lose 1 Force).",
     "deployCost": 5,
     "destiny": 1,
     "power": 6,
@@ -55344,7 +55392,7 @@
     "cardTypes": [
       "EPIC_EVENT"
     ],
-    "gameText": "Once per game, deploy on Death Star; it is hyperspeed = 2. Superlaser may not target planet systems. Once during your control phase, may fire Superlaser as follows: Prepare Single Reactor Ignition: If Death Star orbiting Jedha or Scarif, target your related unique (•) battleground site, even if converted (regardless of objective restrictions). Fire!: Draw destiny. It's Beautiful: If destiny +X > 8, site is 'blown away,' and opponent loses 3 Force. X = number of Death Star sites on table.",
+    "gameText": "Once per game, deploy on Death Star; it is hyperspeed = 2. Superlaser may not target planet systems. Once during your control phase, may fire Superlaser as follows: Prepare Single Reactor Ignition: If Death Star orbiting Jedha or Scarif, target your related unique (â€¢) battleground site, even if converted (regardless of objective restrictions). Fire!: Draw destiny. It's Beautiful: If destiny +X > 8, site is 'blown away,' and opponent loses 3 Force. X = number of Death Star sites on table.",
     "deployCost": 0,
     "destiny": 0,
     "icons": [
@@ -56525,7 +56573,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "Deploy City Outskirts, Watto's Junkyard, and Credits Will Do Fine. For remainder of game, you may not deploy cards with ability except unique (•) aliens, Republic characters, [Republic] starships, and [Episode I] Jedi. Your Destiny is suspended. You lose no Force from [Reflections II] objectives. While this side up, once per game, may take into hand from Reserve Deck an [Episode I] system. Unless present with Qui-Gon, Maul is immune to attrition. Flip this card if there are four or more cards beneath Credits Will Do Fine.",
+    "gameText": "Deploy City Outskirts, Watto's Junkyard, and Credits Will Do Fine. For remainder of game, you may not deploy cards with ability except unique (â€¢) aliens, Republic characters, [Republic] starships, and [Episode I] Jedi. Your Destiny is suspended. You lose no Force from [Reflections II] objectives. While this side up, once per game, may take into hand from Reserve Deck an [Episode I] system. Unless present with Qui-Gon, Maul is immune to attrition. Flip this card if there are four or more cards beneath Credits Will Do Fine.",
     "destiny": 0,
     "icons": [
       {
@@ -56560,7 +56608,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "While this side up, your unique (•) Republic characters are power +1 and forfeit +2. Aliens may not have their deploy cost modified to Tatooine locations. Whenever you complete a non-substituted battle destiny draw, may retrieve 1 Force (Force retrieved in this way may be taken into hand). Once during opponent's turn, if Queen's Royal Starship at a system, may activate up to 2 Force. During your control phase, opponent loses 1 Force for each battleground occupied by Amidala or Jar Jar.",
+    "gameText": "While this side up, your unique (â€¢) Republic characters are power +1 and forfeit +2. Aliens may not have their deploy cost modified to Tatooine locations. Whenever you complete a non-substituted battle destiny draw, may retrieve 1 Force (Force retrieved in this way may be taken into hand). Once during opponent's turn, if Queen's Royal Starship at a system, may activate up to 2 Force. During your control phase, opponent loses 1 Force for each battleground occupied by Amidala or Jar Jar.",
     "destiny": 7,
     "icons": [
       {
@@ -56954,7 +57002,7 @@
     ],
     "cardSubtype": "COMBAT",
     "lore": "Enclosed. Death Squadron.",
-    "gameText": "May add 1 pilot. Permanent pilot is •Marquand, who provides ability of 2. Cards Blizzard 6 hits are power and forfeit -2 and may not apply ability towards drawing battle destiny. Immune to attrition < 4.",
+    "gameText": "May add 1 pilot. Permanent pilot is â€¢Marquand, who provides ability of 2. Cards Blizzard 6 hits are power and forfeit -2 and may not apply ability towards drawing battle destiny. Immune to attrition < 4.",
     "deployCost": 6,
     "destiny": 1,
     "power": 6,
@@ -57553,7 +57601,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "On her assignment to kill Sharad Hett, Aurra used her patience and cunning to help track down the Jedi Master.",
-    "gameText": "Deploy on table. While alone, assassins are power +1. Once per game, may reveal up to two unique (•) aliens from hand and/or Reserve Deck (reshuffle); for remainder of game, those cards are assassins and, if your [Reflections II] objective on table, Black Sun agents. [Immune to Alter.]",
+    "gameText": "Deploy on table. While alone, assassins are power +1. Once per game, may reveal up to two unique (â€¢) aliens from hand and/or Reserve Deck (reshuffle); for remainder of game, those cards are assassins and, if your [Reflections II] objective on table, Black Sun agents. [Immune to Alter.]",
     "destiny": 4,
     "icons": [
       {
@@ -58407,7 +58455,7 @@
       "STARSHIP"
     ],
     "cardSubtype": "STARFIGHTER",
-    "gameText": "May add 1 pilot. Permanent astromech aboard is •BB-8. If Poe piloting, may lose 1 Force to cancel a just drawn weapon destiny targeting this starship. Immune to attrition < 4.",
+    "gameText": "May add 1 pilot. Permanent astromech aboard is â€¢BB-8. If Poe piloting, may lose 1 Force to cancel a just drawn weapon destiny targeting this starship. Immune to attrition < 4.",
     "deployCost": 3,
     "destiny": 3.1415927,
     "power": 4,
@@ -58724,7 +58772,7 @@
       "STARSHIP"
     ],
     "cardSubtype": "STARFIGHTER",
-    "gameText": "Permanent pilot is •Tallie, who provides ability of 2. May move as a 'react' to same location as your [Episode VII] character. Characters here may not have their forfeit increased beyond their printed value.",
+    "gameText": "Permanent pilot is â€¢Tallie, who provides ability of 2. May move as a 'react' to same location as your [Episode VII] character. Characters here may not have their forfeit increased beyond their printed value.",
     "deployCost": 3,
     "destiny": 3,
     "power": 4,
@@ -58810,7 +58858,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "Immediately place Luke out of play (ignore [Death Star II] objective restrictions, if any). For remainder of battle, weapons may not be fired. While this side up, opponent's immunity to attrition is limited to < 6. Once during your turn, may peek at the top card of your Force Pile and Reserve Deck; place both cards (in any order) on top of one of those piles. Where you have two unique (•) Resistance characters, your Force drains are +1 and, once per turn during battle, may cancel an opponent's just drawn destiny to cause a redraw.",
+    "gameText": "Immediately place Luke out of play (ignore [Death Star II] objective restrictions, if any). For remainder of battle, weapons may not be fired. While this side up, opponent's immunity to attrition is limited to < 6. Once during your turn, may peek at the top card of your Force Pile and Reserve Deck; place both cards (in any order) on top of one of those piles. Where you have two unique (â€¢) Resistance characters, your Force drains are +1 and, once per turn during battle, may cancel an opponent's just drawn destiny to cause a redraw.",
     "destiny": 7,
     "icons": [
       {
@@ -61120,7 +61168,7 @@
       "LOCATION"
     ],
     "cardSubtype": "SITE",
-    "locationDarkSideGameText": "While your unique (•) alien here, your Force generation is +1 here (+2 if Margo).",
+    "locationDarkSideGameText": "While your unique (â€¢) alien here, your Force generation is +1 here (+2 if Margo).",
     "locationLightSideGameText": "Force drain -1 here (if your smuggler here, Force drain +1 instead).",
     "deployCost": 0,
     "destiny": 0,
@@ -63922,7 +63970,7 @@
     ],
     "cardSubtype": "SITE",
     "locationDarkSideGameText": "Total ability of 6 or more required for you to draw battle destiny here.",
-    "locationLightSideGameText": "Once per turn, if you occupy with a Wookiee, may [download]▼ a Kashyyyk location.",
+    "locationLightSideGameText": "Once per turn, if you occupy with a Wookiee, may [download]â–¼ a Kashyyyk location.",
     "deployCost": 0,
     "destiny": 0,
     "icons": [
@@ -64043,7 +64091,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "Deploy Central Core, A Power Loss, Detention Block Corridor (with [A New Hope] Leia imprisoned there), and Trash Compactor. For remainder of game, your Death Star sites generate +1 Force for you. You may not deploy Luke of ability > 4 or [Episode I] (or [Episode VII]) Jedi. If Leia is about to leave table (for any reason, even if inactive), imprison her in Detention Block Corridor (cards on her are placed in owner's Used Pile). Once per turn, may ▼ a Death Star site. Flip this card if Leia occupies a Death Star site and A Power Loss is 'shut down.'",
+    "gameText": "Deploy Central Core, A Power Loss, Detention Block Corridor (with [A New Hope] Leia imprisoned there), and Trash Compactor. For remainder of game, your Death Star sites generate +1 Force for you. You may not deploy Luke of ability > 4 or [Episode I] (or [Episode VII]) Jedi. If Leia is about to leave table (for any reason, even if inactive), imprison her in Detention Block Corridor (cards on her are placed in owner's Used Pile). Once per turn, may â–¼ a Death Star site. Flip this card if Leia occupies a Death Star site and A Power Loss is 'shut down.'",
     "destiny": 0,
     "icons": [
       {
@@ -66856,7 +66904,7 @@
     ],
     "cardSubtype": "SITE",
     "locationDarkSideGameText": "Once per turn, may [download] a starfighter with 'Vader' in title here.",
-    "locationLightSideGameText": "Your docking bay transit to or from here requires +4 Force (+6 Force if Vader or Vaneé here).",
+    "locationLightSideGameText": "Your docking bay transit to or from here requires +4 Force (+6 Force if Vader or VaneÃ© here).",
     "deployCost": 0,
     "destiny": 0,
     "icons": [
@@ -67721,7 +67769,7 @@
       "EFFECT"
     ],
     "cardSubtype": "NORMAL",
-    "gameText": "Deploy on table. Your unique (•) Republic characters (and your unique (•) Gungans) of ability < 4 are forfeit +1. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites only. Once per turn, may [download] a docking bay. Once during opponent's turn, if Jar Jar or your [Episode I] leader occupies an [Episode I] battleground, may activate 1 Force. [Immune to Alter.]",
+    "gameText": "Deploy on table. Your unique (â€¢) Republic characters (and your unique (â€¢) Gungans) of ability < 4 are forfeit +1. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites only. Once per turn, may [download] a docking bay. Once during opponent's turn, if Jar Jar or your [Episode I] leader occupies an [Episode I] battleground, may activate 1 Force. [Immune to Alter.]",
     "destiny": 4,
     "icons": [
       {
@@ -67784,7 +67832,7 @@
       "EFFECT"
     ],
     "cardSubtype": "NORMAL",
-    "gameText": "Deploy on table. Your unique (•) Republic characters of ability < 4 and your [Trade Federation] starships are forfeit +2. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites only. Once per turn, may deploy an [Episode I] (or Coruscant) docking bay from Reserve Deck; reshuffle. While you occupy Naboo system with a [Trade Federation] starship, your Force generation is +1 there. [Immune to Alter.]",
+    "gameText": "Deploy on table. Your unique (â€¢) Republic characters of ability < 4 and your [Trade Federation] starships are forfeit +2. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites only. Once per turn, may deploy an [Episode I] (or Coruscant) docking bay from Reserve Deck; reshuffle. While you occupy Naboo system with a [Trade Federation] starship, your Force generation is +1 there. [Immune to Alter.]",
     "destiny": 4,
     "icons": [
       {
@@ -68896,7 +68944,7 @@
       "IMPERIAL"
     ],
     "lore": "ISB leader.",
-    "gameText": "During your deploy phase, a unique (•) Imperial of ability < 3 here may make a regular move. When deployed, may place a unique (•) ISB agent here in Used Pile to deploy (for free) a non-Tarkin ISB agent with a different title here from Used Pile; reshuffle.",
+    "gameText": "During your deploy phase, a unique (â€¢) Imperial of ability < 3 here may make a regular move. When deployed, may place a unique (â€¢) ISB agent here in Used Pile to deploy (for free) a non-Tarkin ISB agent with a different title here from Used Pile; reshuffle.",
     "deployCost": 3,
     "destiny": 2,
     "power": 3,
@@ -69805,7 +69853,7 @@
       "JEDI_MASTER"
     ],
     "lore": "",
-    "gameText": "Permanent weapon is •Qui-Gon Jinn's Lightsaber (may target a character or creature for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
+    "gameText": "Permanent weapon is â€¢Qui-Gon Jinn's Lightsaber (may target a character or creature for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
     "deployCost": 6,
     "destiny": 1,
     "power": 6,
@@ -70477,7 +70525,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Jabba's influence is not easily ignored. Neither are his voracious and vile appetites. Even Jedi soon learn this lesson.",
-    "gameText": "Deploy on table. When deployed, may take the top card of Lost Pile into hand. During your move phase, may cancel Landing Claw. If Landing Claw was just lost, place it out of play. Elis Helrot and Nabrun Leids are unique (•) and are Lost Interrupts. [Immune to Alter.]",
+    "gameText": "Deploy on table. When deployed, may take the top card of Lost Pile into hand. During your move phase, may cancel Landing Claw. If Landing Claw was just lost, place it out of play. Elis Helrot and Nabrun Leids are unique (â€¢) and are Lost Interrupts. [Immune to Alter.]",
     "destiny": 4,
     "icons": [
       {
@@ -70892,7 +70940,7 @@
       "ALIEN"
     ],
     "lore": "Crolute scavenger and thief.",
-    "gameText": "Your battle destiny draws here are +¼ for each device, droid, starship, vehicle, or weapon card here. During battle with an opponent's droid, adds one destiny to total power. Once per game, may retrieve a device or character weapon.",
+    "gameText": "Your battle destiny draws here are +Â¼ for each device, droid, starship, vehicle, or weapon card here. During battle with an opponent's droid, adds one destiny to total power. Once per game, may retrieve a device or character weapon.",
     "deployCost": 2,
     "destiny": 4,
     "power": 2,
@@ -71153,7 +71201,7 @@
       "ALIEN"
     ],
     "lore": "Female Alderaanian. Gambler. Trooper.",
-    "gameText": " If Alderaan has been 'blown away,' Force drain +1 here. Permanent weapon is •Cara's Heavy Blaster Rifle (twice per battle, may target a character or vehicle; draw destiny; target hit, and its forfeit is cumulatively -3, if destiny +1 > defense value).",
+    "gameText": " If Alderaan has been 'blown away,' Force drain +1 here. Permanent weapon is â€¢Cara's Heavy Blaster Rifle (twice per battle, may target a character or vehicle; draw destiny; target hit, and its forfeit is cumulatively -3, if destiny +1 > defense value).",
     "deployCost": 4,
     "destiny": 2,
     "power": 4,
@@ -71866,7 +71914,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "The metal rods extending from the bottom of Cloud City are part of the city's flotation system. Sensors detect the velocity of wind and the content of local clouds.",
-    "gameText": "Deploy on table. Unless this card upright, characters here are lost. If you just Force drained or initiated battle, rotate this card 90° clockwise; if now upright, retrieve any one card. If opponent just initiated battle, unless this card upright, rotate it 90° counterclockwise.",
+    "gameText": "Deploy on table. Unless this card upright, characters here are lost. If you just Force drained or initiated battle, rotate this card 90Â° clockwise; if now upright, retrieve any one card. If opponent just initiated battle, unless this card upright, rotate it 90Â° counterclockwise.",
     "destiny": 4,
     "icons": [
       {
@@ -72575,7 +72623,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Customized transport of Lord Vader. Employs advanced sensor jamming gear. Modified with enhanced tactical displays constructed to the Dark Lord's specifications.",
-    "gameText": "Deploys -2 to Mustafar. May add 1 pilot and 3 passengers. Permanent pilot is •Jendon, who provides ability of 2. If Vader armed with a lightsaber weapon card at a battleground, Force drain +1 here.",
+    "gameText": "Deploys -2 to Mustafar. May add 1 pilot and 3 passengers. Permanent pilot is â€¢Jendon, who provides ability of 2. If Vader armed with a lightsaber weapon card at a battleground, Force drain +1 here.",
     "deployCost": 5,
     "destiny": 3,
     "power": 5,
@@ -73566,7 +73614,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Sandtroopers commanded by Governor Aryon do not enjoy their assignment. They find a means of venting their frustrations by harassing the local inhabitants.",
-    "gameText": "Deploy on table. During your control phase, if you occupy Tatooine system, opponent loses 1 Force for each Tatooine battleground site you occupy with a unique (•) trooper. While you have three troopers on Tatooine, immune to Alter and Endor Celebration.",
+    "gameText": "Deploy on table. During your control phase, if you occupy Tatooine system, opponent loses 1 Force for each Tatooine battleground site you occupy with a unique (â€¢) trooper. While you have three troopers on Tatooine, immune to Alter and Endor Celebration.",
     "destiny": 4,
     "icons": [
       {
@@ -73991,7 +74039,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Commissioned by a group of Gand venture capitalists headed by Zuckuss. Manufactured by Byblos Drive Yards. Uses repulsorlift technology developed for combat cloud cars.",
-    "gameText": "May 1 pilot. Permanent pilots are •Zuckuss, who provides ability of 4, and •4-LOM. Players may not add power destinies or draw more than one battle destiny here. Immune to attrition < 5.",
+    "gameText": "May 1 pilot. Permanent pilots are â€¢Zuckuss, who provides ability of 4, and â€¢4-LOM. Players may not add power destinies or draw more than one battle destiny here. Immune to attrition < 5.",
     "deployCost": 5,
     "destiny": 2,
     "power": 5,
@@ -74859,7 +74907,7 @@
       "EFFECT"
     ],
     "cardSubtype": "NORMAL",
-    "gameText": "Deploy on table. Unique (•) [Clone Army] capital starships are deploy -1 and immunity to attrition +1. Once per turn, may reveal a [Clone Army] starship from hand to take an [Episode I] pilot character from Reserve Deck (or vice versa) and deploy both simultaneously; reshuffle. [Immune to Alter.]",
+    "gameText": "Deploy on table. Unique (â€¢) [Clone Army] capital starships are deploy -1 and immunity to attrition +1. Once per turn, may reveal a [Clone Army] starship from hand to take an [Episode I] pilot character from Reserve Deck (or vice versa) and deploy both simultaneously; reshuffle. [Immune to Alter.]",
     "destiny": 5,
     "icons": [
       {
@@ -75760,7 +75808,7 @@
       "STARSHIP"
     ],
     "cardSubtype": "STARFIGHTER",
-    "gameText": "May add 1 pilot and 3 passengers. Permanent pilot is •Kuruk, who provides ability of 3. Kylo and Knights of Ren deploy -1 to same and related locations. Immune to attrition < 4.",
+    "gameText": "May add 1 pilot and 3 passengers. Permanent pilot is â€¢Kuruk, who provides ability of 3. Kylo and Knights of Ren deploy -1 to same and related locations. Immune to attrition < 4.",
     "deployCost": 4,
     "destiny": 2,
     "power": 4,
@@ -76502,7 +76550,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "While this side up, cancels Hoth Sentry, Sunsdown, and the game text of your Admiral's Orders and unique (•) characters (except gunners, pilots, and troopers) on table. Cards 'hit' by your artillery or vehicle weapons may not be used to satisfy attrition. If you just initiated battle, may peek at top X cards of your Used Pile, where X = number of Hoth battlegrounds you occupy; take one into hand and shuffle your Used Pile.Flip this card if opponent does not occupy your Hoth location.",
+    "gameText": "While this side up, cancels Hoth Sentry, Sunsdown, and the game text of your Admiral's Orders and unique (â€¢) characters (except gunners, pilots, and troopers) on table. Cards 'hit' by your artillery or vehicle weapons may not be used to satisfy attrition. If you just initiated battle, may peek at top X cards of your Used Pile, where X = number of Hoth battlegrounds you occupy; take one into hand and shuffle your Used Pile.Flip this card if opponent does not occupy your Hoth location.",
     "destiny": 7,
     "icons": [
       {
@@ -76756,7 +76804,7 @@
       "ALIEN"
     ],
     "lore": "Notorious bounty hunter. 'As you wish.'",
-    "gameText": "[Pilot] 2. Permanent weapon is •Boba Fett's Blaster Rifle (may target a character for free; draw destiny; if destiny > defense value, target captured; otherwise, if destiny +2 > defense value, target hit, is forfeit -3, and opponent loses 1 Force; may not be retargeted).",
+    "gameText": "[Pilot] 2. Permanent weapon is â€¢Boba Fett's Blaster Rifle (may target a character for free; draw destiny; if destiny > defense value, target captured; otherwise, if destiny +2 > defense value, target hit, is forfeit -3, and opponent loses 1 Force; may not be retargeted).",
     "deployCost": 4,
     "destiny": 1,
     "power": 5,
@@ -77059,7 +77107,7 @@
     ],
     "cardSubtype": "CAPITAL",
     "lore": "",
-    "gameText": "May add 2 pilots, and 2 passengers. Permanent pilot is •Vanto, who provides ability of 3. Immune to attrition < 4 (< 6 while piloted by Thrawn or while a 'probed' or 'liberated' system on table).",
+    "gameText": "May add 2 pilots, and 2 passengers. Permanent pilot is â€¢Vanto, who provides ability of 3. Immune to attrition < 4 (< 6 while piloted by Thrawn or while a 'probed' or 'liberated' system on table).",
     "deployCost": 4,
     "destiny": 1,
     "power": 5,
@@ -77270,7 +77318,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Maul's Sith Infiltrator.",
-    "gameText": "May add 1 pilot. Permanent pilot is •Maul, who provides ability of 6. Once per battle, may lose 1 Force to 'cloak' (either add one destiny to total power or make this starship immune to attrition < 6).",
+    "gameText": "May add 1 pilot. Permanent pilot is â€¢Maul, who provides ability of 6. Once per battle, may lose 1 Force to 'cloak' (either add one destiny to total power or make this starship immune to attrition < 6).",
     "deployCost": 4,
     "destiny": 4,
     "power": 4,
@@ -77780,7 +77828,7 @@
       "ALIEN"
     ],
     "lore": "Gand bounty hunter and scout.",
-    "gameText": "[Pilot] 2. Once per game, may peek at top card of any Reserve Deck. Permanent weapon is •Zuckuss' Snare Rifle (may target a character for free; draw destiny; target excluded from battle if destiny +1 > target's power).",
+    "gameText": "[Pilot] 2. Once per game, may peek at top card of any Reserve Deck. Permanent weapon is â€¢Zuckuss' Snare Rifle (may target a character for free; draw destiny; target excluded from battle if destiny +1 > target's power).",
     "deployCost": 4,
     "destiny": 1,
     "power": 2,
@@ -79581,7 +79629,7 @@
     ],
     "cardSubtype": "COMBAT",
     "lore": "Enclosed. First snowspeeder to be successfully adapted to Hoth's environment. Piloted by Zev Senesca. Led team in search of Captain Solo and Commander Skywalker.",
-    "gameText": "Deploys -2 to Hoth. May add 1 pilot. Permanent pilot is •Zev, who provides ability of 2. Draws one battle destiny if unable to otherwise. May move as a 'react' to Hoth sites. Vehicle weapons deploy free aboard.",
+    "gameText": "Deploys -2 to Hoth. May add 1 pilot. Permanent pilot is â€¢Zev, who provides ability of 2. Draws one battle destiny if unable to otherwise. May move as a 'react' to Hoth sites. Vehicle weapons deploy free aboard.",
     "deployCost": 6,
     "destiny": 2,
     "power": 6,
@@ -79906,7 +79954,7 @@
       "INTERRUPT"
     ],
     "cardSubtype": "USED_OR_LOST",
-    "gameText": "USED: [Upload] a unique (•) unpiloted starfighter. LOST: During battle at a system or sector, if you are about to draw a card for battle destiny, target your participating starship to instead use the ability number of its highest-ability pilot. OR Once per game, if Alderaan 'blown away' (or if opponent has deployed two battleground systems and no battleground sites), deploy a non-unique Corellian Corvette from outside your deck.",
+    "gameText": "USED: [Upload] a unique (â€¢) unpiloted starfighter. LOST: During battle at a system or sector, if you are about to draw a card for battle destiny, target your participating starship to instead use the ability number of its highest-ability pilot. OR Once per game, if Alderaan 'blown away' (or if opponent has deployed two battleground systems and no battleground sites), deploy a non-unique Corellian Corvette from outside your deck.",
     "destiny": 5,
     "icons": [
       {
@@ -80143,7 +80191,7 @@
       "FIRST_ORDER"
     ],
     "lore": "Knight of Ren.",
-    "gameText": "[Pilot] 2. While an [Episode VII] objective on table, draws one battle destiny if unable to otherwise. Permanent weapon is •Arm Cannon (may target a character for free; draw destiny; target hit, and its forfeit = 0, if destiny + 1 > defense value).",
+    "gameText": "[Pilot] 2. While an [Episode VII] objective on table, draws one battle destiny if unable to otherwise. Permanent weapon is â€¢Arm Cannon (may target a character for free; draw destiny; target hit, and its forfeit = 0, if destiny + 1 > defense value).",
     "deployCost": 4,
     "destiny": 2,
     "power": 4,
@@ -81806,7 +81854,7 @@
       "ALIEN"
     ],
     "lore": "Works every time. Smuggler.",
-    "gameText": "[Pilot] 2. Permanent weapon is •Lando's Blaster Rifle (may target a character for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value). During battle, if your total battle destiny is odd, may retrieve 1 Force (2 if total is 11).",
+    "gameText": "[Pilot] 2. Permanent weapon is â€¢Lando's Blaster Rifle (may target a character for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value). During battle, if your total battle destiny is odd, may retrieve 1 Force (2 if total is 11).",
     "deployCost": 3,
     "destiny": 1,
     "power": 3,
@@ -82892,7 +82940,7 @@
       "JEDI_MASTER"
     ],
     "lore": "Wookiee.",
-    "gameText": "Once per turn, if Wookiee Homestead on table, may place a card from hand on top of Force Pile to draw bottom card from Force Pile. Once per game, may [download] a unique (•) Forest. Immune to Wookiee Strangle and You Are Beaten.",
+    "gameText": "Once per turn, if Wookiee Homestead on table, may place a card from hand on top of Force Pile to draw bottom card from Force Pile. Once per game, may [download] a unique (â€¢) Forest. Immune to Wookiee Strangle and You Are Beaten.",
     "deployCost": 5,
     "destiny": 2,
     "power": 5,
@@ -83183,7 +83231,7 @@
       "ALIEN"
     ],
     "lore": "Female mechanic and scavenger.",
-    "gameText": "While at Starship Graveyard, a docking bay, or on Tatooine, power +3 and may cancel I’ve Lost Artoo! or Lateral Damage (or Restraining Bolt here). During your control phase, if at a battleground with a Jawa, landed starfighter or Grogu, may retrieve 1 Force.",
+    "gameText": "While at Starship Graveyard, a docking bay, or on Tatooine, power +3 and may cancel Iâ€™ve Lost Artoo! or Lateral Damage (or Restraining Bolt here). During your control phase, if at a battleground with a Jawa, landed starfighter or Grogu, may retrieve 1 Force.",
     "deployCost": 2,
     "destiny": 2,
     "power": 1,
@@ -83481,7 +83529,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "'I'm sorry, too.'",
-    "gameText": "If your [Cloud City] objective on table, deploy on table. Elis Helrot, Stunning Leader, and Surreptitious Glance may not be played. Once per turn, may [download] an interior Cloud City site. Your unique (•) characters with printed forfeit < 5 are forfeit +2 (limit +2). [Immune to Alter.]",
+    "gameText": "If your [Cloud City] objective on table, deploy on table. Elis Helrot, Stunning Leader, and Surreptitious Glance may not be played. Once per turn, may [download] an interior Cloud City site. Your unique (â€¢) characters with printed forfeit < 5 are forfeit +2 (limit +2). [Immune to Alter.]",
     "destiny": 5,
     "icons": [
       {
@@ -84631,7 +84679,7 @@
     ],
     "cardSubtype": "IMMEDIATE",
     "lore": "Dianogas use their seven tentacles for both locomotion and catching food. The few survivors of such attacks claim that a dianoga tentacle has the strength of a hydro-clamp.",
-    "gameText": "If opponent just played an Interrupt, use 1 Force to deploy on table and stack that Interrupt here. All Interrupts of that title are unique (•). (Immune to Control.)",
+    "gameText": "If opponent just played an Interrupt, use 1 Force to deploy on table and stack that Interrupt here. All Interrupts of that title are unique (â€¢). (Immune to Control.)",
     "destiny": 5,
     "icons": [
       {
@@ -86518,7 +86566,7 @@
     ],
     "cardSubtype": "IMMEDIATE",
     "lore": "Stormtrooper utility belts contain basic tools such as a grappling hook to grab onto protrusions. The hook can also be used to ensnare escaping targets.",
-    "gameText": "If opponent just played an Interrupt, use 1 Force to deploy on table and stack that Interrupt here. All Interrupts of that title are unique (•). (Immune to Control.)",
+    "gameText": "If opponent just played an Interrupt, use 1 Force to deploy on table and stack that Interrupt here. All Interrupts of that title are unique (â€¢). (Immune to Control.)",
     "destiny": 5,
     "icons": [
       {
@@ -89075,7 +89123,7 @@
       "REPUBLIC"
     ],
     "lore": "Female Togruta Padawan",
-    "gameText": "Power +1 with Anakin. Permanent weapon is •Ahsoka's Lightsabers (may target a character for free, or target two characters using 1 Force; draw two destiny; target(s) hit and forfeit -2 if total destiny > total defense value).",
+    "gameText": "Power +1 with Anakin. Permanent weapon is â€¢Ahsoka's Lightsabers (may target a character for free, or target two characters using 1 Force; draw two destiny; target(s) hit and forfeit -2 if total destiny > total defense value).",
     "deployCost": 5,
     "destiny": 1,
     "power": 4,
@@ -89199,7 +89247,7 @@
       "SITH"
     ],
     "lore": "Female Dathomirian assassin",
-    "gameText": "Power +1 with Dooku. Permanent weapon is •Asajj's Lightsabers (may target a character for free, or target two characters using 1 Force; draw two destiny; target(s) hit and forfeit -2 if total destiny > total defense value).",
+    "gameText": "Power +1 with Dooku. Permanent weapon is â€¢Asajj's Lightsabers (may target a character for free, or target two characters using 1 Force; draw two destiny; target(s) hit and forfeit -2 if total destiny > total defense value).",
     "deployCost": 5,
     "destiny": 1,
     "power": 4,
@@ -95856,7 +95904,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Like nerf herders herding nerfs, Imperial commanders often use TIE fighters to drive fleeing Rebel ships into tractor beam range.",
-    "gameText": "Deploy on one opponent's unique (•) starship at a location you do not occupy. When starship is targeted by any tractor beam or ion cannon, subtract 2 from maneuver. If starship is captured or lost, lose Effect and opponent must lose 3 Force (5 if Falcon).",
+    "gameText": "Deploy on one opponent's unique (â€¢) starship at a location you do not occupy. When starship is targeted by any tractor beam or ion cannon, subtract 2 from maneuver. If starship is captured or lost, lose Effect and opponent must lose 3 Force (5 if Falcon).",
     "destiny": 4,
     "icons": [
       {
@@ -101044,7 +101092,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Careless abuse of the Force by a young Jedi trainee can have dire consequences. When hanging from the weather vane of Cloud City, Luke's balance was his only hope.",
-    "gameText": "Deploy on table. If a unique (•) card is drawn for destiny and a duplicate is on table, destiny card is lost (destiny = 0). If duplicated card is a character, it loses immunity to attrition for rest of turn and player must lose 2 Force or lose that character. (Immune to Alter.)",
+    "gameText": "Deploy on table. If a unique (â€¢) card is drawn for destiny and a duplicate is on table, destiny card is lost (destiny = 0). If duplicated card is a character, it loses immunity to attrition for rest of turn and player must lose 2 Force or lose that character. (Immune to Alter.)",
     "destiny": 4,
     "icons": [
       {
@@ -103335,7 +103383,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "At Cloud City, Luke came face to face with his own destiny. Looking into the abyss, he made his decision.",
-    "gameText": "Deploy on table. If a unique (•) card is drawn for destiny and a duplicate is on table, destiny card is lost (destiny = 0). If duplicated card is a character, it loses immunity to attrition for rest of turn and player must lose 2 Force or lose that character. (Immune to Alter.)",
+    "gameText": "Deploy on table. If a unique (â€¢) card is drawn for destiny and a duplicate is on table, destiny card is lost (destiny = 0). If duplicated card is a character, it loses immunity to attrition for rest of turn and player must lose 2 Force or lose that character. (Immune to Alter.)",
     "destiny": 4,
     "icons": [
       {
@@ -103604,7 +103652,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "The face that launched a thousand starships.",
-    "gameText": "Deploy on Leia. While at any Rebel Base site, your Rebels, except unique (•) Rebels, are deploy -2 and power +2 at same and adjacent sites. While at any system, your starfighters, except unique (•) starfighters, are deploy -2 there.",
+    "gameText": "Deploy on Leia. While at any Rebel Base site, your Rebels, except unique (â€¢) Rebels, are deploy -2 and power +2 at same and adjacent sites. While at any system, your starfighters, except unique (â€¢) starfighters, are deploy -2 there.",
     "destiny": 3,
     "icons": [
       {
@@ -107625,7 +107673,7 @@
       "ALIEN"
     ],
     "lore": "Male Jawa. Leader of a large tribe of Jawas. Plotting with Jabba to take control of a neighboring tribe's territory.",
-    "gameText": "Deploys only on Tatooine. Your Jawa Pack is not unique(•), is doubled, deploys free (or for 6 Force from each player) and cummulatively affects your Jawas' forfeit. While at Audience Chamber or Jawa Camp, all your other Jawas are power +2.",
+    "gameText": "Deploys only on Tatooine. Your Jawa Pack is not unique(â€¢), is doubled, deploys free (or for 6 Force from each player) and cummulatively affects your Jawas' forfeit. While at Audience Chamber or Jawa Camp, all your other Jawas are power +2.",
     "deployCost": 3,
     "destiny": 2,
     "power": 2,
@@ -109487,7 +109535,7 @@
       "ALIEN"
     ],
     "lore": "Jawa leader. Seeking to peacefully settle a long-standing disagreement with his rival, Wittin. Wants Jabba to mediate their talks.",
-    "gameText": "Deploys only on Tatooine. Your Jawa Siesta is not unique(•), is doubled, deploys free (or for 6 Force from each player) and cummulatively affects your Jawas' forfeit. While at Audience Chamber or Jawa Camp, all your other Jawas are power +2.",
+    "gameText": "Deploys only on Tatooine. Your Jawa Siesta is not unique(â€¢), is doubled, deploys free (or for 6 Force from each player) and cummulatively affects your Jawas' forfeit. While at Audience Chamber or Jawa Camp, all your other Jawas are power +2.",
     "deployCost": 3,
     "destiny": 2,
     "power": 2,
@@ -109758,7 +109806,7 @@
       "ALIEN"
     ],
     "lore": "Female Twi'lek musician. Became a dancer to live a life of luxury. Has worked for Jabba for only two days. Desperate to escape.",
-    "gameText": "During your control phase, may cause opponent to reveal entire hand by using X Force, where X = number of cards in opponent's hand. All unique (•) male Imperials or unique (•) male aliens there are placed in opponent's Used Pile.",
+    "gameText": "During your control phase, may cause opponent to reveal entire hand by using X Force, where X = number of cards in opponent's hand. All unique (â€¢) male Imperials or unique (â€¢) male aliens there are placed in opponent's Used Pile.",
     "deployCost": 2,
     "destiny": 3,
     "power": 1,
@@ -110959,7 +111007,7 @@
     ],
     "cardSubtype": "LOST",
     "lore": "Reaching out with the Force, Luke rendered Ortugg unconscious without doing the Gamorrean any actual harm.",
-    "gameText": "During your control phase, cancel the game text of one unique (•) alien for remainder of turn. OR If you just forfeited an alien, cancel all remaining attrition against you.",
+    "gameText": "During your control phase, cancel the game text of one unique (â€¢) alien for remainder of turn. OR If you just forfeited an alien, cancel all remaining attrition against you.",
     "destiny": 4,
     "icons": [
       {
@@ -113514,7 +113562,7 @@
     ],
     "cardSubtype": "SITE",
     "locationDarkSideGameText": "May not be deployed to Bespin, Dagobah, Endor, Hoth, Kashyyyk or Yavin 4. Imperials are power -1 here.",
-    "locationLightSideGameText": "May not be deployed to Bespin, Dagobah, Endor, Hoth, Kashyyyk or Yavin 4. During your move phase, may move free between here and any related ◇ spaceport site.",
+    "locationLightSideGameText": "May not be deployed to Bespin, Dagobah, Endor, Hoth, Kashyyyk or Yavin 4. During your move phase, may move free between here and any related â—‡ spaceport site.",
     "deployCost": 0,
     "destiny": 0,
     "icons": [
@@ -113992,7 +114040,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "Deploy any planet system and one ◇ site to that system. This system is the Subjugated planet. While this side up, once during each of your deploy phases, you may deploy one ◇ site to the Subjugated planet from Reserve Deck; reshuffle. Flip this card if your matching operatives control at least three battleground sites related to the Subjugated planet.",
+    "gameText": "Deploy any planet system and one â—‡ site to that system. This system is the Subjugated planet. While this side up, once during each of your deploy phases, you may deploy one â—‡ site to the Subjugated planet from Reserve Deck; reshuffle. Flip this card if your matching operatives control at least three battleground sites related to the Subjugated planet.",
     "destiny": 0,
     "icons": [
       {
@@ -114120,7 +114168,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "While this side up, for opponent to initiate a Force drain, opponent must use +1 Force. During battle, opponent's unique (•) characters, vehicles and starships lost from table are placed out of play; Leia adds one battle destiny; attrition against opponent is +2; and Imperials, Dark Jedi and Imperial starships lose all immunity to attrition. Flip this card if Leia is captured.",
+    "gameText": "While this side up, for opponent to initiate a Force drain, opponent must use +1 Force. During battle, opponent's unique (â€¢) characters, vehicles and starships lost from table are placed out of play; Leia adds one battle destiny; attrition against opponent is +2; and Imperials, Dark Jedi and Imperial starships lose all immunity to attrition. Flip this card if Leia is captured.",
     "destiny": 7,
     "icons": [
       {
@@ -115591,7 +115639,7 @@
       "IMPERIAL"
     ],
     "lore": "Death Star trooper who witnessed Leia's interrogation. Senior tactical advisor to Sergeant Major Enfield. Coordinates security duty assignments for Detention Block AA-23.",
-    "gameText": "While Grenwick is on Death Star, your Death Star Sentry is not unique (•), is doubled, deploys free, applies all three of its modifiers and is immune to Alter. Power -1 when not on Death Star.",
+    "gameText": "While Grenwick is on Death Star, your Death Star Sentry is not unique (â€¢), is doubled, deploys free, applies all three of its modifiers and is immune to Alter. Power -1 when not on Death Star.",
     "deployCost": 1,
     "destiny": 3,
     "power": 2,
@@ -115964,7 +116012,7 @@
       "REBEL"
     ],
     "lore": "Commander from Ralltiir. Fled from his homeworld after its occupation by the Empire. Was instrumental in the establishment of the new Rebel base on Hoth.",
-    "gameText": "While McQuarrie is on Hoth, your Hoth Sentry is not unique (•), is doubled, deploys free, applies all of its modifiers and is immune to Alter. Power -1 when not on Hoth.",
+    "gameText": "While McQuarrie is on Hoth, your Hoth Sentry is not unique (â€¢), is doubled, deploys free, applies all of its modifiers and is immune to Alter. Power -1 when not on Hoth.",
     "deployCost": 2,
     "destiny": 3,
     "power": 2,
@@ -116356,7 +116404,7 @@
       "REBEL"
     ],
     "lore": "Formerly belonged to the Corellian militia. Popular musician before the Empire blacklisted his songs for their political content. Joined the Alliance with his wife, Duriet.",
-    "gameText": "While Grondorn is on Yavin 4, your Yavin Sentry is not unique (•), is doubled, deploys free, applies all three of its modifiers and is immune to Alter. Power -1 when not on Yavin 4.",
+    "gameText": "While Grondorn is on Yavin 4, your Yavin Sentry is not unique (â€¢), is doubled, deploys free, applies all three of its modifiers and is immune to Alter. Power -1 when not on Yavin 4.",
     "deployCost": 3,
     "destiny": 2,
     "power": 2,
@@ -117748,7 +117796,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Vader was nearly killed when Han damaged his TIE fighter during a surprise attack in the Death Star trench.",
-    "gameText": "Deploy on your side of table. During a battle, you may place out of play from hand a copy of any unique (•) card participating in that battle to reduce attrition against you by that card's forfeit value. (Immune to Alter while you occupy a battleground.)",
+    "gameText": "Deploy on your side of table. During a battle, you may place out of play from hand a copy of any unique (â€¢) card participating in that battle to reduce attrition against you by that card's forfeit value. (Immune to Alter while you occupy a battleground.)",
     "destiny": 2,
     "icons": [
       {
@@ -120261,7 +120309,7 @@
       "LOCATION"
     ],
     "cardSubtype": "SITE",
-    "locationDarkSideGameText": "May not deploy to Bespin, Dagobah, Endor, Hoth, Kashyyyk or Yavin 4. During your move phase, may move free between here and any related ◇ spaceport site.",
+    "locationDarkSideGameText": "May not deploy to Bespin, Dagobah, Endor, Hoth, Kashyyyk or Yavin 4. During your move phase, may move free between here and any related â—‡ spaceport site.",
     "locationLightSideGameText": "May not deploy to Bespin, Dagobah, Endor, Hoth, Kashyyyk or Yavin 4. Rebels are power -1 here.",
     "deployCost": 0,
     "destiny": 0,
@@ -120567,7 +120615,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "Deploy any planet system and one ◇ site to that system. This system is the Renegade planet. While this side up, once during each of your deploy phases, you may deploy one ◇ site to the Renegade planet from Reserve Deck; reshuffle. Flip this card if your matching operatives control at least three battleground sites related to the Renegade planet.",
+    "gameText": "Deploy any planet system and one â—‡ site to that system. This system is the Renegade planet. While this side up, once during each of your deploy phases, you may deploy one â—‡ site to the Renegade planet from Reserve Deck; reshuffle. Flip this card if your matching operatives control at least three battleground sites related to the Renegade planet.",
     "destiny": 0,
     "icons": [
       {
@@ -120707,7 +120755,7 @@
       "REBEL"
     ],
     "lore": "Former Imperial pilot. Joined the Alliance shortly after the Battle of Yavin. Flew cover for Bright Hope during the evacuation of Hoth. Expert marksman.",
-    "gameText": "Deploys -1 aboard your unique (•) Rebel starfighter. Adds 2 to power of anything he pilots. When starfighter he pilots fires a starship weapon, characters aboard target are forfeit = 0 for remainder of turn.",
+    "gameText": "Deploys -1 aboard your unique (â€¢) Rebel starfighter. Adds 2 to power of anything he pilots. When starfighter he pilots fires a starship weapon, characters aboard target are forfeit = 0 for remainder of turn.",
     "deployCost": 2,
     "destiny": 3,
     "power": 1,
@@ -120796,7 +120844,7 @@
     ],
     "cardSubtype": "CAPITAL",
     "lore": "Bossk once said of his ship, 'Greeezeg uut nikek!'",
-    "gameText": "May add 6 passengers and 1 vehicle. Permanent pilot is •Bossk, who provides ability of 2, adds 2 to power and adds one battle destiny. Deploys and moves like a starfighter. Has ship-docking capability.",
+    "gameText": "May add 6 passengers and 1 vehicle. Permanent pilot is â€¢Bossk, who provides ability of 2, adds 2 to power and adds one battle destiny. Deploys and moves like a starfighter. Has ship-docking capability.",
     "deployCost": 8,
     "destiny": 1,
     "power": 5,
@@ -120913,7 +120961,7 @@
     ],
     "cardSubtype": "SQUADRON",
     "lore": "Notoriety gained during the assaults on Ralltiir and Mon Calamari makes this the most feared squadron in the Empire. Defended the Death Star during the Battle of Yavin.",
-    "gameText": "Permanent pilots aboard are •Darth Vader, •DS-61-2 and •DS-61-3, who provide total ability of 10 and add 9 to total power of •Vader's Custom TIE, •Black 2 and •Black 3.",
+    "gameText": "Permanent pilots aboard are â€¢Darth Vader, â€¢DS-61-2 and â€¢DS-61-3, who provide total ability of 10 and add 9 to total power of â€¢Vader's Custom TIE, â€¢Black 2 and â€¢Black 3.",
     "deployCost": 12,
     "destiny": 1,
     "power": 3,
@@ -121018,7 +121066,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Lead starfighter of Obsidian Squadron. Flown by Cive Rashon. Call sign 'Howlrunner.' She served in an elite TIE squadron aboard the Star Destroyer Avenger.",
-    "gameText": "Deploy -1 and power +3 at a cloud sector. Permanent pilot is •OS-72-1, who provides ability of 2, adds 2 to power and, at a cloud sector, may draw one battle destiny if not able to otherwise.",
+    "gameText": "Deploy -1 and power +3 at a cloud sector. Permanent pilot is â€¢OS-72-1, who provides ability of 2, adds 2 to power and, at a cloud sector, may draw one battle destiny if not able to otherwise.",
     "deployCost": 5,
     "destiny": 2,
     "power": 2,
@@ -121061,7 +121109,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Piloted by Dodson Makraven, wingman of Cive Rashon. Experienced TIE pilot with many kills in atmospheric combat. Nicknamed 'Night Beast' for his many curfew violations.",
-    "gameText": "Deploy -1 and power +3 at a cloud sector. Permanent pilot is •OS-72-2, who provides ability of 2, adds 2 to power and, at a cloud sector, may draw one battle destiny if not able to otherwise.",
+    "gameText": "Deploy -1 and power +3 at a cloud sector. Permanent pilot is â€¢OS-72-2, who provides ability of 2, adds 2 to power and, at a cloud sector, may draw one battle destiny if not able to otherwise.",
     "deployCost": 4,
     "destiny": 3,
     "power": 1,
@@ -122718,7 +122766,7 @@
       "CREATURE"
     ],
     "lore": "Considered to be a nuisance. Feeds on garbage. Its only defense is its speed. Nasty bite attack when surprised or cornered. Grow as big as 1.2 meters long.",
-    "gameText": "Habitat: planet sites. Landspeed = 2. Ferocity +2 when present at Mos Eisley or any ◇ spaceport site.",
+    "gameText": "Habitat: planet sites. Landspeed = 2. Ferocity +2 when present at Mos Eisley or any â—‡ spaceport site.",
     "deployCost": 2,
     "destiny": 5,
     "forfeit": 0,
@@ -123209,7 +123257,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Company responsible for design of the rugged Y-wing snub fighter. Maintains sales offices on many planets. Koensayr parts often find their way into a variety of ships.",
-    "gameText": "Deploy on Ralltiir system. Once during each of your control phases, you may retrieve one Y-wing. Also Special Modifications is not unique (•) and makes its target immune to attrition < 4. Suspended while opponent controls Ralltiir. (Immune to Alter.)",
+    "gameText": "Deploy on Ralltiir system. Once during each of your control phases, you may retrieve one Y-wing. Also Special Modifications is not unique (â€¢) and makes its target immune to attrition < 4. Suspended while opponent controls Ralltiir. (Immune to Alter.)",
     "destiny": 4,
     "icons": [
       {
@@ -123395,7 +123443,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Luke barely escaped being crushed by the AT-AT's massive footpad during the Battle of Hoth.",
-    "gameText": "Deploy on your side of table. During a battle, you may place out of play from hand a copy of any unique (•) card participating in that battle to reduce attrition against you by that card's forfeit value. (Immune to Alter while you occupy a battleground.)",
+    "gameText": "Deploy on your side of table. During a battle, you may place out of play from hand a copy of any unique (â€¢) card participating in that battle to reduce attrition against you by that card's forfeit value. (Immune to Alter while you occupy a battleground.)",
     "destiny": 2,
     "icons": [
       {
@@ -124705,7 +124753,7 @@
       "ALIEN"
     ],
     "lore": "Ewok sentries Scout the perimeter of their domain. Their watchful eyes search for both predatory animals and invading stormtroopers.",
-    "gameText": "Deploys only on Endor. Power and forfeit +1 for each Light side icon at same Endor site. May deploy as a 'react'. May move as a 'react' (for free) to a battle where you have a unique (•) Ewok.",
+    "gameText": "Deploys only on Endor. Power and forfeit +1 for each Light side icon at same Endor site. May deploy as a 'react'. May move as a 'react' (for free) to a battle where you have a unique (â€¢) Ewok.",
     "deployCost": 1,
     "destiny": 3,
     "power": 0,
@@ -125282,7 +125330,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "When an Imperial blockade raises the alert level, all independent ships are scanned and any suspicious characters on planet are detained and interrogated.",
-    "gameText": "Deploy on table. Unique (•) Imperials of ability < 3 are forfeit +2. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites. Once during each of your deploy phases, may deploy one docking bay from Reserve Deck; reshuffle. (Immune to Alter.)",
+    "gameText": "Deploy on table. Unique (â€¢) Imperials of ability < 3 are forfeit +2. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites. Once during each of your deploy phases, may deploy one docking bay from Reserve Deck; reshuffle. (Immune to Alter.)",
     "destiny": 5,
     "icons": [
       {
@@ -125611,7 +125659,7 @@
     ],
     "cardSubtype": "USED_OR_STARTING",
     "lore": "Imperial troops prepared for quick deployment to seize valuable terrain.",
-    "gameText": "USED: If a battle was just initiated, draw destiny and activate up to that much Force. STARTING: If you have not deployed an Objective, deploy from Reserve Deck one battleground site (or two ◇ sites) related to your starting location. Place Interrupt in Reserve Deck.",
+    "gameText": "USED: If a battle was just initiated, draw destiny and activate up to that much Force. STARTING: If you have not deployed an Objective, deploy from Reserve Deck one battleground site (or two â—‡ sites) related to your starting location. Place Interrupt in Reserve Deck.",
     "destiny": 5,
     "icons": [
       {
@@ -126123,7 +126171,7 @@
     ],
     "cardSubtype": "USED_OR_LOST",
     "lore": "Imperial training allows scouts to use speed and stealth to their advantage. On Endor, they were also backed up by Commander Igar's ATSTs.",
-    "gameText": "USED: If all of your ability in a battle is provided by scouts and/or spies, they each add 1 to your total battle destiny (limit +6). LOST: For remainder of turn, your unique (•) scouts and unique (•) spies are each power +1 (or +2 while being attacked by a creature).",
+    "gameText": "USED: If all of your ability in a battle is provided by scouts and/or spies, they each add 1 to your total battle destiny (limit +6). LOST: For remainder of turn, your unique (â€¢) scouts and unique (â€¢) spies are each power +1 (or +2 while being attacked by a creature).",
     "destiny": 4,
     "icons": [
       {
@@ -128239,7 +128287,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Rebel insurgents and local activists are the first step in breaking the Imperial stranglehold on a world.",
-    "gameText": "Deploy on table. Unique (•) Rebels of ability < 3 are forfeit +2. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites. Once during each of your deploy phases, may deploy one docking bay from Reserve Deck; reshuffle. (Immune to Alter.)",
+    "gameText": "Deploy on table. Unique (â€¢) Rebels of ability < 3 are forfeit +2. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites. Once during each of your deploy phases, may deploy one docking bay from Reserve Deck; reshuffle. (Immune to Alter.)",
     "destiny": 5,
     "icons": [
       {
@@ -128357,7 +128405,7 @@
     ],
     "cardSubtype": "USED_OR_STARTING",
     "lore": "Alliance troops on planet must plan ahead to achieve success in military operations.",
-    "gameText": "USED: If a battle was just initiated, draw destiny and activate up to that much Force. STARTING: If you have not deployed an Objective, deploy from Reserve Deck one battleground site (or two ◇ sites) related to your starting location. Place Interrupt in Reserve Deck.",
+    "gameText": "USED: If a battle was just initiated, draw destiny and activate up to that much Force. STARTING: If you have not deployed an Objective, deploy from Reserve Deck one battleground site (or two â—‡ sites) related to your starting location. Place Interrupt in Reserve Deck.",
     "destiny": 5,
     "icons": [
       {
@@ -128860,7 +128908,7 @@
     ],
     "cardSubtype": "USED_OR_LOST",
     "lore": "The ability to think and act independently gave the Rebels an advantage over their Imperial foes.",
-    "gameText": "USED: If all of your ability in a battle is provided by scouts and/or spies, they each add 1 to your total battle destiny (limit +6). LOST: For remainder of turn, your unique (•) scouts and unique (•) spies are each power +1 (or +2 while being attacked by a creature).",
+    "gameText": "USED: If all of your ability in a battle is provided by scouts and/or spies, they each add 1 to your total battle destiny (limit +6). LOST: For remainder of turn, your unique (â€¢) scouts and unique (â€¢) spies are each power +1 (or +2 while being attacked by a creature).",
     "destiny": 3,
     "icons": [
       {
@@ -130900,7 +130948,7 @@
       "IMPERIAL"
     ],
     "lore": "Wingman of Major Phennir. Earned promotion to Fel's squadron by scoring 12 kills at Mon Calamari. Repeatedly refused further promotion so that he could remain in the 181st.",
-    "gameText": "Adds 3 to power of any TIE he pilots. Once during each of your deploy phases, you may take one unique (•) TIE Interceptor into hand from Reserve Deck; reshuffle.",
+    "gameText": "Adds 3 to power of any TIE he pilots. Once during each of your deploy phases, you may take one unique (â€¢) TIE Interceptor into hand from Reserve Deck; reshuffle.",
     "deployCost": 2,
     "destiny": 4,
     "power": 2,
@@ -134081,7 +134129,7 @@
       "REBEL"
     ],
     "lore": "Rescued from an Imperial detention center by Wedge Antilles. Rogue Squadron veteran. Assigned to Red Squadron at the Battle of Endor. Coordinates with Rebellion procurement.",
-    "gameText": "Adds 2 to the power of anything he pilots. When at a system, sector, or docking bay, once during each of your deploy phases, subtracts 2 from deploy cost of your unique (•) X-wing deploying here.",
+    "gameText": "Adds 2 to the power of anything he pilots. When at a system, sector, or docking bay, once during each of your deploy phases, subtracts 2 from deploy cost of your unique (â€¢) X-wing deploying here.",
     "deployCost": 2,
     "destiny": 3,
     "power": 2,
@@ -134149,7 +134197,7 @@
       "REBEL"
     ],
     "lore": "Rogue Squadron pilot. Assigned as gunner aboard Colonel Salm's Y-wing at Battle of Endor, as part of Gray Squadron. Former member of Aggressor Squadron.",
-    "gameText": "Adds 1 to power of anything he pilots. While aboard your starship, adds 2 to each of its weapon destiny draws. While aboard a unique (•) Gray Squadron Y-wing at a system or sector, adds 1 to each of your Force drains there.",
+    "gameText": "Adds 1 to power of anything he pilots. While aboard your starship, adds 2 to each of its weapon destiny draws. While aboard a unique (â€¢) Gray Squadron Y-wing at a system or sector, adds 1 to each of your Force drains there.",
     "deployCost": 2,
     "destiny": 3,
     "power": 2,
@@ -134283,7 +134331,7 @@
       "REBEL"
     ],
     "lore": "One of only four attackers who survived the raid on the Imperial Academy at Carida. Gray Squadron pilot.",
-    "gameText": "Adds 2 to power of anything he pilots. When at a system, sector or docking bay, once during each of your deploy phases, subtracts 2 from deploy cost of your unique (•) Y-wing deploying there.",
+    "gameText": "Adds 2 to power of anything he pilots. When at a system, sector or docking bay, once during each of your deploy phases, subtracts 2 from deploy cost of your unique (â€¢) Y-wing deploying there.",
     "deployCost": 2,
     "destiny": 3,
     "power": 2,
@@ -134930,7 +134978,7 @@
     "cardTypes": [
       "ADMIRALS_ORDER"
     ],
-    "gameText": "Unique (•) starfighters without permanent pilots are immune to attrition < 4 (or add 2 to immunity if starfighter already has immunity). Starships without pilot characters aboard are power -2. At docking bays related to systems you occupy, your Force drains are +1. Once per turn, your starfighter just lost from a system may be relocated to a related docking bay.",
+    "gameText": "Unique (â€¢) starfighters without permanent pilots are immune to attrition < 4 (or add 2 to immunity if starfighter already has immunity). Starships without pilot characters aboard are power -2. At docking bays related to systems you occupy, your Force drains are +1. Once per turn, your starfighter just lost from a system may be relocated to a related docking bay.",
     "deployCost": 0,
     "destiny": 6,
     "icons": [
@@ -135015,7 +135063,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Admiral Ackbar's hit-and-fade tactics force the Imperial Navy to spread throughout the galaxy in a futile attempt to engage the Rebels.",
-    "gameText": "Deploy on table. While you control a battleground site, your Force drain may not be modified or canceled at a system where you have a Star Cruiser or unique(•) starfighter, except by a 'react.' Place Effect in Used Pile if you lose a battle at a system.",
+    "gameText": "Deploy on table. While you control a battleground site, your Force drain may not be modified or canceled at a system where you have a Star Cruiser or unique(â€¢) starfighter, except by a 'react.' Place Effect in Used Pile if you lose a battle at a system.",
     "destiny": 5,
     "icons": [
       {
@@ -135269,7 +135317,7 @@
     ],
     "cardSubtype": "USED",
     "lore": "'And see if you can get a few of those TIE fighters to follow you.'",
-    "gameText": "If your piloted unique (•) starfighter is present with opponent's piloted starfighter during your move phase at a non-cloud sector, relocate both to related system. OR Target your starfighter in battle. During this battle, your other starships may not be targeted by weapons.",
+    "gameText": "If your piloted unique (â€¢) starfighter is present with opponent's piloted starfighter during your move phase at a non-cloud sector, relocate both to related system. OR Target your starfighter in battle. During this battle, your other starships may not be targeted by weapons.",
     "destiny": 5,
     "icons": [
       {
@@ -137338,7 +137386,7 @@
     "cardTypes": [
       "ADMIRALS_ORDER"
     ],
-    "gameText": "Unique (•) starfighters without permanent pilots are immune to attrition < 4 (or add 2 to immunity if starfighter already has immunity). Starships without pilot characters aboard are power -2. At docking bays related to systems you occupy, your Force drains are +1. Once per turn, your starfighter just lost from a system may be relocated to a related docking bay.",
+    "gameText": "Unique (â€¢) starfighters without permanent pilots are immune to attrition < 4 (or add 2 to immunity if starfighter already has immunity). Starships without pilot characters aboard are power -2. At docking bays related to systems you occupy, your Force drains are +1. Once per turn, your starfighter just lost from a system may be relocated to a related docking bay.",
     "deployCost": 0,
     "destiny": 6,
     "icons": [

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_dark.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_dark.json
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     "cardId": "101_4",
     "title": "Death Star: Docking Control Room 327",
@@ -50,7 +50,7 @@
       "IMPERIAL"
     ],
     "lore": "Sought to extinguish all Jedi. Former student of Obi-Wan Kenobi. Seduced by the dark side of the Force.",
-    "gameText": "Must deploy on Death Star, but may move elsewhere. May not be deployed if two or more of opponent's unique (•) characters on table. If in a losing battle, draw destiny. If destiny > 4, 'choke' (lose) one Imperial present (your choice).",
+    "gameText": "Must deploy on Death Star, but may move elsewhere. May not be deployed if two or more of opponent's unique (â€¢) characters on table. If in a losing battle, draw destiny. If destiny > 4, 'choke' (lose) one Imperial present (your choice).",
     "deployCost": 7,
     "destiny": 1,
     "power": 4,
@@ -385,7 +385,7 @@
       "IMPERIAL"
     ],
     "lore": "General of the AT-AT assault armor division sent by Darth Vader to crush the Rebellion on Hoth. Cold and ruthless.",
-    "gameText": "Must deploy on Hoth, but may move elsewhere. May not be deployed if three or more of opponent's unique (•) characters on table. Snowtroopers at same site are forfeit +1.",
+    "gameText": "Must deploy on Hoth, but may move elsewhere. May not be deployed if three or more of opponent's unique (â€¢) characters on table. Snowtroopers at same site are forfeit +1.",
     "deployCost": 4,
     "destiny": 1,
     "power": 2,
@@ -505,7 +505,7 @@
     ],
     "cardSubtype": "SQUADRON",
     "lore": "Notoriety gained during the assaults on Ralltiir and Mon Calamari makes this the most feared squadron in the Empire. Defended the Death Star during the Battle of Yavin.",
-    "gameText": "Permanent pilots aboard are •Darth Vader, •DS-61-2 and •DS-61-3, who provide total ability of 10 and add 9 to total power of •Vader's Custom TIE, •Black 2 and •Black 3.",
+    "gameText": "Permanent pilots aboard are â€¢Darth Vader, â€¢DS-61-2 and â€¢DS-61-3, who provide total ability of 10 and add 9 to total power of â€¢Vader's Custom TIE, â€¢Black 2 and â€¢Black 3.",
     "deployCost": 12,
     "destiny": 1,
     "power": 3,
@@ -1060,7 +1060,7 @@
       "ALIEN"
     ],
     "lore": "Notorious bounty hunter. 'As you wish.'",
-    "gameText": "Adds 3 to power of anything he pilots. Adds one battle destiny if with Han or Jabba. Permanent weapon is •Boba Fett's Blaster Rifle (may target a character or creature for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value).",
+    "gameText": "Adds 3 to power of anything he pilots. Adds one battle destiny if with Han or Jabba. Permanent weapon is â€¢Boba Fett's Blaster Rifle (may target a character or creature for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value).",
     "deployCost": 5,
     "destiny": 1,
     "power": 4,
@@ -1112,7 +1112,7 @@
       "IMPERIAL"
     ],
     "lore": "'If you only knew the power of the dark side.'",
-    "gameText": "Adds 3 to power of anything he pilots. Permanent weapon is •Vader's Lightsaber (may target a character or creature for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
+    "gameText": "Adds 3 to power of anything he pilots. Permanent weapon is â€¢Vader's Lightsaber (may target a character or creature for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
     "deployCost": 6,
     "destiny": 1,
     "power": 6,
@@ -1161,7 +1161,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Corellian starfighter. Dengar replaced its passenger capacity and TIE cannons with enhanced targeting systems. Allows Dengar to track and engage multiple enemies at once.",
-    "gameText": "Permanent pilot is •Dengar, who provides ability of 2 and adds 2 to power. When in battle, adds 1 to total battle destiny for each opponent's starship present. Cancels opponent's immunity to attrition here.",
+    "gameText": "Permanent pilot is â€¢Dengar, who provides ability of 2 and adds 2 to power. When in battle, adds 1 to total battle destiny for each opponent's starship present. Cancels opponent's immunity to attrition here.",
     "deployCost": 5,
     "destiny": 1,
     "power": 2,
@@ -1317,7 +1317,7 @@
       "DROID"
     ],
     "lore": "Accomplished thief and information broker. Modified by Jabba to be an effective bounty hunter. The Hutt often teams 4-LOM with other hired killers.",
-    "gameText": "Adds one battle destiny if with Jabba or Zuckuss. Permanent weapon is •4-LOM's Concussion Rifle (may target a character for free; target may not use its game text for remainder of turn).",
+    "gameText": "Adds one battle destiny if with Jabba or Zuckuss. Permanent weapon is â€¢4-LOM's Concussion Rifle (may target a character for free; target may not use its game text for remainder of turn).",
     "deployCost": 3,
     "destiny": 3,
     "power": 2,
@@ -1399,7 +1399,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Dangerous and deadly starfighter piloted by its notorious owner. Uses combat-grade shields and sensors. Hidden weapons provide lethal surprises for Fett's victims.",
-    "gameText": "May add 3 passengers. Permanent pilot is •Boba Fett, who provides ability of 3, adds 3 to power, adds 2 to maneuver and draws one battle destiny if not able to otherwise. Immune to attrition < 5.",
+    "gameText": "May add 3 passengers. Permanent pilot is â€¢Boba Fett, who provides ability of 3, adds 3 to power, adds 2 to maneuver and draws one battle destiny if not able to otherwise. Immune to attrition < 5.",
     "deployCost": 7,
     "destiny": 1,
     "power": 4,
@@ -2592,7 +2592,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Zuckuss is a dangerous adversary, especially when aboard his own starship. Mystical omens enable the Gand to predict enemy maneuvers in starship combat.",
-    "gameText": "May add 1 pilot and 3 passengers. Permanent pilot is •Zuckuss, who provides ability of 4 and adds 2 to power. Unless opponent has total ability > 6 piloting here, opponent's total battle destiny here = zero.",
+    "gameText": "May add 1 pilot and 3 passengers. Permanent pilot is â€¢Zuckuss, who provides ability of 4 and adds 2 to power. Unless opponent has total ability > 6 piloting here, opponent's total battle destiny here = zero.",
     "deployCost": 6,
     "destiny": 1,
     "power": 2,
@@ -2648,7 +2648,7 @@
       "ALIEN"
     ],
     "lore": "Trandoshan bounty hunter. Modified his mortar gun to fire stun cartridges for live captures. Uses non-fragmentary capture rounds to minimize collateral damage.",
-    "gameText": "Adds 2 to power of anything he pilots. Permanent weapon is •Bossk's Mortar Gun (may fire for free; draw destiny; may subtract or add 1 if at same site as a bounty; choose one character with that destiny number present to be captured.)",
+    "gameText": "Adds 2 to power of anything he pilots. Permanent weapon is â€¢Bossk's Mortar Gun (may fire for free; draw destiny; may subtract or add 1 if at same site as a bounty; choose one character with that destiny number present to be captured.)",
     "deployCost": 5,
     "destiny": 1,
     "power": 4,
@@ -2751,7 +2751,7 @@
       "ALIEN"
     ],
     "lore": "Corellian bounty hunter. Skilled athlete. Expert shot. Has worked many times for Jabba the Hutt. Carries a long-standing grudge against Han Solo.",
-    "gameText": "Adds 2 to the power of anything he pilots. Permanent weapon is •Dengar's Blaster Carbine (may target a character, creature or vehicle for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value; may be fired twice per battle).",
+    "gameText": "Adds 2 to the power of anything he pilots. Permanent weapon is â€¢Dengar's Blaster Carbine (may target a character, creature or vehicle for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value; may be fired twice per battle).",
     "deployCost": 5,
     "destiny": 2,
     "power": 3,
@@ -2804,7 +2804,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Starship adapted to the assassin droid's specifications. Flight controls linked directly to processing unit. Real-time relays minimize response time.",
-    "gameText": "May add 2 passengers. Permanent pilot is •IG-88, who adds 2 to power and 3 to maneuver. May initiate battle. When in a battle you initiate, adds one battle destiny. Ion Cannon may deploy aboard.",
+    "gameText": "May add 2 passengers. Permanent pilot is â€¢IG-88, who adds 2 to power and 3 to maneuver. May initiate battle. When in a battle you initiate, adds one battle destiny. Ion Cannon may deploy aboard.",
     "deployCost": 5,
     "destiny": 1,
     "power": 3,
@@ -3108,7 +3108,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "Deploy Desert Heart and a Jabba's Palace site. May deploy Well Guarded. Reveal one unique (•) alien from your deck whose lore specifies its species. This card is your Rep. For remainder of game, your Rep is a leader. Well Guarded is immune to Alter. You may not deploy 'insert' cards or operatives. While frozen Han on table, Rebels are immune to No Bargain and Bad Feeling Have I. Flip this card if you occupy two battleground sites (must occupy a third with a non-unique alien of your Rep's species if a non-Tatooine location is on table).",
+    "gameText": "Deploy Desert Heart and a Jabba's Palace site. May deploy Well Guarded. Reveal one unique (â€¢) alien from your deck whose lore specifies its species. This card is your Rep. For remainder of game, your Rep is a leader. Well Guarded is immune to Alter. You may not deploy 'insert' cards or operatives. While frozen Han on table, Rebels are immune to No Bargain and Bad Feeling Have I. Flip this card if you occupy two battleground sites (must occupy a third with a non-unique alien of your Rep's species if a non-Tatooine location is on table).",
     "destiny": 0,
     "icons": [
       {
@@ -3162,7 +3162,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Jabba's influence is not easily ignored. Neither are his voracious and vile appetites. Even Jedi soon learn this lesson.",
-    "gameText": "Deploy on table. You may immediately take top card of Lost Pile into hand. Effects, Epic Events, and Objectives are immune to Honor Of The Jedi. At each opponent's ◇ site, your characters and vehicles are each deploy -3 and your Force generation is +1. (Immune to Alter.)",
+    "gameText": "Deploy on table. You may immediately take top card of Lost Pile into hand. Effects, Epic Events, and Objectives are immune to Honor Of The Jedi. At each opponent's â—‡ site, your characters and vehicles are each deploy -3 and your Force generation is +1. (Immune to Alter.)",
     "destiny": 4,
     "icons": [
       {
@@ -4053,7 +4053,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Tarkin silenced the voices of Alderaan with the power of the Death Star.",
-    "gameText": "Deploy on table. Twice per game may take Commence Primary Ignition into hand from Lost Pile or Reserve Deck; reshuffle. If Alderaan 'blown away,' retrieve 3 Force whenever you deploy a unique (•) Star Destroyer. (Immune to Alter.)",
+    "gameText": "Deploy on table. Twice per game may take Commence Primary Ignition into hand from Lost Pile or Reserve Deck; reshuffle. If Alderaan 'blown away,' retrieve 3 Force whenever you deploy a unique (â€¢) Star Destroyer. (Immune to Alter.)",
     "destiny": 5,
     "icons": [
       {
@@ -6322,7 +6322,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Once begun, the occupation of Naboo was swift, and devastatingly effective.",
-    "gameText": "Deploy on table. Your unique (•) Republicans are forfeit +2 and immune to Goo Nee Tay. Unless Imperial Arrest Order on table, once during your deploy phase, may deploy one docking bay from Reserve Deck; reshuffle. (Immune to Alter.)",
+    "gameText": "Deploy on table. Your unique (â€¢) Republicans are forfeit +2 and immune to Goo Nee Tay. Unless Imperial Arrest Order on table, once during your deploy phase, may deploy one docking bay from Reserve Deck; reshuffle. (Immune to Alter.)",
     "destiny": 4,
     "icons": [
       {
@@ -6354,7 +6354,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Imperial officers are always on the lookout for Rebel espionage.",
-    "gameText": "Deploy on table. Unique (•) Imperials of ability = 3 are forfeit +3. If opponent just retrieved Force using an Interrupt or Utinni Effect, you may place that card here. Opponent's Force retrieval is reduced by X, where X = number of cards here. (Immune to Alter.)",
+    "gameText": "Deploy on table. Unique (â€¢) Imperials of ability = 3 are forfeit +3. If opponent just retrieved Force using an Interrupt or Utinni Effect, you may place that card here. Opponent's Force retrieval is reduced by X, where X = number of cards here. (Immune to Alter.)",
     "destiny": 5,
     "icons": [
       {
@@ -6484,7 +6484,7 @@
       "EFFECT"
     ],
     "cardSubtype": "NORMAL",
-    "gameText": "Deploy on table. Unique (•) Imperials of ability < 3 are forfeit +1. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites only. Once during each of your deploy phases, may deploy one docking bay from Reserve Deck; reshuffle. When opponent retrieves X cards, opponent must first use X Force or that retrieval is canceled. (Immune to Alter.)",
+    "gameText": "Deploy on table. Unique (â€¢) Imperials of ability < 3 are forfeit +1. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites only. Once during each of your deploy phases, may deploy one docking bay from Reserve Deck; reshuffle. When opponent retrieves X cards, opponent must first use X Force or that retrieval is canceled. (Immune to Alter.)",
     "destiny": 5,
     "icons": [
       {
@@ -7084,7 +7084,7 @@
     ],
     "cardSubtype": "USED_OR_STARTING",
     "lore": "'We must move quickly to disrupt all communication down there.'",
-    "gameText": "USED: Use 2 Force to deploy a unique (•) battleground not on table, from Reserve Deck; reshuffle. STARTING: Deploy from your Reserve Deck one Effect which deploys on table (or your side of table) and has no deploy cost; reshuffle. Place Interrupt in Lost Pile.",
+    "gameText": "USED: Use 2 Force to deploy a unique (â€¢) battleground not on table, from Reserve Deck; reshuffle. STARTING: Deploy from your Reserve Deck one Effect which deploys on table (or your side of table) and has no deploy cost; reshuffle. Place Interrupt in Lost Pile.",
     "destiny": 5,
     "icons": [
       {
@@ -7211,7 +7211,7 @@
       "INTERRUPT"
     ],
     "cardSubtype": "USED_OR_LOST",
-    "gameText": "USED: Take one unique (•) unpiloted starfighter into hand from Reserve Deck; reshuffle. LOST: During a battle at a system or sector, if you are about to draw a card for battle destiny, you may instead use the maneuver number of your unique (•) starfighter in that battle.",
+    "gameText": "USED: Take one unique (â€¢) unpiloted starfighter into hand from Reserve Deck; reshuffle. LOST: During a battle at a system or sector, if you are about to draw a card for battle destiny, you may instead use the maneuver number of your unique (â€¢) starfighter in that battle.",
     "destiny": 5,
     "icons": [
       {
@@ -9753,7 +9753,7 @@
       "DEFENSIVE_SHIELD"
     ],
     "lore": "Jabba's influence is not easily ignored. Neither are his voracious and vile appetites. Even Jedi soon learn this lesson.",
-    "gameText": "Plays on table. At opponent's ◇ site where opponent's creature present, you may deploy without presence or Force icons, and your Force generation there is +1.",
+    "gameText": "Plays on table. At opponent's â—‡ site where opponent's creature present, you may deploy without presence or Force icons, and your Force generation there is +1.",
     "deployCost": 0,
     "destiny": 0,
     "icons": [
@@ -11844,6 +11844,54 @@
       "BATTLE"
     ]
   },
+      {
+    "cardId": "14_71",
+    "title": "3B3-21",
+    "slug": "3b3-21",
+    "slugWithSetName": "3b3-21-theed-palace",
+    "side": "DARK",
+    "uniqueness": "UNIQUE",
+    "expansionSet": "THEED_PALACE",
+    "rarity": "U",
+    "cardCategory": "CHARACTER",
+    "cardTypes": [
+      "DROID"
+    ],
+    "lore": "Infantry battle droid equipped with command programs to call reinforcements into his patrol zone when needed. Assigned to escort Amidala soon after her capture.",
+    "gameText": "If opponent just initiated a battle at same site, may use X Force to reveal the top X cards of your Reserve Deck. (maximum 4). Any battle droids revealed this way may deploy for free; all other cards are lost.",
+    "deployCost": 3,
+    "destiny": 2,
+    "power": 3,
+    "ability": 0,
+    "forfeit": 3,
+    "armor": 4,
+    "landspeed": 1,
+    "politics": 0,
+    "icons": [
+      {
+        "icon": "THEED_PALACE",
+        "count": 1
+      },
+      {
+        "icon": "DROID",
+        "count": 1
+      },
+      {
+        "icon": "PRESENCE",
+        "count": 1
+      },
+      {
+        "icon": "EPISODE_I",
+        "count": 1
+      }
+    ],
+    "keywords": [
+      "INFANTRY_BATTLE_DROID"
+    ],
+    "modelTypes": [
+      "BATTLE"
+    ]
+  },
   {
     "cardId": "14_72",
     "title": "3B3-888",
@@ -12090,7 +12138,7 @@
       "SITH"
     ],
     "lore": "'Yes, my Master.'",
-    "gameText": "Permanent weapon is •Maul's Double-Bladed Lightsaber (twice per battle, may target a character for free; draw two destiny; target 'hit,' and its forfeit = 0, if total destiny > defense value).",
+    "gameText": "Permanent weapon is â€¢Maul's Double-Bladed Lightsaber (twice per battle, may target a character for free; draw two destiny; target 'hit,' and its forfeit = 0, if total destiny > defense value).",
     "deployCost": 7,
     "destiny": 1,
     "power": 7,
@@ -13943,7 +13991,7 @@
       "ALIEN"
     ],
     "lore": "Female H'nemthe, a species whose females ritually kill their mates. Stranded on Tatooine due to questionable passage tax. Razor-sharp tongue. M'iiyoom means, 'nightlilly'.",
-    "gameText": "Once during each of your control phases, may reveal opponent's hand by using X Force, where X = number of cards in opponent's hand. All unique (•) male Rebels and unique (•) male aliens there are lost.",
+    "gameText": "Once during each of your control phases, may reveal opponent's hand by using X Force, where X = number of cards in opponent's hand. All unique (â€¢) male Rebels and unique (â€¢) male aliens there are lost.",
     "deployCost": 3,
     "destiny": 3,
     "power": 1,
@@ -17865,7 +17913,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Aratech Corporation sent support staff to various Imperial outposts and garrisons. Gave advanced briefings and training to biker scout personnel.",
-    "gameText": "Deploy on table. AT-STs and speeder bikes are power and forfeit +1. During your deploy phase, may reveal an AT-ST or Speeder Bike from hand to [upload] a unique (•) [Endor] Imperial pilot of ability < 3 (or vice versa) and deploy both simultaneously. (Immune to Alter.)",
+    "gameText": "Deploy on table. AT-STs and speeder bikes are power and forfeit +1. During your deploy phase, may reveal an AT-ST or Speeder Bike from hand to [upload] a unique (â€¢) [Endor] Imperial pilot of ability < 3 (or vice versa) and deploy both simultaneously. (Immune to Alter.)",
     "destiny": 4,
     "icons": [
       {
@@ -17927,7 +17975,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Being stationed at Endor during the construction of the second Death Star allows Imperial pilots time to train in the latest starfighter combat techniques.",
-    "gameText": "Deploy on table. Tallon Roll is canceled. Once per turn, may reveal an unpiloted starfighter from hand to [upload] its matching pilot character (or vice versa) and deploy both simultaneously. Your unique (•) TIEs (except Scythe Squadron TIEs) at systems may use 1 Force to relocate (as a regular move) to system within 3 parsecs. [Immune to Alter]",
+    "gameText": "Deploy on table. Tallon Roll is canceled. Once per turn, may reveal an unpiloted starfighter from hand to [upload] its matching pilot character (or vice versa) and deploy both simultaneously. Your unique (â€¢) TIEs (except Scythe Squadron TIEs) at systems may use 1 Force to relocate (as a regular move) to system within 3 parsecs. [Immune to Alter]",
     "destiny": 5,
     "icons": [
       {
@@ -18131,7 +18179,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Company that produces current generation of Star Destroyers, as well as Nebulon-B Frigates. Ship yards are extremely well defended.",
-    "gameText": "Deploy on table. Unique (•) Imperial-class Star Destroyers draw one battle destiny if unable to otherwise and are immune to attrition < 4. During your deploy phase, may use 2 Force to [download] a battleground system. We're In Attack Position Now is canceled. Immune to Alter.",
+    "gameText": "Deploy on table. Unique (â€¢) Imperial-class Star Destroyers draw one battle destiny if unable to otherwise and are immune to attrition < 4. During your deploy phase, may use 2 Force to [download] a battleground system. We're In Attack Position Now is canceled. Immune to Alter.",
     "destiny": 3,
     "icons": [
       {
@@ -18816,7 +18864,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Dangerous and deadly starfighter piloted by its notorious owner. Uses combat-grade shields and sensors. Hidden weapons provide lethal surprises for Fett's victims.",
-    "gameText": "Permanent pilot is •Boba Fett, who provides ability of 3. Draws one battle destiny if unable to otherwise. Slave I's power may not be reduced by opponent. Immune to Eject! Eject! and attrition < 5.",
+    "gameText": "Permanent pilot is â€¢Boba Fett, who provides ability of 3. Draws one battle destiny if unable to otherwise. Slave I's power may not be reduced by opponent. Immune to Eject! Eject! and attrition < 5.",
     "deployCost": 6,
     "destiny": 1,
     "power": 7,
@@ -18876,7 +18924,7 @@
     ],
     "cardSubtype": "CAPITAL",
     "lore": "Bossk once said of his ship, 'Greeezeg uut nikek!'",
-    "gameText": "Permanent pilot is •Bossk, who provides ability of 2. During battle with opponent's [Independent] starship (or Falcon), may add one destiny to total power or attrition. Immune to attrition < 4.",
+    "gameText": "Permanent pilot is â€¢Bossk, who provides ability of 2. During battle with opponent's [Independent] starship (or Falcon), may add one destiny to total power or attrition. Immune to attrition < 4.",
     "deployCost": 4,
     "destiny": 1,
     "power": 6,
@@ -18939,7 +18987,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Designed to emulate Rebel starfighter advantages. Production began shortly before the Battle of Endor. Armed with laser cannons, ion cannons and missile launchers.",
-    "gameText": "May deploy as a 'react'. Permanent pilot is •Jendon, who provides ability of 2. When deployed, may [download] a weapon on Onyx 1. Adds one battle destiny if with Onyx 2. Immune to attrition < 4.",
+    "gameText": "May deploy as a 'react'. Permanent pilot is â€¢Jendon, who provides ability of 2. When deployed, may [download] a weapon on Onyx 1. Adds one battle destiny if with Onyx 2. Immune to attrition < 4.",
     "deployCost": 4,
     "destiny": 2,
     "power": 5,
@@ -19051,7 +19099,7 @@
       "STARSHIP"
     ],
     "cardSubtype": "STARFIGHTER",
-    "gameText": "May add 1 pilot and 3 passengers. Permanent pilot is •Elis, who provides ability of 2. Once per game, may use 1 Force to [download] a smuggler aboard. Immune to attrition < 5.",
+    "gameText": "May add 1 pilot and 3 passengers. Permanent pilot is â€¢Elis, who provides ability of 2. Once per game, may use 1 Force to [download] a smuggler aboard. Immune to attrition < 5.",
     "deployCost": 4,
     "destiny": 2,
     "power": 4,
@@ -19548,7 +19596,7 @@
       "DROID"
     ],
     "lore": "Accomplished thief and information broker. Modified by Jabba to be an effective bounty hunter. The Hutt often teams 4-LOM with other hired killers.",
-    "gameText": "Permanent weapon is •4-LOM's Concussion Rifle (may target a character for free; target is power -1 until end of turn). Once per turn, may place a card from hand on bottom of Used Pile to draw top card from Reserve Deck.",
+    "gameText": "Permanent weapon is â€¢4-LOM's Concussion Rifle (may target a character for free; target is power -1 until end of turn). Once per turn, may place a card from hand on bottom of Used Pile to draw top card from Reserve Deck.",
     "deployCost": 3,
     "destiny": 3,
     "power": 2,
@@ -19650,7 +19698,7 @@
       "IMPERIAL"
     ],
     "lore": "Senior Navy Commander of Death Star. Believes in technology. Ridiculed the Force. Ambitious leader. Promoted due to support of New Order, not military skills. Hates Vader.",
-    "gameText": "[Pilot] 2. Chiraneau may not modify your Force drains. Kuat Drive Yards is immune to Alter. Unless your Senate on table, unique (•) Star Destroyers are power +2 and immunity to attrition +1. Once per game, may [download] non-[Set 0] Kuat Drive Yards.",
+    "gameText": "[Pilot] 2. Chiraneau may not modify your Force drains. Kuat Drive Yards is immune to Alter. Unless your Senate on table, unique (â€¢) Star Destroyers are power +2 and immunity to attrition +1. Once per game, may [download] non-[Set 0] Kuat Drive Yards.",
     "deployCost": 3,
     "destiny": 1,
     "power": 3,
@@ -19952,7 +20000,7 @@
       "ALIEN"
     ],
     "lore": "Corellian bounty hunter. Skilled athlete. Expert shot. Has worked many times for Jabba the Hutt. Carries a long-standing grudge against Han Solo.",
-    "gameText": "While opponent's [Reflection II icon] objective on table, adds one battle destiny. Permanent weapon is •Dengar's Blaster Carbine (may target a character, creature or vehicle for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value; may be fired twice per battle).",
+    "gameText": "While opponent's [Reflection II icon] objective on table, adds one battle destiny. Permanent weapon is â€¢Dengar's Blaster Carbine (may target a character, creature or vehicle for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value; may be fired twice per battle).",
     "deployCost": 4,
     "destiny": 2,
     "power": 3,
@@ -20321,7 +20369,7 @@
       "ALIEN"
     ],
     "lore": "Ordered to kill Luke Skywalker. Assumed the identity of a dancer named 'Arica' in order to sneak into Jabba's Palace.",
-    "gameText": "With Luke or Emperor on table, power +1 and she moves for free. Permanent weapon is •Mara Jade's Lightsaber (may target a character or creature for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
+    "gameText": "With Luke or Emperor on table, power +1 and she moves for free. Permanent weapon is â€¢Mara Jade's Lightsaber (may target a character or creature for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
     "deployCost": 5,
     "destiny": 1,
     "power": 4,
@@ -22108,7 +22156,7 @@
       "ALIEN"
     ],
     "lore": "Gamorrean in charge of the Gamorreans at Jabba's palace. Posted to stand guard at the entrance cavern. Assigned by Jabba to keep an eye on Tessek.",
-    "gameText": "Permanent weapon is •Ortugg's Ax (may target a character or creature for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value). While Ortugg is your Rep, your non-unique Gamorreans are deploy -1 and forfeit +3.",
+    "gameText": "Permanent weapon is â€¢Ortugg's Ax (may target a character or creature for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value). While Ortugg is your Rep, your non-unique Gamorreans are deploy -1 and forfeit +3.",
     "deployCost": 3,
     "destiny": 3,
     "power": 4,
@@ -23826,7 +23874,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "TIE bomber repaired after being struck by an asteroid in the Anoat system. Stationed aboard second Death Star battle station.",
-    "gameText": "Permanent pilot is •Jonus, who provides ability of 2. This starship's missile weapon destiny draws are +1. If at a system you control, your total power at related sites is +1.",
+    "gameText": "Permanent pilot is â€¢Jonus, who provides ability of 2. This starship's missile weapon destiny draws are +1. If at a system you control, your total power at related sites is +1.",
     "deployCost": 2,
     "destiny": 2,
     "power": 4,
@@ -24923,7 +24971,7 @@
       "SITH"
     ],
     "lore": "Trade Federation.",
-    "gameText": "Permanent weapon is •Maul's Lightsaber (may add 1 to Force drain where present; adds 1 to your battle destiny draws here; may target a character for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
+    "gameText": "Permanent weapon is â€¢Maul's Lightsaber (may add 1 to Force drain where present; adds 1 to your battle destiny draws here; may target a character for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
     "deployCost": 6,
     "destiny": 1,
     "power": 7,
@@ -25355,7 +25403,7 @@
     ],
     "cardSubtype": "USED_OR_LOST",
     "lore": "Oouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioo-",
-    "gameText": "USED: [Upload] Downtown Plaza or a prison. LOST: [Upload] one unique (•) bounty. OR Target an alien. For remainder of turn, target is power and forfeit -1 (-3 if Chewie).",
+    "gameText": "USED: [Upload] Downtown Plaza or a prison. LOST: [Upload] one unique (â€¢) bounty. OR Target an alien. For remainder of turn, target is power and forfeit -1 (-3 if Chewie).",
     "destiny": 4,
     "icons": [
       {
@@ -25863,7 +25911,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "Deploy Tuanul Village, any other [Episode VII] location, and I Will Finish What You Started. Opponent may reveal a unique (•) character with ability (except Luke or a Jedi) from Reserve Deck; that card is a Resistance Agent. Otherwise, Luke is a Resistance Agent and loses immunity to attrition. For remainder of game, non-[Episode VII] Dark Jedi are lost and Resistance Agents are immune to Set For Stun. Flip this card if your First Order characters control two battlegrounds and a Resistance Agent is not present at a battleground site.",
+    "gameText": "Deploy Tuanul Village, any other [Episode VII] location, and I Will Finish What You Started. Opponent may reveal a unique (â€¢) character with ability (except Luke or a Jedi) from Reserve Deck; that card is a Resistance Agent. Otherwise, Luke is a Resistance Agent and loses immunity to attrition. For remainder of game, non-[Episode VII] Dark Jedi are lost and Resistance Agents are immune to Set For Stun. Flip this card if your First Order characters control two battlegrounds and a Resistance Agent is not present at a battleground site.",
     "destiny": 0,
     "icons": [
       {
@@ -25924,7 +25972,7 @@
       "STARSHIP"
     ],
     "cardSubtype": "STARFIGHTER",
-    "gameText": "May add 1 pilot and 2 passengers. Permanent pilot is •Mara Jade, who provides ability of 5. While alone and piloted by an Imperial, adds one battle destiny. Immune to attrition < 4.",
+    "gameText": "May add 1 pilot and 2 passengers. Permanent pilot is â€¢Mara Jade, who provides ability of 5. While alone and piloted by an Imperial, adds one battle destiny. Immune to attrition < 4.",
     "deployCost": 5,
     "destiny": 2,
     "power": 5,
@@ -26198,7 +26246,7 @@
       "FIRST_ORDER"
     ],
     "lore": "Leader.",
-    "gameText": "[Pilot] 2. Permanent weapon is •Kylo's Lightsaber (may target a character for free; draw two destiny; target hit, its forfeit = 0, and opponent loses 1 Force, if total destiny > defense value; otherwise you lose 1 Force).",
+    "gameText": "[Pilot] 2. Permanent weapon is â€¢Kylo's Lightsaber (may target a character for free; draw two destiny; target hit, its forfeit = 0, and opponent loses 1 Force, if total destiny > defense value; otherwise you lose 1 Force).",
     "deployCost": 5,
     "destiny": 1,
     "power": 6,
@@ -26503,7 +26551,7 @@
     "cardTypes": [
       "EPIC_EVENT"
     ],
-    "gameText": "Once per game, deploy on Death Star; it is hyperspeed = 2. Superlaser may not target planet systems. Once during your control phase, may fire Superlaser as follows: Prepare Single Reactor Ignition: If Death Star orbiting Jedha or Scarif, target your related unique (•) battleground site, even if converted (regardless of objective restrictions). Fire!: Draw destiny. It's Beautiful: If destiny +X > 8, site is 'blown away,' and opponent loses 3 Force. X = number of Death Star sites on table.",
+    "gameText": "Once per game, deploy on Death Star; it is hyperspeed = 2. Superlaser may not target planet systems. Once during your control phase, may fire Superlaser as follows: Prepare Single Reactor Ignition: If Death Star orbiting Jedha or Scarif, target your related unique (â€¢) battleground site, even if converted (regardless of objective restrictions). Fire!: Draw destiny. It's Beautiful: If destiny +X > 8, site is 'blown away,' and opponent loses 3 Force. X = number of Death Star sites on table.",
     "deployCost": 0,
     "destiny": 0,
     "icons": [
@@ -27079,7 +27127,7 @@
     ],
     "cardSubtype": "COMBAT",
     "lore": "Enclosed. Death Squadron.",
-    "gameText": "May add 1 pilot. Permanent pilot is •Marquand, who provides ability of 2. Cards Blizzard 6 hits are power and forfeit -2 and may not apply ability towards drawing battle destiny. Immune to attrition < 4.",
+    "gameText": "May add 1 pilot. Permanent pilot is â€¢Marquand, who provides ability of 2. Cards Blizzard 6 hits are power and forfeit -2 and may not apply ability towards drawing battle destiny. Immune to attrition < 4.",
     "deployCost": 6,
     "destiny": 1,
     "power": 6,
@@ -27448,7 +27496,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "On her assignment to kill Sharad Hett, Aurra used her patience and cunning to help track down the Jedi Master.",
-    "gameText": "Deploy on table. While alone, assassins are power +1. Once per game, may reveal up to two unique (•) aliens from hand and/or Reserve Deck (reshuffle); for remainder of game, those cards are assassins and, if your [Reflections II] objective on table, Black Sun agents. [Immune to Alter.]",
+    "gameText": "Deploy on table. While alone, assassins are power +1. Once per game, may reveal up to two unique (â€¢) aliens from hand and/or Reserve Deck (reshuffle); for remainder of game, those cards are assassins and, if your [Reflections II] objective on table, Black Sun agents. [Immune to Alter.]",
     "destiny": 4,
     "icons": [
       {
@@ -29654,7 +29702,7 @@
       "LOCATION"
     ],
     "cardSubtype": "SITE",
-    "locationDarkSideGameText": "While your unique (•) alien here, your Force generation is +1 here (+2 if Margo).",
+    "locationDarkSideGameText": "While your unique (â€¢) alien here, your Force generation is +1 here (+2 if Margo).",
     "locationLightSideGameText": "Force drain -1 here (if your smuggler here, Force drain +1 instead).",
     "deployCost": 0,
     "destiny": 0,
@@ -31864,7 +31912,7 @@
     ],
     "cardSubtype": "SITE",
     "locationDarkSideGameText": "Once per turn, may [download] a starfighter with 'Vader' in title here.",
-    "locationLightSideGameText": "Your docking bay transit to or from here requires +4 Force (+6 Force if Vader or Vaneé here).",
+    "locationLightSideGameText": "Your docking bay transit to or from here requires +4 Force (+6 Force if Vader or VaneÃ© here).",
     "deployCost": 0,
     "destiny": 0,
     "icons": [
@@ -32630,7 +32678,7 @@
       "EFFECT"
     ],
     "cardSubtype": "NORMAL",
-    "gameText": "Deploy on table. Your unique (•) Republic characters of ability < 4 and your [Trade Federation] starships are forfeit +2. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites only. Once per turn, may deploy an [Episode I] (or Coruscant) docking bay from Reserve Deck; reshuffle. While you occupy Naboo system with a [Trade Federation] starship, your Force generation is +1 there. [Immune to Alter.]",
+    "gameText": "Deploy on table. Your unique (â€¢) Republic characters of ability < 4 and your [Trade Federation] starships are forfeit +2. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites only. Once per turn, may deploy an [Episode I] (or Coruscant) docking bay from Reserve Deck; reshuffle. While you occupy Naboo system with a [Trade Federation] starship, your Force generation is +1 there. [Immune to Alter.]",
     "destiny": 4,
     "icons": [
       {
@@ -32856,7 +32904,7 @@
       "IMPERIAL"
     ],
     "lore": "ISB leader.",
-    "gameText": "During your deploy phase, a unique (•) Imperial of ability < 3 here may make a regular move. When deployed, may place a unique (•) ISB agent here in Used Pile to deploy (for free) a non-Tarkin ISB agent with a different title here from Used Pile; reshuffle.",
+    "gameText": "During your deploy phase, a unique (â€¢) Imperial of ability < 3 here may make a regular move. When deployed, may place a unique (â€¢) ISB agent here in Used Pile to deploy (for free) a non-Tarkin ISB agent with a different title here from Used Pile; reshuffle.",
     "deployCost": 3,
     "destiny": 2,
     "power": 3,
@@ -33563,7 +33611,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Jabba's influence is not easily ignored. Neither are his voracious and vile appetites. Even Jedi soon learn this lesson.",
-    "gameText": "Deploy on table. When deployed, may take the top card of Lost Pile into hand. During your move phase, may cancel Landing Claw. If Landing Claw was just lost, place it out of play. Elis Helrot and Nabrun Leids are unique (•) and are Lost Interrupts. [Immune to Alter.]",
+    "gameText": "Deploy on table. When deployed, may take the top card of Lost Pile into hand. During your move phase, may cancel Landing Claw. If Landing Claw was just lost, place it out of play. Elis Helrot and Nabrun Leids are unique (â€¢) and are Lost Interrupts. [Immune to Alter.]",
     "destiny": 4,
     "icons": [
       {
@@ -33978,7 +34026,7 @@
       "ALIEN"
     ],
     "lore": "Crolute scavenger and thief.",
-    "gameText": "Your battle destiny draws here are +¼ for each device, droid, starship, vehicle, or weapon card here. During battle with an opponent's droid, adds one destiny to total power. Once per game, may retrieve a device or character weapon.",
+    "gameText": "Your battle destiny draws here are +Â¼ for each device, droid, starship, vehicle, or weapon card here. During battle with an opponent's droid, adds one destiny to total power. Once per game, may retrieve a device or character weapon.",
     "deployCost": 2,
     "destiny": 4,
     "power": 2,
@@ -34596,7 +34644,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Customized transport of Lord Vader. Employs advanced sensor jamming gear. Modified with enhanced tactical displays constructed to the Dark Lord's specifications.",
-    "gameText": "Deploys -2 to Mustafar. May add 1 pilot and 3 passengers. Permanent pilot is •Jendon, who provides ability of 2. If Vader armed with a lightsaber weapon card at a battleground, Force drain +1 here.",
+    "gameText": "Deploys -2 to Mustafar. May add 1 pilot and 3 passengers. Permanent pilot is â€¢Jendon, who provides ability of 2. If Vader armed with a lightsaber weapon card at a battleground, Force drain +1 here.",
     "deployCost": 5,
     "destiny": 3,
     "power": 5,
@@ -35554,7 +35602,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Sandtroopers commanded by Governor Aryon do not enjoy their assignment. They find a means of venting their frustrations by harassing the local inhabitants.",
-    "gameText": "Deploy on table. During your control phase, if you occupy Tatooine system, opponent loses 1 Force for each Tatooine battleground site you occupy with a unique (•) trooper. While you have three troopers on Tatooine, immune to Alter and Endor Celebration.",
+    "gameText": "Deploy on table. During your control phase, if you occupy Tatooine system, opponent loses 1 Force for each Tatooine battleground site you occupy with a unique (â€¢) trooper. While you have three troopers on Tatooine, immune to Alter and Endor Celebration.",
     "destiny": 4,
     "icons": [
       {
@@ -35946,7 +35994,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Commissioned by a group of Gand venture capitalists headed by Zuckuss. Manufactured by Byblos Drive Yards. Uses repulsorlift technology developed for combat cloud cars.",
-    "gameText": "May 1 pilot. Permanent pilots are •Zuckuss, who provides ability of 4, and •4-LOM. Players may not add power destinies or draw more than one battle destiny here. Immune to attrition < 5.",
+    "gameText": "May 1 pilot. Permanent pilots are â€¢Zuckuss, who provides ability of 4, and â€¢4-LOM. Players may not add power destinies or draw more than one battle destiny here. Immune to attrition < 5.",
     "deployCost": 5,
     "destiny": 2,
     "power": 5,
@@ -36213,7 +36261,7 @@
       "STARSHIP"
     ],
     "cardSubtype": "STARFIGHTER",
-    "gameText": "May add 1 pilot and 3 passengers. Permanent pilot is •Kuruk, who provides ability of 3. Kylo and Knights of Ren deploy -1 to same and related locations. Immune to attrition < 4.",
+    "gameText": "May add 1 pilot and 3 passengers. Permanent pilot is â€¢Kuruk, who provides ability of 3. Kylo and Knights of Ren deploy -1 to same and related locations. Immune to attrition < 4.",
     "deployCost": 4,
     "destiny": 2,
     "power": 4,
@@ -36743,7 +36791,7 @@
       "ALIEN"
     ],
     "lore": "Notorious bounty hunter. 'As you wish.'",
-    "gameText": "[Pilot] 2. Permanent weapon is •Boba Fett's Blaster Rifle (may target a character for free; draw destiny; if destiny > defense value, target captured; otherwise, if destiny +2 > defense value, target hit, is forfeit -3, and opponent loses 1 Force; may not be retargeted).",
+    "gameText": "[Pilot] 2. Permanent weapon is â€¢Boba Fett's Blaster Rifle (may target a character for free; draw destiny; if destiny > defense value, target captured; otherwise, if destiny +2 > defense value, target hit, is forfeit -3, and opponent loses 1 Force; may not be retargeted).",
     "deployCost": 4,
     "destiny": 1,
     "power": 5,
@@ -37046,7 +37094,7 @@
     ],
     "cardSubtype": "CAPITAL",
     "lore": "",
-    "gameText": "May add 2 pilots, and 2 passengers. Permanent pilot is •Vanto, who provides ability of 3. Immune to attrition < 4 (< 6 while piloted by Thrawn or while a 'probed' or 'liberated' system on table).",
+    "gameText": "May add 2 pilots, and 2 passengers. Permanent pilot is â€¢Vanto, who provides ability of 3. Immune to attrition < 4 (< 6 while piloted by Thrawn or while a 'probed' or 'liberated' system on table).",
     "deployCost": 4,
     "destiny": 1,
     "power": 5,
@@ -37257,7 +37305,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Maul's Sith Infiltrator.",
-    "gameText": "May add 1 pilot. Permanent pilot is •Maul, who provides ability of 6. Once per battle, may lose 1 Force to 'cloak' (either add one destiny to total power or make this starship immune to attrition < 6).",
+    "gameText": "May add 1 pilot. Permanent pilot is â€¢Maul, who provides ability of 6. Once per battle, may lose 1 Force to 'cloak' (either add one destiny to total power or make this starship immune to attrition < 6).",
     "deployCost": 4,
     "destiny": 4,
     "power": 4,
@@ -37767,7 +37815,7 @@
       "ALIEN"
     ],
     "lore": "Gand bounty hunter and scout.",
-    "gameText": "[Pilot] 2. Once per game, may peek at top card of any Reserve Deck. Permanent weapon is •Zuckuss' Snare Rifle (may target a character for free; draw destiny; target excluded from battle if destiny +1 > target's power).",
+    "gameText": "[Pilot] 2. Once per game, may peek at top card of any Reserve Deck. Permanent weapon is â€¢Zuckuss' Snare Rifle (may target a character for free; draw destiny; target excluded from battle if destiny +1 > target's power).",
     "deployCost": 4,
     "destiny": 1,
     "power": 2,
@@ -38422,7 +38470,7 @@
       "FIRST_ORDER"
     ],
     "lore": "Knight of Ren.",
-    "gameText": "[Pilot] 2. While an [Episode VII] objective on table, draws one battle destiny if unable to otherwise. Permanent weapon is •Arm Cannon (may target a character for free; draw destiny; target hit, and its forfeit = 0, if destiny + 1 > defense value).",
+    "gameText": "[Pilot] 2. While an [Episode VII] objective on table, draws one battle destiny if unable to otherwise. Permanent weapon is â€¢Arm Cannon (may target a character for free; draw destiny; target hit, and its forfeit = 0, if destiny + 1 > defense value).",
     "deployCost": 4,
     "destiny": 2,
     "power": 4,
@@ -40036,7 +40084,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "'I'm sorry, too.'",
-    "gameText": "If your [Cloud City] objective on table, deploy on table. Elis Helrot, Stunning Leader, and Surreptitious Glance may not be played. Once per turn, may [download] an interior Cloud City site. Your unique (•) characters with printed forfeit < 5 are forfeit +2 (limit +2). [Immune to Alter.]",
+    "gameText": "If your [Cloud City] objective on table, deploy on table. Elis Helrot, Stunning Leader, and Surreptitious Glance may not be played. Once per turn, may [download] an interior Cloud City site. Your unique (â€¢) characters with printed forfeit < 5 are forfeit +2 (limit +2). [Immune to Alter.]",
     "destiny": 5,
     "icons": [
       {
@@ -41040,7 +41088,7 @@
     ],
     "cardSubtype": "IMMEDIATE",
     "lore": "Dianogas use their seven tentacles for both locomotion and catching food. The few survivors of such attacks claim that a dianoga tentacle has the strength of a hydro-clamp.",
-    "gameText": "If opponent just played an Interrupt, use 1 Force to deploy on table and stack that Interrupt here. All Interrupts of that title are unique (•). (Immune to Control.)",
+    "gameText": "If opponent just played an Interrupt, use 1 Force to deploy on table and stack that Interrupt here. All Interrupts of that title are unique (â€¢). (Immune to Control.)",
     "destiny": 5,
     "icons": [
       {
@@ -42896,7 +42944,7 @@
       "SITH"
     ],
     "lore": "Female Dathomirian assassin",
-    "gameText": "Power +1 with Dooku. Permanent weapon is •Asajj's Lightsabers (may target a character for free, or target two characters using 1 Force; draw two destiny; target(s) hit and forfeit -2 if total destiny > total defense value).",
+    "gameText": "Power +1 with Dooku. Permanent weapon is â€¢Asajj's Lightsabers (may target a character for free, or target two characters using 1 Force; draw two destiny; target(s) hit and forfeit -2 if total destiny > total defense value).",
     "deployCost": 5,
     "destiny": 1,
     "power": 4,
@@ -46516,7 +46564,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Like nerf herders herding nerfs, Imperial commanders often use TIE fighters to drive fleeing Rebel ships into tractor beam range.",
-    "gameText": "Deploy on one opponent's unique (•) starship at a location you do not occupy. When starship is targeted by any tractor beam or ion cannon, subtract 2 from maneuver. If starship is captured or lost, lose Effect and opponent must lose 3 Force (5 if Falcon).",
+    "gameText": "Deploy on one opponent's unique (â€¢) starship at a location you do not occupy. When starship is targeted by any tractor beam or ion cannon, subtract 2 from maneuver. If starship is captured or lost, lose Effect and opponent must lose 3 Force (5 if Falcon).",
     "destiny": 4,
     "icons": [
       {
@@ -49160,7 +49208,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Careless abuse of the Force by a young Jedi trainee can have dire consequences. When hanging from the weather vane of Cloud City, Luke's balance was his only hope.",
-    "gameText": "Deploy on table. If a unique (•) card is drawn for destiny and a duplicate is on table, destiny card is lost (destiny = 0). If duplicated card is a character, it loses immunity to attrition for rest of turn and player must lose 2 Force or lose that character. (Immune to Alter.)",
+    "gameText": "Deploy on table. If a unique (â€¢) card is drawn for destiny and a duplicate is on table, destiny card is lost (destiny = 0). If duplicated card is a character, it loses immunity to attrition for rest of turn and player must lose 2 Force or lose that character. (Immune to Alter.)",
     "destiny": 4,
     "icons": [
       {
@@ -52953,7 +53001,7 @@
       "ALIEN"
     ],
     "lore": "Male Jawa. Leader of a large tribe of Jawas. Plotting with Jabba to take control of a neighboring tribe's territory.",
-    "gameText": "Deploys only on Tatooine. Your Jawa Pack is not unique(•), is doubled, deploys free (or for 6 Force from each player) and cummulatively affects your Jawas' forfeit. While at Audience Chamber or Jawa Camp, all your other Jawas are power +2.",
+    "gameText": "Deploys only on Tatooine. Your Jawa Pack is not unique(â€¢), is doubled, deploys free (or for 6 Force from each player) and cummulatively affects your Jawas' forfeit. While at Audience Chamber or Jawa Camp, all your other Jawas are power +2.",
     "deployCost": 3,
     "destiny": 2,
     "power": 2,
@@ -55162,7 +55210,7 @@
       "IMPERIAL"
     ],
     "lore": "Death Star trooper who witnessed Leia's interrogation. Senior tactical advisor to Sergeant Major Enfield. Coordinates security duty assignments for Detention Block AA-23.",
-    "gameText": "While Grenwick is on Death Star, your Death Star Sentry is not unique (•), is doubled, deploys free, applies all three of its modifiers and is immune to Alter. Power -1 when not on Death Star.",
+    "gameText": "While Grenwick is on Death Star, your Death Star Sentry is not unique (â€¢), is doubled, deploys free, applies all three of its modifiers and is immune to Alter. Power -1 when not on Death Star.",
     "deployCost": 1,
     "destiny": 3,
     "power": 2,
@@ -57075,7 +57123,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Vader was nearly killed when Han damaged his TIE fighter during a surprise attack in the Death Star trench.",
-    "gameText": "Deploy on your side of table. During a battle, you may place out of play from hand a copy of any unique (•) card participating in that battle to reduce attrition against you by that card's forfeit value. (Immune to Alter while you occupy a battleground.)",
+    "gameText": "Deploy on your side of table. During a battle, you may place out of play from hand a copy of any unique (â€¢) card participating in that battle to reduce attrition against you by that card's forfeit value. (Immune to Alter while you occupy a battleground.)",
     "destiny": 2,
     "icons": [
       {
@@ -59346,7 +59394,7 @@
       "LOCATION"
     ],
     "cardSubtype": "SITE",
-    "locationDarkSideGameText": "May not deploy to Bespin, Dagobah, Endor, Hoth, Kashyyyk or Yavin 4. During your move phase, may move free between here and any related ◇ spaceport site.",
+    "locationDarkSideGameText": "May not deploy to Bespin, Dagobah, Endor, Hoth, Kashyyyk or Yavin 4. During your move phase, may move free between here and any related â—‡ spaceport site.",
     "locationLightSideGameText": "May not deploy to Bespin, Dagobah, Endor, Hoth, Kashyyyk or Yavin 4. Rebels are power -1 here.",
     "deployCost": 0,
     "destiny": 0,
@@ -59652,7 +59700,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "Deploy any planet system and one ◇ site to that system. This system is the Renegade planet. While this side up, once during each of your deploy phases, you may deploy one ◇ site to the Renegade planet from Reserve Deck; reshuffle. Flip this card if your matching operatives control at least three battleground sites related to the Renegade planet.",
+    "gameText": "Deploy any planet system and one â—‡ site to that system. This system is the Renegade planet. While this side up, once during each of your deploy phases, you may deploy one â—‡ site to the Renegade planet from Reserve Deck; reshuffle. Flip this card if your matching operatives control at least three battleground sites related to the Renegade planet.",
     "destiny": 0,
     "icons": [
       {
@@ -59808,7 +59856,7 @@
     ],
     "cardSubtype": "CAPITAL",
     "lore": "Bossk once said of his ship, 'Greeezeg uut nikek!'",
-    "gameText": "May add 6 passengers and 1 vehicle. Permanent pilot is •Bossk, who provides ability of 2, adds 2 to power and adds one battle destiny. Deploys and moves like a starfighter. Has ship-docking capability.",
+    "gameText": "May add 6 passengers and 1 vehicle. Permanent pilot is â€¢Bossk, who provides ability of 2, adds 2 to power and adds one battle destiny. Deploys and moves like a starfighter. Has ship-docking capability.",
     "deployCost": 8,
     "destiny": 1,
     "power": 5,
@@ -59925,7 +59973,7 @@
     ],
     "cardSubtype": "SQUADRON",
     "lore": "Notoriety gained during the assaults on Ralltiir and Mon Calamari makes this the most feared squadron in the Empire. Defended the Death Star during the Battle of Yavin.",
-    "gameText": "Permanent pilots aboard are •Darth Vader, •DS-61-2 and •DS-61-3, who provide total ability of 10 and add 9 to total power of •Vader's Custom TIE, •Black 2 and •Black 3.",
+    "gameText": "Permanent pilots aboard are â€¢Darth Vader, â€¢DS-61-2 and â€¢DS-61-3, who provide total ability of 10 and add 9 to total power of â€¢Vader's Custom TIE, â€¢Black 2 and â€¢Black 3.",
     "deployCost": 12,
     "destiny": 1,
     "power": 3,
@@ -60030,7 +60078,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Lead starfighter of Obsidian Squadron. Flown by Cive Rashon. Call sign 'Howlrunner.' She served in an elite TIE squadron aboard the Star Destroyer Avenger.",
-    "gameText": "Deploy -1 and power +3 at a cloud sector. Permanent pilot is •OS-72-1, who provides ability of 2, adds 2 to power and, at a cloud sector, may draw one battle destiny if not able to otherwise.",
+    "gameText": "Deploy -1 and power +3 at a cloud sector. Permanent pilot is â€¢OS-72-1, who provides ability of 2, adds 2 to power and, at a cloud sector, may draw one battle destiny if not able to otherwise.",
     "deployCost": 5,
     "destiny": 2,
     "power": 2,
@@ -60073,7 +60121,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Piloted by Dodson Makraven, wingman of Cive Rashon. Experienced TIE pilot with many kills in atmospheric combat. Nicknamed 'Night Beast' for his many curfew violations.",
-    "gameText": "Deploy -1 and power +3 at a cloud sector. Permanent pilot is •OS-72-2, who provides ability of 2, adds 2 to power and, at a cloud sector, may draw one battle destiny if not able to otherwise.",
+    "gameText": "Deploy -1 and power +3 at a cloud sector. Permanent pilot is â€¢OS-72-2, who provides ability of 2, adds 2 to power and, at a cloud sector, may draw one battle destiny if not able to otherwise.",
     "deployCost": 4,
     "destiny": 3,
     "power": 1,
@@ -61727,7 +61775,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "When an Imperial blockade raises the alert level, all independent ships are scanned and any suspicious characters on planet are detained and interrogated.",
-    "gameText": "Deploy on table. Unique (•) Imperials of ability < 3 are forfeit +2. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites. Once during each of your deploy phases, may deploy one docking bay from Reserve Deck; reshuffle. (Immune to Alter.)",
+    "gameText": "Deploy on table. Unique (â€¢) Imperials of ability < 3 are forfeit +2. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites. Once during each of your deploy phases, may deploy one docking bay from Reserve Deck; reshuffle. (Immune to Alter.)",
     "destiny": 5,
     "icons": [
       {
@@ -62022,7 +62070,7 @@
     ],
     "cardSubtype": "USED_OR_STARTING",
     "lore": "Imperial troops prepared for quick deployment to seize valuable terrain.",
-    "gameText": "USED: If a battle was just initiated, draw destiny and activate up to that much Force. STARTING: If you have not deployed an Objective, deploy from Reserve Deck one battleground site (or two ◇ sites) related to your starting location. Place Interrupt in Reserve Deck.",
+    "gameText": "USED: If a battle was just initiated, draw destiny and activate up to that much Force. STARTING: If you have not deployed an Objective, deploy from Reserve Deck one battleground site (or two â—‡ sites) related to your starting location. Place Interrupt in Reserve Deck.",
     "destiny": 5,
     "icons": [
       {
@@ -62442,7 +62490,7 @@
     ],
     "cardSubtype": "USED_OR_LOST",
     "lore": "Imperial training allows scouts to use speed and stealth to their advantage. On Endor, they were also backed up by Commander Igar's ATSTs.",
-    "gameText": "USED: If all of your ability in a battle is provided by scouts and/or spies, they each add 1 to your total battle destiny (limit +6). LOST: For remainder of turn, your unique (•) scouts and unique (•) spies are each power +1 (or +2 while being attacked by a creature).",
+    "gameText": "USED: If all of your ability in a battle is provided by scouts and/or spies, they each add 1 to your total battle destiny (limit +6). LOST: For remainder of turn, your unique (â€¢) scouts and unique (â€¢) spies are each power +1 (or +2 while being attacked by a creature).",
     "destiny": 4,
     "icons": [
       {
@@ -64320,7 +64368,7 @@
       "IMPERIAL"
     ],
     "lore": "Wingman of Major Phennir. Earned promotion to Fel's squadron by scoring 12 kills at Mon Calamari. Repeatedly refused further promotion so that he could remain in the 181st.",
-    "gameText": "Adds 3 to power of any TIE he pilots. Once during each of your deploy phases, you may take one unique (•) TIE Interceptor into hand from Reserve Deck; reshuffle.",
+    "gameText": "Adds 3 to power of any TIE he pilots. Once during each of your deploy phases, you may take one unique (â€¢) TIE Interceptor into hand from Reserve Deck; reshuffle.",
     "deployCost": 2,
     "destiny": 4,
     "power": 2,
@@ -67208,7 +67256,7 @@
     "cardTypes": [
       "ADMIRALS_ORDER"
     ],
-    "gameText": "Unique (•) starfighters without permanent pilots are immune to attrition < 4 (or add 2 to immunity if starfighter already has immunity). Starships without pilot characters aboard are power -2. At docking bays related to systems you occupy, your Force drains are +1. Once per turn, your starfighter just lost from a system may be relocated to a related docking bay.",
+    "gameText": "Unique (â€¢) starfighters without permanent pilots are immune to attrition < 4 (or add 2 to immunity if starfighter already has immunity). Starships without pilot characters aboard are power -2. At docking bays related to systems you occupy, your Force drains are +1. Once per turn, your starfighter just lost from a system may be relocated to a related docking bay.",
     "deployCost": 0,
     "destiny": 6,
     "icons": [

--- a/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_dark.json
+++ b/src/gemp-swccg-cards/src/main/resources/card_blueprint_database_dark.json
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "cardId": "101_4",
     "title": "Death Star: Docking Control Room 327",
@@ -50,7 +50,7 @@
       "IMPERIAL"
     ],
     "lore": "Sought to extinguish all Jedi. Former student of Obi-Wan Kenobi. Seduced by the dark side of the Force.",
-    "gameText": "Must deploy on Death Star, but may move elsewhere. May not be deployed if two or more of opponent's unique (â€¢) characters on table. If in a losing battle, draw destiny. If destiny > 4, 'choke' (lose) one Imperial present (your choice).",
+    "gameText": "Must deploy on Death Star, but may move elsewhere. May not be deployed if two or more of opponent's unique (•) characters on table. If in a losing battle, draw destiny. If destiny > 4, 'choke' (lose) one Imperial present (your choice).",
     "deployCost": 7,
     "destiny": 1,
     "power": 4,
@@ -385,7 +385,7 @@
       "IMPERIAL"
     ],
     "lore": "General of the AT-AT assault armor division sent by Darth Vader to crush the Rebellion on Hoth. Cold and ruthless.",
-    "gameText": "Must deploy on Hoth, but may move elsewhere. May not be deployed if three or more of opponent's unique (â€¢) characters on table. Snowtroopers at same site are forfeit +1.",
+    "gameText": "Must deploy on Hoth, but may move elsewhere. May not be deployed if three or more of opponent's unique (•) characters on table. Snowtroopers at same site are forfeit +1.",
     "deployCost": 4,
     "destiny": 1,
     "power": 2,
@@ -505,7 +505,7 @@
     ],
     "cardSubtype": "SQUADRON",
     "lore": "Notoriety gained during the assaults on Ralltiir and Mon Calamari makes this the most feared squadron in the Empire. Defended the Death Star during the Battle of Yavin.",
-    "gameText": "Permanent pilots aboard are â€¢Darth Vader, â€¢DS-61-2 and â€¢DS-61-3, who provide total ability of 10 and add 9 to total power of â€¢Vader's Custom TIE, â€¢Black 2 and â€¢Black 3.",
+    "gameText": "Permanent pilots aboard are •Darth Vader, •DS-61-2 and •DS-61-3, who provide total ability of 10 and add 9 to total power of •Vader's Custom TIE, •Black 2 and •Black 3.",
     "deployCost": 12,
     "destiny": 1,
     "power": 3,
@@ -1060,7 +1060,7 @@
       "ALIEN"
     ],
     "lore": "Notorious bounty hunter. 'As you wish.'",
-    "gameText": "Adds 3 to power of anything he pilots. Adds one battle destiny if with Han or Jabba. Permanent weapon is â€¢Boba Fett's Blaster Rifle (may target a character or creature for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value).",
+    "gameText": "Adds 3 to power of anything he pilots. Adds one battle destiny if with Han or Jabba. Permanent weapon is •Boba Fett's Blaster Rifle (may target a character or creature for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value).",
     "deployCost": 5,
     "destiny": 1,
     "power": 4,
@@ -1112,7 +1112,7 @@
       "IMPERIAL"
     ],
     "lore": "'If you only knew the power of the dark side.'",
-    "gameText": "Adds 3 to power of anything he pilots. Permanent weapon is â€¢Vader's Lightsaber (may target a character or creature for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
+    "gameText": "Adds 3 to power of anything he pilots. Permanent weapon is •Vader's Lightsaber (may target a character or creature for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
     "deployCost": 6,
     "destiny": 1,
     "power": 6,
@@ -1161,7 +1161,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Corellian starfighter. Dengar replaced its passenger capacity and TIE cannons with enhanced targeting systems. Allows Dengar to track and engage multiple enemies at once.",
-    "gameText": "Permanent pilot is â€¢Dengar, who provides ability of 2 and adds 2 to power. When in battle, adds 1 to total battle destiny for each opponent's starship present. Cancels opponent's immunity to attrition here.",
+    "gameText": "Permanent pilot is •Dengar, who provides ability of 2 and adds 2 to power. When in battle, adds 1 to total battle destiny for each opponent's starship present. Cancels opponent's immunity to attrition here.",
     "deployCost": 5,
     "destiny": 1,
     "power": 2,
@@ -1317,7 +1317,7 @@
       "DROID"
     ],
     "lore": "Accomplished thief and information broker. Modified by Jabba to be an effective bounty hunter. The Hutt often teams 4-LOM with other hired killers.",
-    "gameText": "Adds one battle destiny if with Jabba or Zuckuss. Permanent weapon is â€¢4-LOM's Concussion Rifle (may target a character for free; target may not use its game text for remainder of turn).",
+    "gameText": "Adds one battle destiny if with Jabba or Zuckuss. Permanent weapon is •4-LOM's Concussion Rifle (may target a character for free; target may not use its game text for remainder of turn).",
     "deployCost": 3,
     "destiny": 3,
     "power": 2,
@@ -1399,7 +1399,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Dangerous and deadly starfighter piloted by its notorious owner. Uses combat-grade shields and sensors. Hidden weapons provide lethal surprises for Fett's victims.",
-    "gameText": "May add 3 passengers. Permanent pilot is â€¢Boba Fett, who provides ability of 3, adds 3 to power, adds 2 to maneuver and draws one battle destiny if not able to otherwise. Immune to attrition < 5.",
+    "gameText": "May add 3 passengers. Permanent pilot is •Boba Fett, who provides ability of 3, adds 3 to power, adds 2 to maneuver and draws one battle destiny if not able to otherwise. Immune to attrition < 5.",
     "deployCost": 7,
     "destiny": 1,
     "power": 4,
@@ -2592,7 +2592,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Zuckuss is a dangerous adversary, especially when aboard his own starship. Mystical omens enable the Gand to predict enemy maneuvers in starship combat.",
-    "gameText": "May add 1 pilot and 3 passengers. Permanent pilot is â€¢Zuckuss, who provides ability of 4 and adds 2 to power. Unless opponent has total ability > 6 piloting here, opponent's total battle destiny here = zero.",
+    "gameText": "May add 1 pilot and 3 passengers. Permanent pilot is •Zuckuss, who provides ability of 4 and adds 2 to power. Unless opponent has total ability > 6 piloting here, opponent's total battle destiny here = zero.",
     "deployCost": 6,
     "destiny": 1,
     "power": 2,
@@ -2648,7 +2648,7 @@
       "ALIEN"
     ],
     "lore": "Trandoshan bounty hunter. Modified his mortar gun to fire stun cartridges for live captures. Uses non-fragmentary capture rounds to minimize collateral damage.",
-    "gameText": "Adds 2 to power of anything he pilots. Permanent weapon is â€¢Bossk's Mortar Gun (may fire for free; draw destiny; may subtract or add 1 if at same site as a bounty; choose one character with that destiny number present to be captured.)",
+    "gameText": "Adds 2 to power of anything he pilots. Permanent weapon is •Bossk's Mortar Gun (may fire for free; draw destiny; may subtract or add 1 if at same site as a bounty; choose one character with that destiny number present to be captured.)",
     "deployCost": 5,
     "destiny": 1,
     "power": 4,
@@ -2751,7 +2751,7 @@
       "ALIEN"
     ],
     "lore": "Corellian bounty hunter. Skilled athlete. Expert shot. Has worked many times for Jabba the Hutt. Carries a long-standing grudge against Han Solo.",
-    "gameText": "Adds 2 to the power of anything he pilots. Permanent weapon is â€¢Dengar's Blaster Carbine (may target a character, creature or vehicle for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value; may be fired twice per battle).",
+    "gameText": "Adds 2 to the power of anything he pilots. Permanent weapon is •Dengar's Blaster Carbine (may target a character, creature or vehicle for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value; may be fired twice per battle).",
     "deployCost": 5,
     "destiny": 2,
     "power": 3,
@@ -2804,7 +2804,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Starship adapted to the assassin droid's specifications. Flight controls linked directly to processing unit. Real-time relays minimize response time.",
-    "gameText": "May add 2 passengers. Permanent pilot is â€¢IG-88, who adds 2 to power and 3 to maneuver. May initiate battle. When in a battle you initiate, adds one battle destiny. Ion Cannon may deploy aboard.",
+    "gameText": "May add 2 passengers. Permanent pilot is •IG-88, who adds 2 to power and 3 to maneuver. May initiate battle. When in a battle you initiate, adds one battle destiny. Ion Cannon may deploy aboard.",
     "deployCost": 5,
     "destiny": 1,
     "power": 3,
@@ -3108,7 +3108,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "Deploy Desert Heart and a Jabba's Palace site. May deploy Well Guarded. Reveal one unique (â€¢) alien from your deck whose lore specifies its species. This card is your Rep. For remainder of game, your Rep is a leader. Well Guarded is immune to Alter. You may not deploy 'insert' cards or operatives. While frozen Han on table, Rebels are immune to No Bargain and Bad Feeling Have I. Flip this card if you occupy two battleground sites (must occupy a third with a non-unique alien of your Rep's species if a non-Tatooine location is on table).",
+    "gameText": "Deploy Desert Heart and a Jabba's Palace site. May deploy Well Guarded. Reveal one unique (•) alien from your deck whose lore specifies its species. This card is your Rep. For remainder of game, your Rep is a leader. Well Guarded is immune to Alter. You may not deploy 'insert' cards or operatives. While frozen Han on table, Rebels are immune to No Bargain and Bad Feeling Have I. Flip this card if you occupy two battleground sites (must occupy a third with a non-unique alien of your Rep's species if a non-Tatooine location is on table).",
     "destiny": 0,
     "icons": [
       {
@@ -3162,7 +3162,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Jabba's influence is not easily ignored. Neither are his voracious and vile appetites. Even Jedi soon learn this lesson.",
-    "gameText": "Deploy on table. You may immediately take top card of Lost Pile into hand. Effects, Epic Events, and Objectives are immune to Honor Of The Jedi. At each opponent's â—‡ site, your characters and vehicles are each deploy -3 and your Force generation is +1. (Immune to Alter.)",
+    "gameText": "Deploy on table. You may immediately take top card of Lost Pile into hand. Effects, Epic Events, and Objectives are immune to Honor Of The Jedi. At each opponent's ◇ site, your characters and vehicles are each deploy -3 and your Force generation is +1. (Immune to Alter.)",
     "destiny": 4,
     "icons": [
       {
@@ -4053,7 +4053,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Tarkin silenced the voices of Alderaan with the power of the Death Star.",
-    "gameText": "Deploy on table. Twice per game may take Commence Primary Ignition into hand from Lost Pile or Reserve Deck; reshuffle. If Alderaan 'blown away,' retrieve 3 Force whenever you deploy a unique (â€¢) Star Destroyer. (Immune to Alter.)",
+    "gameText": "Deploy on table. Twice per game may take Commence Primary Ignition into hand from Lost Pile or Reserve Deck; reshuffle. If Alderaan 'blown away,' retrieve 3 Force whenever you deploy a unique (•) Star Destroyer. (Immune to Alter.)",
     "destiny": 5,
     "icons": [
       {
@@ -6322,7 +6322,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Once begun, the occupation of Naboo was swift, and devastatingly effective.",
-    "gameText": "Deploy on table. Your unique (â€¢) Republicans are forfeit +2 and immune to Goo Nee Tay. Unless Imperial Arrest Order on table, once during your deploy phase, may deploy one docking bay from Reserve Deck; reshuffle. (Immune to Alter.)",
+    "gameText": "Deploy on table. Your unique (•) Republicans are forfeit +2 and immune to Goo Nee Tay. Unless Imperial Arrest Order on table, once during your deploy phase, may deploy one docking bay from Reserve Deck; reshuffle. (Immune to Alter.)",
     "destiny": 4,
     "icons": [
       {
@@ -6354,7 +6354,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Imperial officers are always on the lookout for Rebel espionage.",
-    "gameText": "Deploy on table. Unique (â€¢) Imperials of ability = 3 are forfeit +3. If opponent just retrieved Force using an Interrupt or Utinni Effect, you may place that card here. Opponent's Force retrieval is reduced by X, where X = number of cards here. (Immune to Alter.)",
+    "gameText": "Deploy on table. Unique (•) Imperials of ability = 3 are forfeit +3. If opponent just retrieved Force using an Interrupt or Utinni Effect, you may place that card here. Opponent's Force retrieval is reduced by X, where X = number of cards here. (Immune to Alter.)",
     "destiny": 5,
     "icons": [
       {
@@ -6484,7 +6484,7 @@
       "EFFECT"
     ],
     "cardSubtype": "NORMAL",
-    "gameText": "Deploy on table. Unique (â€¢) Imperials of ability < 3 are forfeit +1. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites only. Once during each of your deploy phases, may deploy one docking bay from Reserve Deck; reshuffle. When opponent retrieves X cards, opponent must first use X Force or that retrieval is canceled. (Immune to Alter.)",
+    "gameText": "Deploy on table. Unique (•) Imperials of ability < 3 are forfeit +1. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites only. Once during each of your deploy phases, may deploy one docking bay from Reserve Deck; reshuffle. When opponent retrieves X cards, opponent must first use X Force or that retrieval is canceled. (Immune to Alter.)",
     "destiny": 5,
     "icons": [
       {
@@ -7084,7 +7084,7 @@
     ],
     "cardSubtype": "USED_OR_STARTING",
     "lore": "'We must move quickly to disrupt all communication down there.'",
-    "gameText": "USED: Use 2 Force to deploy a unique (â€¢) battleground not on table, from Reserve Deck; reshuffle. STARTING: Deploy from your Reserve Deck one Effect which deploys on table (or your side of table) and has no deploy cost; reshuffle. Place Interrupt in Lost Pile.",
+    "gameText": "USED: Use 2 Force to deploy a unique (•) battleground not on table, from Reserve Deck; reshuffle. STARTING: Deploy from your Reserve Deck one Effect which deploys on table (or your side of table) and has no deploy cost; reshuffle. Place Interrupt in Lost Pile.",
     "destiny": 5,
     "icons": [
       {
@@ -7211,7 +7211,7 @@
       "INTERRUPT"
     ],
     "cardSubtype": "USED_OR_LOST",
-    "gameText": "USED: Take one unique (â€¢) unpiloted starfighter into hand from Reserve Deck; reshuffle. LOST: During a battle at a system or sector, if you are about to draw a card for battle destiny, you may instead use the maneuver number of your unique (â€¢) starfighter in that battle.",
+    "gameText": "USED: Take one unique (•) unpiloted starfighter into hand from Reserve Deck; reshuffle. LOST: During a battle at a system or sector, if you are about to draw a card for battle destiny, you may instead use the maneuver number of your unique (•) starfighter in that battle.",
     "destiny": 5,
     "icons": [
       {
@@ -9753,7 +9753,7 @@
       "DEFENSIVE_SHIELD"
     ],
     "lore": "Jabba's influence is not easily ignored. Neither are his voracious and vile appetites. Even Jedi soon learn this lesson.",
-    "gameText": "Plays on table. At opponent's â—‡ site where opponent's creature present, you may deploy without presence or Force icons, and your Force generation there is +1.",
+    "gameText": "Plays on table. At opponent's ◇ site where opponent's creature present, you may deploy without presence or Force icons, and your Force generation there is +1.",
     "deployCost": 0,
     "destiny": 0,
     "icons": [
@@ -11844,7 +11844,7 @@
       "BATTLE"
     ]
   },
-      {
+    {
     "cardId": "14_71",
     "title": "3B3-21",
     "slug": "3b3-21",
@@ -12138,7 +12138,7 @@
       "SITH"
     ],
     "lore": "'Yes, my Master.'",
-    "gameText": "Permanent weapon is â€¢Maul's Double-Bladed Lightsaber (twice per battle, may target a character for free; draw two destiny; target 'hit,' and its forfeit = 0, if total destiny > defense value).",
+    "gameText": "Permanent weapon is •Maul's Double-Bladed Lightsaber (twice per battle, may target a character for free; draw two destiny; target 'hit,' and its forfeit = 0, if total destiny > defense value).",
     "deployCost": 7,
     "destiny": 1,
     "power": 7,
@@ -13991,7 +13991,7 @@
       "ALIEN"
     ],
     "lore": "Female H'nemthe, a species whose females ritually kill their mates. Stranded on Tatooine due to questionable passage tax. Razor-sharp tongue. M'iiyoom means, 'nightlilly'.",
-    "gameText": "Once during each of your control phases, may reveal opponent's hand by using X Force, where X = number of cards in opponent's hand. All unique (â€¢) male Rebels and unique (â€¢) male aliens there are lost.",
+    "gameText": "Once during each of your control phases, may reveal opponent's hand by using X Force, where X = number of cards in opponent's hand. All unique (•) male Rebels and unique (•) male aliens there are lost.",
     "deployCost": 3,
     "destiny": 3,
     "power": 1,
@@ -17913,7 +17913,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Aratech Corporation sent support staff to various Imperial outposts and garrisons. Gave advanced briefings and training to biker scout personnel.",
-    "gameText": "Deploy on table. AT-STs and speeder bikes are power and forfeit +1. During your deploy phase, may reveal an AT-ST or Speeder Bike from hand to [upload] a unique (â€¢) [Endor] Imperial pilot of ability < 3 (or vice versa) and deploy both simultaneously. (Immune to Alter.)",
+    "gameText": "Deploy on table. AT-STs and speeder bikes are power and forfeit +1. During your deploy phase, may reveal an AT-ST or Speeder Bike from hand to [upload] a unique (•) [Endor] Imperial pilot of ability < 3 (or vice versa) and deploy both simultaneously. (Immune to Alter.)",
     "destiny": 4,
     "icons": [
       {
@@ -17975,7 +17975,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Being stationed at Endor during the construction of the second Death Star allows Imperial pilots time to train in the latest starfighter combat techniques.",
-    "gameText": "Deploy on table. Tallon Roll is canceled. Once per turn, may reveal an unpiloted starfighter from hand to [upload] its matching pilot character (or vice versa) and deploy both simultaneously. Your unique (â€¢) TIEs (except Scythe Squadron TIEs) at systems may use 1 Force to relocate (as a regular move) to system within 3 parsecs. [Immune to Alter]",
+    "gameText": "Deploy on table. Tallon Roll is canceled. Once per turn, may reveal an unpiloted starfighter from hand to [upload] its matching pilot character (or vice versa) and deploy both simultaneously. Your unique (•) TIEs (except Scythe Squadron TIEs) at systems may use 1 Force to relocate (as a regular move) to system within 3 parsecs. [Immune to Alter]",
     "destiny": 5,
     "icons": [
       {
@@ -18179,7 +18179,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Company that produces current generation of Star Destroyers, as well as Nebulon-B Frigates. Ship yards are extremely well defended.",
-    "gameText": "Deploy on table. Unique (â€¢) Imperial-class Star Destroyers draw one battle destiny if unable to otherwise and are immune to attrition < 4. During your deploy phase, may use 2 Force to [download] a battleground system. We're In Attack Position Now is canceled. Immune to Alter.",
+    "gameText": "Deploy on table. Unique (•) Imperial-class Star Destroyers draw one battle destiny if unable to otherwise and are immune to attrition < 4. During your deploy phase, may use 2 Force to [download] a battleground system. We're In Attack Position Now is canceled. Immune to Alter.",
     "destiny": 3,
     "icons": [
       {
@@ -18864,7 +18864,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Dangerous and deadly starfighter piloted by its notorious owner. Uses combat-grade shields and sensors. Hidden weapons provide lethal surprises for Fett's victims.",
-    "gameText": "Permanent pilot is â€¢Boba Fett, who provides ability of 3. Draws one battle destiny if unable to otherwise. Slave I's power may not be reduced by opponent. Immune to Eject! Eject! and attrition < 5.",
+    "gameText": "Permanent pilot is •Boba Fett, who provides ability of 3. Draws one battle destiny if unable to otherwise. Slave I's power may not be reduced by opponent. Immune to Eject! Eject! and attrition < 5.",
     "deployCost": 6,
     "destiny": 1,
     "power": 7,
@@ -18924,7 +18924,7 @@
     ],
     "cardSubtype": "CAPITAL",
     "lore": "Bossk once said of his ship, 'Greeezeg uut nikek!'",
-    "gameText": "Permanent pilot is â€¢Bossk, who provides ability of 2. During battle with opponent's [Independent] starship (or Falcon), may add one destiny to total power or attrition. Immune to attrition < 4.",
+    "gameText": "Permanent pilot is •Bossk, who provides ability of 2. During battle with opponent's [Independent] starship (or Falcon), may add one destiny to total power or attrition. Immune to attrition < 4.",
     "deployCost": 4,
     "destiny": 1,
     "power": 6,
@@ -18987,7 +18987,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Designed to emulate Rebel starfighter advantages. Production began shortly before the Battle of Endor. Armed with laser cannons, ion cannons and missile launchers.",
-    "gameText": "May deploy as a 'react'. Permanent pilot is â€¢Jendon, who provides ability of 2. When deployed, may [download] a weapon on Onyx 1. Adds one battle destiny if with Onyx 2. Immune to attrition < 4.",
+    "gameText": "May deploy as a 'react'. Permanent pilot is •Jendon, who provides ability of 2. When deployed, may [download] a weapon on Onyx 1. Adds one battle destiny if with Onyx 2. Immune to attrition < 4.",
     "deployCost": 4,
     "destiny": 2,
     "power": 5,
@@ -19099,7 +19099,7 @@
       "STARSHIP"
     ],
     "cardSubtype": "STARFIGHTER",
-    "gameText": "May add 1 pilot and 3 passengers. Permanent pilot is â€¢Elis, who provides ability of 2. Once per game, may use 1 Force to [download] a smuggler aboard. Immune to attrition < 5.",
+    "gameText": "May add 1 pilot and 3 passengers. Permanent pilot is •Elis, who provides ability of 2. Once per game, may use 1 Force to [download] a smuggler aboard. Immune to attrition < 5.",
     "deployCost": 4,
     "destiny": 2,
     "power": 4,
@@ -19596,7 +19596,7 @@
       "DROID"
     ],
     "lore": "Accomplished thief and information broker. Modified by Jabba to be an effective bounty hunter. The Hutt often teams 4-LOM with other hired killers.",
-    "gameText": "Permanent weapon is â€¢4-LOM's Concussion Rifle (may target a character for free; target is power -1 until end of turn). Once per turn, may place a card from hand on bottom of Used Pile to draw top card from Reserve Deck.",
+    "gameText": "Permanent weapon is •4-LOM's Concussion Rifle (may target a character for free; target is power -1 until end of turn). Once per turn, may place a card from hand on bottom of Used Pile to draw top card from Reserve Deck.",
     "deployCost": 3,
     "destiny": 3,
     "power": 2,
@@ -19698,7 +19698,7 @@
       "IMPERIAL"
     ],
     "lore": "Senior Navy Commander of Death Star. Believes in technology. Ridiculed the Force. Ambitious leader. Promoted due to support of New Order, not military skills. Hates Vader.",
-    "gameText": "[Pilot] 2. Chiraneau may not modify your Force drains. Kuat Drive Yards is immune to Alter. Unless your Senate on table, unique (â€¢) Star Destroyers are power +2 and immunity to attrition +1. Once per game, may [download] non-[Set 0] Kuat Drive Yards.",
+    "gameText": "[Pilot] 2. Chiraneau may not modify your Force drains. Kuat Drive Yards is immune to Alter. Unless your Senate on table, unique (•) Star Destroyers are power +2 and immunity to attrition +1. Once per game, may [download] non-[Set 0] Kuat Drive Yards.",
     "deployCost": 3,
     "destiny": 1,
     "power": 3,
@@ -20000,7 +20000,7 @@
       "ALIEN"
     ],
     "lore": "Corellian bounty hunter. Skilled athlete. Expert shot. Has worked many times for Jabba the Hutt. Carries a long-standing grudge against Han Solo.",
-    "gameText": "While opponent's [Reflection II icon] objective on table, adds one battle destiny. Permanent weapon is â€¢Dengar's Blaster Carbine (may target a character, creature or vehicle for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value; may be fired twice per battle).",
+    "gameText": "While opponent's [Reflection II icon] objective on table, adds one battle destiny. Permanent weapon is •Dengar's Blaster Carbine (may target a character, creature or vehicle for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value; may be fired twice per battle).",
     "deployCost": 4,
     "destiny": 2,
     "power": 3,
@@ -20369,7 +20369,7 @@
       "ALIEN"
     ],
     "lore": "Ordered to kill Luke Skywalker. Assumed the identity of a dancer named 'Arica' in order to sneak into Jabba's Palace.",
-    "gameText": "With Luke or Emperor on table, power +1 and she moves for free. Permanent weapon is â€¢Mara Jade's Lightsaber (may target a character or creature for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
+    "gameText": "With Luke or Emperor on table, power +1 and she moves for free. Permanent weapon is •Mara Jade's Lightsaber (may target a character or creature for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
     "deployCost": 5,
     "destiny": 1,
     "power": 4,
@@ -22156,7 +22156,7 @@
       "ALIEN"
     ],
     "lore": "Gamorrean in charge of the Gamorreans at Jabba's palace. Posted to stand guard at the entrance cavern. Assigned by Jabba to keep an eye on Tessek.",
-    "gameText": "Permanent weapon is â€¢Ortugg's Ax (may target a character or creature for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value). While Ortugg is your Rep, your non-unique Gamorreans are deploy -1 and forfeit +3.",
+    "gameText": "Permanent weapon is •Ortugg's Ax (may target a character or creature for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value). While Ortugg is your Rep, your non-unique Gamorreans are deploy -1 and forfeit +3.",
     "deployCost": 3,
     "destiny": 3,
     "power": 4,
@@ -23874,7 +23874,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "TIE bomber repaired after being struck by an asteroid in the Anoat system. Stationed aboard second Death Star battle station.",
-    "gameText": "Permanent pilot is â€¢Jonus, who provides ability of 2. This starship's missile weapon destiny draws are +1. If at a system you control, your total power at related sites is +1.",
+    "gameText": "Permanent pilot is •Jonus, who provides ability of 2. This starship's missile weapon destiny draws are +1. If at a system you control, your total power at related sites is +1.",
     "deployCost": 2,
     "destiny": 2,
     "power": 4,
@@ -24971,7 +24971,7 @@
       "SITH"
     ],
     "lore": "Trade Federation.",
-    "gameText": "Permanent weapon is â€¢Maul's Lightsaber (may add 1 to Force drain where present; adds 1 to your battle destiny draws here; may target a character for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
+    "gameText": "Permanent weapon is •Maul's Lightsaber (may add 1 to Force drain where present; adds 1 to your battle destiny draws here; may target a character for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
     "deployCost": 6,
     "destiny": 1,
     "power": 7,
@@ -25403,7 +25403,7 @@
     ],
     "cardSubtype": "USED_OR_LOST",
     "lore": "Oouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioouioo-",
-    "gameText": "USED: [Upload] Downtown Plaza or a prison. LOST: [Upload] one unique (â€¢) bounty. OR Target an alien. For remainder of turn, target is power and forfeit -1 (-3 if Chewie).",
+    "gameText": "USED: [Upload] Downtown Plaza or a prison. LOST: [Upload] one unique (•) bounty. OR Target an alien. For remainder of turn, target is power and forfeit -1 (-3 if Chewie).",
     "destiny": 4,
     "icons": [
       {
@@ -25911,7 +25911,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "Deploy Tuanul Village, any other [Episode VII] location, and I Will Finish What You Started. Opponent may reveal a unique (â€¢) character with ability (except Luke or a Jedi) from Reserve Deck; that card is a Resistance Agent. Otherwise, Luke is a Resistance Agent and loses immunity to attrition. For remainder of game, non-[Episode VII] Dark Jedi are lost and Resistance Agents are immune to Set For Stun. Flip this card if your First Order characters control two battlegrounds and a Resistance Agent is not present at a battleground site.",
+    "gameText": "Deploy Tuanul Village, any other [Episode VII] location, and I Will Finish What You Started. Opponent may reveal a unique (•) character with ability (except Luke or a Jedi) from Reserve Deck; that card is a Resistance Agent. Otherwise, Luke is a Resistance Agent and loses immunity to attrition. For remainder of game, non-[Episode VII] Dark Jedi are lost and Resistance Agents are immune to Set For Stun. Flip this card if your First Order characters control two battlegrounds and a Resistance Agent is not present at a battleground site.",
     "destiny": 0,
     "icons": [
       {
@@ -25972,7 +25972,7 @@
       "STARSHIP"
     ],
     "cardSubtype": "STARFIGHTER",
-    "gameText": "May add 1 pilot and 2 passengers. Permanent pilot is â€¢Mara Jade, who provides ability of 5. While alone and piloted by an Imperial, adds one battle destiny. Immune to attrition < 4.",
+    "gameText": "May add 1 pilot and 2 passengers. Permanent pilot is •Mara Jade, who provides ability of 5. While alone and piloted by an Imperial, adds one battle destiny. Immune to attrition < 4.",
     "deployCost": 5,
     "destiny": 2,
     "power": 5,
@@ -26246,7 +26246,7 @@
       "FIRST_ORDER"
     ],
     "lore": "Leader.",
-    "gameText": "[Pilot] 2. Permanent weapon is â€¢Kylo's Lightsaber (may target a character for free; draw two destiny; target hit, its forfeit = 0, and opponent loses 1 Force, if total destiny > defense value; otherwise you lose 1 Force).",
+    "gameText": "[Pilot] 2. Permanent weapon is •Kylo's Lightsaber (may target a character for free; draw two destiny; target hit, its forfeit = 0, and opponent loses 1 Force, if total destiny > defense value; otherwise you lose 1 Force).",
     "deployCost": 5,
     "destiny": 1,
     "power": 6,
@@ -26551,7 +26551,7 @@
     "cardTypes": [
       "EPIC_EVENT"
     ],
-    "gameText": "Once per game, deploy on Death Star; it is hyperspeed = 2. Superlaser may not target planet systems. Once during your control phase, may fire Superlaser as follows: Prepare Single Reactor Ignition: If Death Star orbiting Jedha or Scarif, target your related unique (â€¢) battleground site, even if converted (regardless of objective restrictions). Fire!: Draw destiny. It's Beautiful: If destiny +X > 8, site is 'blown away,' and opponent loses 3 Force. X = number of Death Star sites on table.",
+    "gameText": "Once per game, deploy on Death Star; it is hyperspeed = 2. Superlaser may not target planet systems. Once during your control phase, may fire Superlaser as follows: Prepare Single Reactor Ignition: If Death Star orbiting Jedha or Scarif, target your related unique (•) battleground site, even if converted (regardless of objective restrictions). Fire!: Draw destiny. It's Beautiful: If destiny +X > 8, site is 'blown away,' and opponent loses 3 Force. X = number of Death Star sites on table.",
     "deployCost": 0,
     "destiny": 0,
     "icons": [
@@ -27127,7 +27127,7 @@
     ],
     "cardSubtype": "COMBAT",
     "lore": "Enclosed. Death Squadron.",
-    "gameText": "May add 1 pilot. Permanent pilot is â€¢Marquand, who provides ability of 2. Cards Blizzard 6 hits are power and forfeit -2 and may not apply ability towards drawing battle destiny. Immune to attrition < 4.",
+    "gameText": "May add 1 pilot. Permanent pilot is •Marquand, who provides ability of 2. Cards Blizzard 6 hits are power and forfeit -2 and may not apply ability towards drawing battle destiny. Immune to attrition < 4.",
     "deployCost": 6,
     "destiny": 1,
     "power": 6,
@@ -27496,7 +27496,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "On her assignment to kill Sharad Hett, Aurra used her patience and cunning to help track down the Jedi Master.",
-    "gameText": "Deploy on table. While alone, assassins are power +1. Once per game, may reveal up to two unique (â€¢) aliens from hand and/or Reserve Deck (reshuffle); for remainder of game, those cards are assassins and, if your [Reflections II] objective on table, Black Sun agents. [Immune to Alter.]",
+    "gameText": "Deploy on table. While alone, assassins are power +1. Once per game, may reveal up to two unique (•) aliens from hand and/or Reserve Deck (reshuffle); for remainder of game, those cards are assassins and, if your [Reflections II] objective on table, Black Sun agents. [Immune to Alter.]",
     "destiny": 4,
     "icons": [
       {
@@ -29702,7 +29702,7 @@
       "LOCATION"
     ],
     "cardSubtype": "SITE",
-    "locationDarkSideGameText": "While your unique (â€¢) alien here, your Force generation is +1 here (+2 if Margo).",
+    "locationDarkSideGameText": "While your unique (•) alien here, your Force generation is +1 here (+2 if Margo).",
     "locationLightSideGameText": "Force drain -1 here (if your smuggler here, Force drain +1 instead).",
     "deployCost": 0,
     "destiny": 0,
@@ -31912,7 +31912,7 @@
     ],
     "cardSubtype": "SITE",
     "locationDarkSideGameText": "Once per turn, may [download] a starfighter with 'Vader' in title here.",
-    "locationLightSideGameText": "Your docking bay transit to or from here requires +4 Force (+6 Force if Vader or VaneÃ© here).",
+    "locationLightSideGameText": "Your docking bay transit to or from here requires +4 Force (+6 Force if Vader or Vaneé here).",
     "deployCost": 0,
     "destiny": 0,
     "icons": [
@@ -32678,7 +32678,7 @@
       "EFFECT"
     ],
     "cardSubtype": "NORMAL",
-    "gameText": "Deploy on table. Your unique (â€¢) Republic characters of ability < 4 and your [Trade Federation] starships are forfeit +2. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites only. Once per turn, may deploy an [Episode I] (or Coruscant) docking bay from Reserve Deck; reshuffle. While you occupy Naboo system with a [Trade Federation] starship, your Force generation is +1 there. [Immune to Alter.]",
+    "gameText": "Deploy on table. Your unique (•) Republic characters of ability < 4 and your [Trade Federation] starships are forfeit +2. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites only. Once per turn, may deploy an [Episode I] (or Coruscant) docking bay from Reserve Deck; reshuffle. While you occupy Naboo system with a [Trade Federation] starship, your Force generation is +1 there. [Immune to Alter.]",
     "destiny": 4,
     "icons": [
       {
@@ -32904,7 +32904,7 @@
       "IMPERIAL"
     ],
     "lore": "ISB leader.",
-    "gameText": "During your deploy phase, a unique (â€¢) Imperial of ability < 3 here may make a regular move. When deployed, may place a unique (â€¢) ISB agent here in Used Pile to deploy (for free) a non-Tarkin ISB agent with a different title here from Used Pile; reshuffle.",
+    "gameText": "During your deploy phase, a unique (•) Imperial of ability < 3 here may make a regular move. When deployed, may place a unique (•) ISB agent here in Used Pile to deploy (for free) a non-Tarkin ISB agent with a different title here from Used Pile; reshuffle.",
     "deployCost": 3,
     "destiny": 2,
     "power": 3,
@@ -33611,7 +33611,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Jabba's influence is not easily ignored. Neither are his voracious and vile appetites. Even Jedi soon learn this lesson.",
-    "gameText": "Deploy on table. When deployed, may take the top card of Lost Pile into hand. During your move phase, may cancel Landing Claw. If Landing Claw was just lost, place it out of play. Elis Helrot and Nabrun Leids are unique (â€¢) and are Lost Interrupts. [Immune to Alter.]",
+    "gameText": "Deploy on table. When deployed, may take the top card of Lost Pile into hand. During your move phase, may cancel Landing Claw. If Landing Claw was just lost, place it out of play. Elis Helrot and Nabrun Leids are unique (•) and are Lost Interrupts. [Immune to Alter.]",
     "destiny": 4,
     "icons": [
       {
@@ -34026,7 +34026,7 @@
       "ALIEN"
     ],
     "lore": "Crolute scavenger and thief.",
-    "gameText": "Your battle destiny draws here are +Â¼ for each device, droid, starship, vehicle, or weapon card here. During battle with an opponent's droid, adds one destiny to total power. Once per game, may retrieve a device or character weapon.",
+    "gameText": "Your battle destiny draws here are +¼ for each device, droid, starship, vehicle, or weapon card here. During battle with an opponent's droid, adds one destiny to total power. Once per game, may retrieve a device or character weapon.",
     "deployCost": 2,
     "destiny": 4,
     "power": 2,
@@ -34644,7 +34644,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Customized transport of Lord Vader. Employs advanced sensor jamming gear. Modified with enhanced tactical displays constructed to the Dark Lord's specifications.",
-    "gameText": "Deploys -2 to Mustafar. May add 1 pilot and 3 passengers. Permanent pilot is â€¢Jendon, who provides ability of 2. If Vader armed with a lightsaber weapon card at a battleground, Force drain +1 here.",
+    "gameText": "Deploys -2 to Mustafar. May add 1 pilot and 3 passengers. Permanent pilot is •Jendon, who provides ability of 2. If Vader armed with a lightsaber weapon card at a battleground, Force drain +1 here.",
     "deployCost": 5,
     "destiny": 3,
     "power": 5,
@@ -35602,7 +35602,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Sandtroopers commanded by Governor Aryon do not enjoy their assignment. They find a means of venting their frustrations by harassing the local inhabitants.",
-    "gameText": "Deploy on table. During your control phase, if you occupy Tatooine system, opponent loses 1 Force for each Tatooine battleground site you occupy with a unique (â€¢) trooper. While you have three troopers on Tatooine, immune to Alter and Endor Celebration.",
+    "gameText": "Deploy on table. During your control phase, if you occupy Tatooine system, opponent loses 1 Force for each Tatooine battleground site you occupy with a unique (•) trooper. While you have three troopers on Tatooine, immune to Alter and Endor Celebration.",
     "destiny": 4,
     "icons": [
       {
@@ -35994,7 +35994,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Commissioned by a group of Gand venture capitalists headed by Zuckuss. Manufactured by Byblos Drive Yards. Uses repulsorlift technology developed for combat cloud cars.",
-    "gameText": "May 1 pilot. Permanent pilots are â€¢Zuckuss, who provides ability of 4, and â€¢4-LOM. Players may not add power destinies or draw more than one battle destiny here. Immune to attrition < 5.",
+    "gameText": "May 1 pilot. Permanent pilots are •Zuckuss, who provides ability of 4, and •4-LOM. Players may not add power destinies or draw more than one battle destiny here. Immune to attrition < 5.",
     "deployCost": 5,
     "destiny": 2,
     "power": 5,
@@ -36261,7 +36261,7 @@
       "STARSHIP"
     ],
     "cardSubtype": "STARFIGHTER",
-    "gameText": "May add 1 pilot and 3 passengers. Permanent pilot is â€¢Kuruk, who provides ability of 3. Kylo and Knights of Ren deploy -1 to same and related locations. Immune to attrition < 4.",
+    "gameText": "May add 1 pilot and 3 passengers. Permanent pilot is •Kuruk, who provides ability of 3. Kylo and Knights of Ren deploy -1 to same and related locations. Immune to attrition < 4.",
     "deployCost": 4,
     "destiny": 2,
     "power": 4,
@@ -36791,7 +36791,7 @@
       "ALIEN"
     ],
     "lore": "Notorious bounty hunter. 'As you wish.'",
-    "gameText": "[Pilot] 2. Permanent weapon is â€¢Boba Fett's Blaster Rifle (may target a character for free; draw destiny; if destiny > defense value, target captured; otherwise, if destiny +2 > defense value, target hit, is forfeit -3, and opponent loses 1 Force; may not be retargeted).",
+    "gameText": "[Pilot] 2. Permanent weapon is •Boba Fett's Blaster Rifle (may target a character for free; draw destiny; if destiny > defense value, target captured; otherwise, if destiny +2 > defense value, target hit, is forfeit -3, and opponent loses 1 Force; may not be retargeted).",
     "deployCost": 4,
     "destiny": 1,
     "power": 5,
@@ -37094,7 +37094,7 @@
     ],
     "cardSubtype": "CAPITAL",
     "lore": "",
-    "gameText": "May add 2 pilots, and 2 passengers. Permanent pilot is â€¢Vanto, who provides ability of 3. Immune to attrition < 4 (< 6 while piloted by Thrawn or while a 'probed' or 'liberated' system on table).",
+    "gameText": "May add 2 pilots, and 2 passengers. Permanent pilot is •Vanto, who provides ability of 3. Immune to attrition < 4 (< 6 while piloted by Thrawn or while a 'probed' or 'liberated' system on table).",
     "deployCost": 4,
     "destiny": 1,
     "power": 5,
@@ -37305,7 +37305,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Maul's Sith Infiltrator.",
-    "gameText": "May add 1 pilot. Permanent pilot is â€¢Maul, who provides ability of 6. Once per battle, may lose 1 Force to 'cloak' (either add one destiny to total power or make this starship immune to attrition < 6).",
+    "gameText": "May add 1 pilot. Permanent pilot is •Maul, who provides ability of 6. Once per battle, may lose 1 Force to 'cloak' (either add one destiny to total power or make this starship immune to attrition < 6).",
     "deployCost": 4,
     "destiny": 4,
     "power": 4,
@@ -37815,7 +37815,7 @@
       "ALIEN"
     ],
     "lore": "Gand bounty hunter and scout.",
-    "gameText": "[Pilot] 2. Once per game, may peek at top card of any Reserve Deck. Permanent weapon is â€¢Zuckuss' Snare Rifle (may target a character for free; draw destiny; target excluded from battle if destiny +1 > target's power).",
+    "gameText": "[Pilot] 2. Once per game, may peek at top card of any Reserve Deck. Permanent weapon is •Zuckuss' Snare Rifle (may target a character for free; draw destiny; target excluded from battle if destiny +1 > target's power).",
     "deployCost": 4,
     "destiny": 1,
     "power": 2,
@@ -38470,7 +38470,7 @@
       "FIRST_ORDER"
     ],
     "lore": "Knight of Ren.",
-    "gameText": "[Pilot] 2. While an [Episode VII] objective on table, draws one battle destiny if unable to otherwise. Permanent weapon is â€¢Arm Cannon (may target a character for free; draw destiny; target hit, and its forfeit = 0, if destiny + 1 > defense value).",
+    "gameText": "[Pilot] 2. While an [Episode VII] objective on table, draws one battle destiny if unable to otherwise. Permanent weapon is •Arm Cannon (may target a character for free; draw destiny; target hit, and its forfeit = 0, if destiny + 1 > defense value).",
     "deployCost": 4,
     "destiny": 2,
     "power": 4,
@@ -40084,7 +40084,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "'I'm sorry, too.'",
-    "gameText": "If your [Cloud City] objective on table, deploy on table. Elis Helrot, Stunning Leader, and Surreptitious Glance may not be played. Once per turn, may [download] an interior Cloud City site. Your unique (â€¢) characters with printed forfeit < 5 are forfeit +2 (limit +2). [Immune to Alter.]",
+    "gameText": "If your [Cloud City] objective on table, deploy on table. Elis Helrot, Stunning Leader, and Surreptitious Glance may not be played. Once per turn, may [download] an interior Cloud City site. Your unique (•) characters with printed forfeit < 5 are forfeit +2 (limit +2). [Immune to Alter.]",
     "destiny": 5,
     "icons": [
       {
@@ -41088,7 +41088,7 @@
     ],
     "cardSubtype": "IMMEDIATE",
     "lore": "Dianogas use their seven tentacles for both locomotion and catching food. The few survivors of such attacks claim that a dianoga tentacle has the strength of a hydro-clamp.",
-    "gameText": "If opponent just played an Interrupt, use 1 Force to deploy on table and stack that Interrupt here. All Interrupts of that title are unique (â€¢). (Immune to Control.)",
+    "gameText": "If opponent just played an Interrupt, use 1 Force to deploy on table and stack that Interrupt here. All Interrupts of that title are unique (•). (Immune to Control.)",
     "destiny": 5,
     "icons": [
       {
@@ -42944,7 +42944,7 @@
       "SITH"
     ],
     "lore": "Female Dathomirian assassin",
-    "gameText": "Power +1 with Dooku. Permanent weapon is â€¢Asajj's Lightsabers (may target a character for free, or target two characters using 1 Force; draw two destiny; target(s) hit and forfeit -2 if total destiny > total defense value).",
+    "gameText": "Power +1 with Dooku. Permanent weapon is •Asajj's Lightsabers (may target a character for free, or target two characters using 1 Force; draw two destiny; target(s) hit and forfeit -2 if total destiny > total defense value).",
     "deployCost": 5,
     "destiny": 1,
     "power": 4,
@@ -46564,7 +46564,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Like nerf herders herding nerfs, Imperial commanders often use TIE fighters to drive fleeing Rebel ships into tractor beam range.",
-    "gameText": "Deploy on one opponent's unique (â€¢) starship at a location you do not occupy. When starship is targeted by any tractor beam or ion cannon, subtract 2 from maneuver. If starship is captured or lost, lose Effect and opponent must lose 3 Force (5 if Falcon).",
+    "gameText": "Deploy on one opponent's unique (•) starship at a location you do not occupy. When starship is targeted by any tractor beam or ion cannon, subtract 2 from maneuver. If starship is captured or lost, lose Effect and opponent must lose 3 Force (5 if Falcon).",
     "destiny": 4,
     "icons": [
       {
@@ -49208,7 +49208,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Careless abuse of the Force by a young Jedi trainee can have dire consequences. When hanging from the weather vane of Cloud City, Luke's balance was his only hope.",
-    "gameText": "Deploy on table. If a unique (â€¢) card is drawn for destiny and a duplicate is on table, destiny card is lost (destiny = 0). If duplicated card is a character, it loses immunity to attrition for rest of turn and player must lose 2 Force or lose that character. (Immune to Alter.)",
+    "gameText": "Deploy on table. If a unique (•) card is drawn for destiny and a duplicate is on table, destiny card is lost (destiny = 0). If duplicated card is a character, it loses immunity to attrition for rest of turn and player must lose 2 Force or lose that character. (Immune to Alter.)",
     "destiny": 4,
     "icons": [
       {
@@ -53001,7 +53001,7 @@
       "ALIEN"
     ],
     "lore": "Male Jawa. Leader of a large tribe of Jawas. Plotting with Jabba to take control of a neighboring tribe's territory.",
-    "gameText": "Deploys only on Tatooine. Your Jawa Pack is not unique(â€¢), is doubled, deploys free (or for 6 Force from each player) and cummulatively affects your Jawas' forfeit. While at Audience Chamber or Jawa Camp, all your other Jawas are power +2.",
+    "gameText": "Deploys only on Tatooine. Your Jawa Pack is not unique(•), is doubled, deploys free (or for 6 Force from each player) and cummulatively affects your Jawas' forfeit. While at Audience Chamber or Jawa Camp, all your other Jawas are power +2.",
     "deployCost": 3,
     "destiny": 2,
     "power": 2,
@@ -55210,7 +55210,7 @@
       "IMPERIAL"
     ],
     "lore": "Death Star trooper who witnessed Leia's interrogation. Senior tactical advisor to Sergeant Major Enfield. Coordinates security duty assignments for Detention Block AA-23.",
-    "gameText": "While Grenwick is on Death Star, your Death Star Sentry is not unique (â€¢), is doubled, deploys free, applies all three of its modifiers and is immune to Alter. Power -1 when not on Death Star.",
+    "gameText": "While Grenwick is on Death Star, your Death Star Sentry is not unique (•), is doubled, deploys free, applies all three of its modifiers and is immune to Alter. Power -1 when not on Death Star.",
     "deployCost": 1,
     "destiny": 3,
     "power": 2,
@@ -57123,7 +57123,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "Vader was nearly killed when Han damaged his TIE fighter during a surprise attack in the Death Star trench.",
-    "gameText": "Deploy on your side of table. During a battle, you may place out of play from hand a copy of any unique (â€¢) card participating in that battle to reduce attrition against you by that card's forfeit value. (Immune to Alter while you occupy a battleground.)",
+    "gameText": "Deploy on your side of table. During a battle, you may place out of play from hand a copy of any unique (•) card participating in that battle to reduce attrition against you by that card's forfeit value. (Immune to Alter while you occupy a battleground.)",
     "destiny": 2,
     "icons": [
       {
@@ -59394,7 +59394,7 @@
       "LOCATION"
     ],
     "cardSubtype": "SITE",
-    "locationDarkSideGameText": "May not deploy to Bespin, Dagobah, Endor, Hoth, Kashyyyk or Yavin 4. During your move phase, may move free between here and any related â—‡ spaceport site.",
+    "locationDarkSideGameText": "May not deploy to Bespin, Dagobah, Endor, Hoth, Kashyyyk or Yavin 4. During your move phase, may move free between here and any related ◇ spaceport site.",
     "locationLightSideGameText": "May not deploy to Bespin, Dagobah, Endor, Hoth, Kashyyyk or Yavin 4. Rebels are power -1 here.",
     "deployCost": 0,
     "destiny": 0,
@@ -59700,7 +59700,7 @@
     "cardTypes": [
       "OBJECTIVE"
     ],
-    "gameText": "Deploy any planet system and one â—‡ site to that system. This system is the Renegade planet. While this side up, once during each of your deploy phases, you may deploy one â—‡ site to the Renegade planet from Reserve Deck; reshuffle. Flip this card if your matching operatives control at least three battleground sites related to the Renegade planet.",
+    "gameText": "Deploy any planet system and one ◇ site to that system. This system is the Renegade planet. While this side up, once during each of your deploy phases, you may deploy one ◇ site to the Renegade planet from Reserve Deck; reshuffle. Flip this card if your matching operatives control at least three battleground sites related to the Renegade planet.",
     "destiny": 0,
     "icons": [
       {
@@ -59856,7 +59856,7 @@
     ],
     "cardSubtype": "CAPITAL",
     "lore": "Bossk once said of his ship, 'Greeezeg uut nikek!'",
-    "gameText": "May add 6 passengers and 1 vehicle. Permanent pilot is â€¢Bossk, who provides ability of 2, adds 2 to power and adds one battle destiny. Deploys and moves like a starfighter. Has ship-docking capability.",
+    "gameText": "May add 6 passengers and 1 vehicle. Permanent pilot is •Bossk, who provides ability of 2, adds 2 to power and adds one battle destiny. Deploys and moves like a starfighter. Has ship-docking capability.",
     "deployCost": 8,
     "destiny": 1,
     "power": 5,
@@ -59973,7 +59973,7 @@
     ],
     "cardSubtype": "SQUADRON",
     "lore": "Notoriety gained during the assaults on Ralltiir and Mon Calamari makes this the most feared squadron in the Empire. Defended the Death Star during the Battle of Yavin.",
-    "gameText": "Permanent pilots aboard are â€¢Darth Vader, â€¢DS-61-2 and â€¢DS-61-3, who provide total ability of 10 and add 9 to total power of â€¢Vader's Custom TIE, â€¢Black 2 and â€¢Black 3.",
+    "gameText": "Permanent pilots aboard are •Darth Vader, •DS-61-2 and •DS-61-3, who provide total ability of 10 and add 9 to total power of •Vader's Custom TIE, •Black 2 and •Black 3.",
     "deployCost": 12,
     "destiny": 1,
     "power": 3,
@@ -60078,7 +60078,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Lead starfighter of Obsidian Squadron. Flown by Cive Rashon. Call sign 'Howlrunner.' She served in an elite TIE squadron aboard the Star Destroyer Avenger.",
-    "gameText": "Deploy -1 and power +3 at a cloud sector. Permanent pilot is â€¢OS-72-1, who provides ability of 2, adds 2 to power and, at a cloud sector, may draw one battle destiny if not able to otherwise.",
+    "gameText": "Deploy -1 and power +3 at a cloud sector. Permanent pilot is •OS-72-1, who provides ability of 2, adds 2 to power and, at a cloud sector, may draw one battle destiny if not able to otherwise.",
     "deployCost": 5,
     "destiny": 2,
     "power": 2,
@@ -60121,7 +60121,7 @@
     ],
     "cardSubtype": "STARFIGHTER",
     "lore": "Piloted by Dodson Makraven, wingman of Cive Rashon. Experienced TIE pilot with many kills in atmospheric combat. Nicknamed 'Night Beast' for his many curfew violations.",
-    "gameText": "Deploy -1 and power +3 at a cloud sector. Permanent pilot is â€¢OS-72-2, who provides ability of 2, adds 2 to power and, at a cloud sector, may draw one battle destiny if not able to otherwise.",
+    "gameText": "Deploy -1 and power +3 at a cloud sector. Permanent pilot is •OS-72-2, who provides ability of 2, adds 2 to power and, at a cloud sector, may draw one battle destiny if not able to otherwise.",
     "deployCost": 4,
     "destiny": 3,
     "power": 1,
@@ -61775,7 +61775,7 @@
     ],
     "cardSubtype": "NORMAL",
     "lore": "When an Imperial blockade raises the alert level, all independent ships are scanned and any suspicious characters on planet are detained and interrogated.",
-    "gameText": "Deploy on table. Unique (â€¢) Imperials of ability < 3 are forfeit +2. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites. Once during each of your deploy phases, may deploy one docking bay from Reserve Deck; reshuffle. (Immune to Alter.)",
+    "gameText": "Deploy on table. Unique (•) Imperials of ability < 3 are forfeit +2. Nabrun Leids and Elis Helrot are limited to owner's move phase and exterior sites. Once during each of your deploy phases, may deploy one docking bay from Reserve Deck; reshuffle. (Immune to Alter.)",
     "destiny": 5,
     "icons": [
       {
@@ -62070,7 +62070,7 @@
     ],
     "cardSubtype": "USED_OR_STARTING",
     "lore": "Imperial troops prepared for quick deployment to seize valuable terrain.",
-    "gameText": "USED: If a battle was just initiated, draw destiny and activate up to that much Force. STARTING: If you have not deployed an Objective, deploy from Reserve Deck one battleground site (or two â—‡ sites) related to your starting location. Place Interrupt in Reserve Deck.",
+    "gameText": "USED: If a battle was just initiated, draw destiny and activate up to that much Force. STARTING: If you have not deployed an Objective, deploy from Reserve Deck one battleground site (or two ◇ sites) related to your starting location. Place Interrupt in Reserve Deck.",
     "destiny": 5,
     "icons": [
       {
@@ -62490,7 +62490,7 @@
     ],
     "cardSubtype": "USED_OR_LOST",
     "lore": "Imperial training allows scouts to use speed and stealth to their advantage. On Endor, they were also backed up by Commander Igar's ATSTs.",
-    "gameText": "USED: If all of your ability in a battle is provided by scouts and/or spies, they each add 1 to your total battle destiny (limit +6). LOST: For remainder of turn, your unique (â€¢) scouts and unique (â€¢) spies are each power +1 (or +2 while being attacked by a creature).",
+    "gameText": "USED: If all of your ability in a battle is provided by scouts and/or spies, they each add 1 to your total battle destiny (limit +6). LOST: For remainder of turn, your unique (•) scouts and unique (•) spies are each power +1 (or +2 while being attacked by a creature).",
     "destiny": 4,
     "icons": [
       {
@@ -64368,7 +64368,7 @@
       "IMPERIAL"
     ],
     "lore": "Wingman of Major Phennir. Earned promotion to Fel's squadron by scoring 12 kills at Mon Calamari. Repeatedly refused further promotion so that he could remain in the 181st.",
-    "gameText": "Adds 3 to power of any TIE he pilots. Once during each of your deploy phases, you may take one unique (â€¢) TIE Interceptor into hand from Reserve Deck; reshuffle.",
+    "gameText": "Adds 3 to power of any TIE he pilots. Once during each of your deploy phases, you may take one unique (•) TIE Interceptor into hand from Reserve Deck; reshuffle.",
     "deployCost": 2,
     "destiny": 4,
     "power": 2,
@@ -67256,7 +67256,7 @@
     "cardTypes": [
       "ADMIRALS_ORDER"
     ],
-    "gameText": "Unique (â€¢) starfighters without permanent pilots are immune to attrition < 4 (or add 2 to immunity if starfighter already has immunity). Starships without pilot characters aboard are power -2. At docking bays related to systems you occupy, your Force drains are +1. Once per turn, your starfighter just lost from a system may be relocated to a related docking bay.",
+    "gameText": "Unique (•) starfighters without permanent pilots are immune to attrition < 4 (or add 2 to immunity if starfighter already has immunity). Starships without pilot characters aboard are power -2. At docking bays related to systems you occupy, your Force drains are +1. Once per turn, your starfighter just lost from a system may be relocated to a related docking bay.",
     "deployCost": 0,
     "destiny": 6,
     "icons": [

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/choose/DeployCardFromReserveDeckEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/choose/DeployCardFromReserveDeckEffect.java
@@ -3,6 +3,7 @@ package com.gempukku.swccgo.logic.effects.choose;
 import com.gempukku.swccgo.common.Zone;
 import com.gempukku.swccgo.filters.Filter;
 import com.gempukku.swccgo.game.DeploymentRestrictionsOption;
+import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.logic.timing.Action;
 
 /**
@@ -133,5 +134,17 @@ public class DeployCardFromReserveDeckEffect extends DeployCardFromPileEffect {
 
     public DeployCardFromReserveDeckEffect(Action action, Filter cardFilter, Filter targetFilter, float changeInCost, boolean reshuffle) {
         super(action, action.getPerformingPlayer(), Zone.RESERVE_DECK, cardFilter, targetFilter, null, null, false, changeInCost, null, null, null, false, reshuffle);
+    }
+
+    /**
+     * Creates an effect that causes the player performing the action to deploy a specific card from Reserve Deck
+     * (anywhere legal for that card).
+     * @param action the action performing this effect
+     * @param card the card to deploy
+     * @param forFree true if deploying for free, otherwise false
+     * @param reshuffle true if pile is reshuffled, otherwise false
+     */
+    public DeployCardFromReserveDeckEffect(Action action, PhysicalCard card, boolean forFree, boolean reshuffle) {
+        super(action, Zone.RESERVE_DECK, card, null, forFree, 0, false, reshuffle);
     }
 }

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/choose/DeployCardsFromReserveDeckAndLoseTheRestEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/choose/DeployCardsFromReserveDeckAndLoseTheRestEffect.java
@@ -1,0 +1,147 @@
+package com.gempukku.swccgo.logic.effects.choose;
+
+import com.gempukku.swccgo.common.Filterable;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.filters.Filter;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.actions.SubAction;
+import com.gempukku.swccgo.logic.effects.ChooseArbitraryCardsEffect;
+import com.gempukku.swccgo.logic.effects.LoseCardsFromReserveDeckEffect;
+import com.gempukku.swccgo.logic.timing.AbstractSubActionEffect;
+import com.gempukku.swccgo.logic.timing.Action;
+import com.gempukku.swccgo.logic.timing.PassthruEffect;
+import com.gempukku.swccgo.logic.timing.StandardEffect;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Shared helper for Panic / Emergency Deployment / similar cards:
+ * among a previously revealed set still in Reserve Deck, optionally deploy matching cards
+ * (for free), then lose any remaining revealed cards still in Reserve Deck.
+ * <p>
+ * Does not introduce persistent revealed-state engine tracking; uses existing reveal UI
+ * plus deploy-from-reserve of specific cards (Sergeant Bruckman-style).
+ */
+public class DeployCardsFromReserveDeckAndLoseTheRestEffect extends AbstractSubActionEffect {
+    private final String _playerId;
+    private final List<PhysicalCard> _remainingCards;
+    private final Filterable _deployableTypesFilter;
+    private final Filter _locationFilter;
+    private final boolean _forFree;
+
+    /**
+     * Deploy matching revealed cards anywhere (for free by default for Panic-family), then lose the rest.
+     */
+    public DeployCardsFromReserveDeckAndLoseTheRestEffect(Action action, Collection<PhysicalCard> revealedCards,
+                                                          Filterable deployableTypesFilter, boolean forFree) {
+        this(action, revealedCards, deployableTypesFilter, null, forFree);
+    }
+
+    /**
+     * Deploy matching revealed cards to a location accepted by locationFilter (or anywhere if null), then lose the rest.
+     */
+    public DeployCardsFromReserveDeckAndLoseTheRestEffect(Action action, Collection<PhysicalCard> revealedCards,
+                                                          Filterable deployableTypesFilter, Filter locationFilter,
+                                                          boolean forFree) {
+        super(action);
+        _playerId = action.getPerformingPlayer();
+        _remainingCards = new LinkedList<PhysicalCard>(revealedCards);
+        _deployableTypesFilter = deployableTypesFilter;
+        _locationFilter = locationFilter;
+        _forFree = forFree;
+    }
+
+    @Override
+    public boolean isPlayableInFull(SwccgGame game) {
+        return true;
+    }
+
+    private Filter currentlyDeployableFilter() {
+        Filter stillInReserve = Filters.and(Filters.in(_remainingCards), Filters.zoneOfPlayer(Zone.RESERVE_DECK, _playerId), _deployableTypesFilter);
+        if (_locationFilter != null) {
+            return Filters.and(stillInReserve, Filters.deployableToLocation(_action.getActionSource(), _locationFilter, _forFree, 0));
+        }
+        return Filters.and(stillInReserve, Filters.deployable(_action.getActionSource(), null, _forFree, 0));
+    }
+
+    @Override
+    protected SubAction getSubAction(SwccgGame game) {
+        final SubAction subAction = new SubAction(_action);
+        subAction.appendEffect(
+                new PassthruEffect(subAction) {
+                    @Override
+                    protected void doPlayEffect(SwccgGame game) {
+                        Collection<PhysicalCard> deployableCards = Filters.filter(_remainingCards, game, currentlyDeployableFilter());
+                        if (!deployableCards.isEmpty()) {
+                            subAction.insertEffect(getChooseOneCardToDeployEffect(subAction, deployableCards));
+                        }
+                    }
+                }
+        );
+        subAction.appendEffect(
+                new PassthruEffect(subAction) {
+                    @Override
+                    protected void doPlayEffect(SwccgGame game) {
+                        Collection<PhysicalCard> cardsToLose = Filters.filter(_remainingCards, game,
+                                Filters.zoneOfPlayer(Zone.RESERVE_DECK, _playerId));
+                        if (!cardsToLose.isEmpty()) {
+                            subAction.appendEffect(new LoseCardsFromReserveDeckEffect(subAction, cardsToLose));
+                        }
+                    }
+                }
+        );
+        return subAction;
+    }
+
+    private StandardEffect getChooseOneCardToDeployEffect(final SubAction subAction, final Collection<PhysicalCard> deployableCards) {
+        // min 0 => player may stop deploying even when more matching cards remain (remainder are lost)
+        return new ChooseArbitraryCardsEffect(subAction, _playerId, "Choose card to deploy" + GameUtils.s(1) + " (or none)",
+                _remainingCards, currentlyDeployableFilter(), 0, 1) {
+            @Override
+            protected void cardsSelected(SwccgGame game, Collection<PhysicalCard> selectedCards) {
+                if (selectedCards.isEmpty()) {
+                    return;
+                }
+                final PhysicalCard selectedCard = selectedCards.iterator().next();
+                _remainingCards.remove(selectedCard);
+                if (_locationFilter != null) {
+                    subAction.insertEffect(
+                            new DeployCardToLocationFromReserveDeckEffect(subAction, selectedCard, _locationFilter, _forFree, false, false),
+                            new PassthruEffect(subAction) {
+                                @Override
+                                protected void doPlayEffect(SwccgGame game) {
+                                    Collection<PhysicalCard> more = Filters.filter(_remainingCards, game, currentlyDeployableFilter());
+                                    if (!more.isEmpty()) {
+                                        subAction.insertEffect(getChooseOneCardToDeployEffect(subAction, more));
+                                    }
+                                }
+                            }
+                    );
+                } else {
+                    subAction.insertEffect(
+                            new DeployCardFromReserveDeckEffect(subAction, selectedCard, _forFree, false),
+                            new PassthruEffect(subAction) {
+                                @Override
+                                protected void doPlayEffect(SwccgGame game) {
+                                    Collection<PhysicalCard> more = Filters.filter(_remainingCards, game, currentlyDeployableFilter());
+                                    if (!more.isEmpty()) {
+                                        subAction.insertEffect(getChooseOneCardToDeployEffect(subAction, more));
+                                    }
+                                }
+                            }
+                    );
+                }
+            }
+        };
+    }
+
+    @Override
+    protected boolean wasActionCarriedOut() {
+        return true;
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set14/dark/Card_14_71_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set14/dark/Card_14_71_Tests.java
@@ -1,0 +1,296 @@
+package com.gempukku.swccgo.cards.set14.dark;
+
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Keyword;
+import com.gempukku.swccgo.common.ModelType;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * VHD tests for Theed Palace 14_71 3B3-21 (reveal X / deploy battle droids / lose rest; Closes #171).
+ */
+public class Card_14_71_Tests {
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("luke", "1_019");
+                    put("ls_hallway", "14_51");
+                }},
+                new HashMap<>() {{
+                    put("threeb3", "14_71");
+                    put("bd1", "14_70");
+                    put("bd2", "14_72");
+                    put("junk", "1_249");
+                    put("ds_hallway", "14_112");
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void ThreeB3TwentyOneStatsAndKeywordsAreCorrect() {
+        var scn = GetScenario();
+        var card = scn.GetDSCard("threeb3").getBlueprint();
+
+        assertEquals("3B3-21", card.getTitle());
+        assertEquals(Uniqueness.UNIQUE, card.getUniqueness());
+        assertEquals(Side.DARK, card.getSide());
+        scn.BlueprintCardTypeCheck(card, new ArrayList<>() {{
+            add(CardType.DROID);
+        }});
+        assertEquals(2, card.getDestiny(), scn.epsilon);
+        assertEquals(3, card.getDeployCost(), scn.epsilon);
+        assertEquals(3, card.getPower(), scn.epsilon);
+        assertEquals(3, card.getForfeit(), scn.epsilon);
+        assertEquals(4, card.getArmor(), scn.epsilon);
+        scn.BlueprintKeywordCheck(card, new ArrayList<>() {{
+            add(Keyword.INFANTRY_BATTLE_DROID);
+        }});
+        scn.BlueprintIconCheck(card, new ArrayList<>() {{
+            add(Icon.DROID);
+            add(Icon.THEED_PALACE);
+            add(Icon.EPISODE_I);
+            add(Icon.PRESENCE);
+        }});
+        scn.BlueprintModelTypeCheck(card, new ArrayList<>() {{
+            add(ModelType.BATTLE);
+        }});
+        assertEquals(ExpansionSet.THEED_PALACE, card.getExpansionSet());
+        assertEquals(Rarity.U, card.getRarity());
+    }
+
+    @Test
+    public void ThreeB3TwentyOneNotAvailableIfYouInitiateBattle() {
+        var scn = GetScenario();
+
+        var luke = scn.GetLSCard("luke");
+        var lsHallway = scn.GetLSCard("ls_hallway");
+
+        var threeb3 = scn.GetDSCard("threeb3");
+
+        scn.StartGame();
+        scn.MoveLocationToTable(lsHallway);
+        scn.MoveCardsToLocation(lsHallway, luke, threeb3);
+
+        scn.SkipToDSTurn(Phase.BATTLE);
+        scn.DSInitiateBattle(lsHallway);
+
+        assertFalse("3B3-21 must not trigger when DS initiates battle",
+                scn.DSAnyDecisionsAvailable() && scn.DSCardActionAvailable(threeb3, "Reveal"));
+    }
+
+    @Test
+    public void ThreeB3TwentyOneRevealsDeploysBattleDroidsAndLosesRestWhenOpponentInitiates() {
+        var scn = GetScenario();
+
+        var luke = scn.GetLSCard("luke");
+        var lsHallway = scn.GetLSCard("ls_hallway");
+
+        var threeb3 = scn.GetDSCard("threeb3");
+        var bd1 = scn.GetDSCard("bd1");
+        var junk = scn.GetDSCard("junk");
+
+        scn.StartGame();
+        scn.MoveLocationToTable(lsHallway);
+        scn.MoveCardsToLocation(lsHallway, luke, threeb3);
+
+        scn.SkipToLSTurn(Phase.BATTLE);
+        // junk then bd1 on top (bd1 is topmost)
+        scn.MoveCardsToTopOfOwnReserveDeck(junk, bd1);
+        scn.LSInitiateBattle(lsHallway);
+
+        assertTrue("Expected 3B3-21 reveal action; decision=" + decisionText(scn),
+                scn.DSCardActionAvailable(threeb3, "Reveal"));
+        scn.DSUseCardAction(threeb3, "Reveal");
+
+        assertTrue("Expected Force amount decision; got: " + decisionText(scn),
+                scn.DSDecisionAvailable("Choose amount of Force to use"));
+        scn.DSDecided(2);
+        scn.PassAllResponses(); // Use X Force cost optional responses
+
+        // Both players acknowledge the reveal UI
+        assertTrue("Expected DS reveal UI; got: " + decisionText(scn),
+                scn.DSDecisionAvailable("Top card") || scn.DSDecisionAvailable("Reserve Deck"));
+        scn.DSPass();
+        if (scn.LSDecisionAvailable("Top card") || scn.LSDecisionAvailable("Reserve Deck")) {
+            scn.LSPass();
+        }
+
+        assertTrue("Expected deploy choice; got: " + decisionText(scn),
+                scn.DSDecisionAvailable("Choose card to deploy"));
+        {
+            var bp = scn.DSGetBPChoices();
+            var ids = scn.DSGetCardChoices();
+            String bdBp = bd1.getBlueprintId(true);
+            int idx = -1;
+            for (int i = 0; i < bp.size(); i++) {
+                if (normalizeBp(bdBp).equals(normalizeBp(bp.get(i)))) {
+                    idx = i;
+                    break;
+                }
+            }
+            assertTrue("Battle droid should appear in deploy choices; bp=" + bp + " bdBp=" + bdBp, idx >= 0);
+            scn.DSDecided(ids.get(idx));
+        }
+        resolveUntilIdle(scn, 50);
+
+        assertFalse("Non-battle-droid revealed card should not remain in Reserve Deck; zone=" + junk.getZone(),
+                junk.getZone() == Zone.RESERVE_DECK || junk.getZone() == Zone.TOP_OF_RESERVE_DECK);
+        assertFalse("Deployed battle droid should not remain in Reserve Deck; zone=" + bd1.getZone(),
+                bd1.getZone() == Zone.RESERVE_DECK || bd1.getZone() == Zone.TOP_OF_RESERVE_DECK);
+        assertFalse("Battle droid should not be left in hand; zone=" + bd1.getZone(), bd1.getZone() == Zone.HAND);
+    }
+
+    @Test
+    public void ThreeB3TwentyOneXLimitedByForceAndReserveSize() {
+        var scn = GetScenario();
+
+        var luke = scn.GetLSCard("luke");
+        var lsHallway = scn.GetLSCard("ls_hallway");
+
+        var threeb3 = scn.GetDSCard("threeb3");
+        var bd1 = scn.GetDSCard("bd1");
+        var bd2 = scn.GetDSCard("bd2");
+
+        scn.StartGame();
+        scn.MoveLocationToTable(lsHallway);
+        scn.MoveCardsToLocation(lsHallway, luke, threeb3);
+
+        scn.SkipToLSTurn(Phase.BATTLE);
+        scn.MoveCardsToTopOfOwnReserveDeck(bd2, bd1);
+        // Leave only bd1+bd2 in Reserve Deck
+        var toClear = new java.util.ArrayList<>(scn.GetDSReserveDeck());
+        for (var card : toClear) {
+            if (card != bd1 && card != bd2) {
+                scn.MoveCardsToTopOfDSUsedPile((com.gempukku.swccgo.game.PhysicalCardImpl) card);
+            }
+        }
+        scn.MoveCardsToTopOfOwnReserveDeck(bd2, bd1);
+        assertEquals(2, scn.GetDSReserveDeckCount());
+
+        scn.LSInitiateBattle(lsHallway);
+        assertTrue(scn.DSCardActionAvailable(threeb3, "Reveal"));
+        scn.DSUseCardAction(threeb3, "Reveal");
+
+        assertTrue(scn.DSDecisionAvailable("Choose amount of Force to use"));
+        String[] max = scn.GetADParam(scn.DS, "max");
+        assertTrue("Expected max param; decision=" + decisionText(scn), max != null && max.length > 0);
+        assertEquals("X max should be limited by remaining Reserve Deck size", "2", max[0]);
+        scn.DSDecided(2);
+        scn.PassAllResponses();
+        resolveUntilIdle(scn, 40);
+    }
+
+    private static void resolveUntilIdle(VirtualTableScenario scn, int maxSteps) {
+        for (int i = 0; i < maxSteps; i++) {
+            if (!scn.DSAnyDecisionsAvailable() && !scn.LSAnyDecisionsAvailable()) {
+                break;
+            }
+            String player = scn.GetDecidingPlayer();
+            var decision = scn.GetAwaitingDecision(player);
+            if (decision == null) {
+                break;
+            }
+            String text = decision.getText() == null ? "" : decision.getText().toLowerCase();
+
+            if (text.contains("optional response")) {
+                scn.PlayerPass(player);
+                continue;
+            }
+
+            String[] cardIds = scn.GetADParam(player, "cardId");
+            String[] selectable = scn.GetADParam(player, "selectable");
+            String[] actionIds = scn.GetADParam(player, "actionId");
+            if (actionIds != null && actionIds.length > 0) {
+                String[] actionTexts = scn.GetADParam(player, "actionText");
+                if (actionTexts != null) {
+                    boolean passed = false;
+                    for (int a = 0; a < actionTexts.length; a++) {
+                        if (actionTexts[a] != null && actionTexts[a].toLowerCase().contains("pass")) {
+                            scn.PlayerDecided(player, actionIds[a]);
+                            passed = true;
+                            break;
+                        }
+                    }
+                    if (!passed) {
+                        scn.PlayerPass(player);
+                    }
+                } else {
+                    scn.PlayerPass(player);
+                }
+                continue;
+            }
+
+            if (cardIds != null && cardIds.length > 0) {
+                String pick = null;
+                if (selectable != null && selectable.length == cardIds.length) {
+                    for (int c = 0; c < cardIds.length; c++) {
+                        if ("true".equalsIgnoreCase(selectable[c])) {
+                            pick = cardIds[c];
+                            break;
+                        }
+                    }
+                    scn.PlayerDecided(player, pick == null ? "" : pick);
+                } else {
+                    scn.PlayerDecided(player, cardIds[0]);
+                }
+                continue;
+            }
+
+            String[] results = scn.GetADParam(player, "results");
+            if (results != null && results.length > 0) {
+                scn.PlayerDecided(player, "0");
+                continue;
+            }
+
+            String[] max = scn.GetADParam(player, "max");
+            if (max != null && max.length > 0) {
+                scn.PlayerDecided(player, max[0]);
+                continue;
+            }
+
+            scn.PlayerPass(player);
+        }
+    }
+
+    private static String normalizeBp(String bp) {
+        if (bp == null || !bp.contains("_")) {
+            return bp;
+        }
+        String[] parts = bp.split("_", 2);
+        try {
+            return parts[0] + "_" + Integer.parseInt(parts[1]);
+        } catch (NumberFormatException e) {
+            return bp;
+        }
+    }
+
+    private static String decisionText(VirtualTableScenario scn) {
+        var d = scn.GetCurrentDecision();
+        return d == null ? "null" : d.getText();
+    }
+}
+


### PR DESCRIPTION
## Summary
Implements **Theed Palace 14_71 •3B3-21** (Dark Character / Battle Droid).

Game text: If opponent just initiated a battle at same site, may use X Force to reveal the top X cards of your Reserve Deck (maximum 4). Any battle droids revealed this way may deploy for free; all other cards are lost.

## What changed
- New `Card14_071` optional-after trigger (same-site opponent battle init)
- Reuses shared Panic/ED helper `DeployCardsFromReserveDeckAndLoseTheRestEffect` (no parallel helper)
- Adds specific-card `DeployCardFromReserveDeckEffect` overload used by that helper
- Blueprint DB entries for `14_71`
- VHD `Card_14_71_Tests` (method names start with card title)

## Card_14_71_Tests (4/4)
1. ThreeB3TwentyOneStatsAndKeywordsAreCorrect
2. ThreeB3TwentyOneNotAvailableIfYouInitiateBattle
3. ThreeB3TwentyOneRevealsDeploysBattleDroidsAndLosesRestWhenOpponentInitiates
4. ThreeB3TwentyOneXLimitedByForceAndReserveSize

Maven: Tests run: 4, Failures: 0, Errors: 0, Skipped: 0

## Notes
- Independent PR vs master; includes the shared helper also landed on Panic/ED #1061 so this branch is self-contained until that merges
- Unusual battle init / Alpha3 #1060 not required (normal same-site battle init)
- Overlay: 17001 only

Closes #171