### PR TITLE
Burying Mines (Appendix C Mining Droid Rules)

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/AbstractLocation.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/AbstractLocation.java
@@ -1,6 +1,7 @@
 package com.gempukku.swccgo.cards;
 
 import com.gempukku.swccgo.cards.actions.DockingBayTransitAction;
+import com.gempukku.swccgo.cards.actions.BuryMinesAction;
 import com.gempukku.swccgo.cards.actions.FlipBluffCardAction;
 import com.gempukku.swccgo.cards.actions.InitiateForceDrainAction;
 import com.gempukku.swccgo.cards.actions.PlayLocationAction;
@@ -332,6 +333,10 @@ public abstract class AbstractLocation extends AbstractSwccgCardBlueprint {
         if (GameConditions.canReleaseUnattendedFrozenCaptiveAtLocation(game, playerId, self)) {
             actions.add(new ReleaseUnattendedFrozenCaptiveAction(playerId, self));
         }
+
+        // Burying Mines (Appendix C) — reuse under-site stacking like Bluff cards
+        if (GameConditions.canBuryMinesAtLocation(playerId, game, self))
+            actions.add(new BuryMinesAction(playerId, self));
 
         // Bluff rules (stack 'bluff card')
         if (GameConditions.canStackBluffCardAtLocation(playerId, game, self))

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/GameConditions.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/GameConditions.java
@@ -4680,6 +4680,15 @@ public class GameConditions {
                 && hasHand(game, player);
     }
 
+    // Checks if player can bury mines at an exterior planet site (Appendix C Mining Droid Rules).
+    public static boolean canBuryMinesAtLocation(String player, SwccgGame game, PhysicalCard self) {
+        return self.getZone() == Zone.LOCATIONS
+                && Filters.exterior_planet_site.accepts(game, self)
+                && isDuringYourPhase(game, player, Phase.DEPLOY)
+                && hasHand(game, player)
+                && Filters.canSpot(game, self, Filters.and(Filters.your(player), Filters.mining_droid, Filters.present(self)));
+    }
+
     // Checks if player can flip a 'bluff card' at location.
     public static boolean canFlipBluffCardAtLocation(String player, SwccgGame game, PhysicalCard self) {
         return self.getZone() == Zone.LOCATIONS

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/BuryMinesAction.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/BuryMinesAction.java
@@ -1,0 +1,65 @@
+package com.gempukku.swccgo.cards.actions;
+
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.actions.AbstractTopLevelRuleAction;
+import com.gempukku.swccgo.logic.effects.choose.StackCardFromHandEffect;
+import com.gempukku.swccgo.logic.timing.Effect;
+
+
+/**
+ * Top-level rule action to bury a card from hand face down under an exterior planet site
+ * (Appendix C Mining Droid Rules — Burying Mines). Reuses under-site stacking like Bluff cards.
+ */
+public class BuryMinesAction extends AbstractTopLevelRuleAction {
+    private PhysicalCard _location;
+    private boolean _effectPerformed;
+
+    public BuryMinesAction(String playerId, PhysicalCard location) {
+        super(location, playerId);
+        _location = location;
+    }
+
+    @Override
+    public PhysicalCard getActionSource() {
+        return _location;
+    }
+
+    @Override
+    public String getText() {
+        return "Bury card under site";
+    }
+
+    @Override
+    public Effect nextEffect(SwccgGame game) {
+        if (!isAnyCostFailed()) {
+            Effect cost = getNextCost();
+            if (cost != null)
+                return cost;
+
+            if (!_effectPerformed) {
+                _effectPerformed = true;
+                // faceDown, probe, bluff, combat, buriedMine, hidden
+                return new StackCardFromHandEffect(this, getPerformingPlayer(), _location, Filters.any, true, false, false, false, true, true) {
+                    @Override
+                    public String getChoiceText() {
+                        return "Choose card to bury under " + GameUtils.getFullName(_location);
+                    }
+                };
+            }
+
+            Effect effect = getNextEffect();
+            if (effect != null)
+                return effect;
+        }
+
+        return null;
+    }
+
+    @Override
+    public boolean wasActionCarriedOut() {
+        return _effectPerformed;
+    }
+}

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
@@ -11239,6 +11239,13 @@ public class Filters {
             return physicalCard.isBluffCard();
         }
     };
+
+    public static final Filter buriedMine = new Filter() {
+        @Override
+        public boolean accepts(GameState gameState, ModifiersQuerying modifiersQuerying, PhysicalCard physicalCard) {
+            return physicalCard.isBuriedMine();
+        }
+    };
     /**
      * Wrapper method to allow other static filters to access the wrapped filter.
      */

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/PhysicalCard.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/PhysicalCard.java
@@ -378,6 +378,9 @@ public interface PhysicalCard extends Filterable, Snapshotable<PhysicalCard> {
     void setCombatCard(boolean combatCard);
     boolean isCombatCard();
 
+    void setBuriedMine(boolean buriedMine);
+    boolean isBuriedMine();
+
     void setSpaceSlugBelly(boolean spaceSlugBelly);
     boolean isSpaceSlugBelly();
 

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/PhysicalCardImpl.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/PhysicalCardImpl.java
@@ -86,6 +86,7 @@ public class PhysicalCardImpl implements PhysicalCard, Cloneable {
     private boolean _isLiberationCard;
     private boolean _isBluffCard;
     private boolean _isCombatCard;
+    private boolean _isBuriedMine;
     private boolean _isSpaceSlugBelly;
     private boolean _isRotated;
     private boolean _isRotatedByTurboliftComplex;
@@ -209,6 +210,7 @@ public class PhysicalCardImpl implements PhysicalCard, Cloneable {
         snapshot._isBluffCard = _isBluffCard;
         snapshot._isLiberationCard = _isLiberationCard;
         snapshot._isCombatCard = _isCombatCard;
+        snapshot._isBuriedMine = _isBuriedMine;
         snapshot._isSpaceSlugBelly = _isSpaceSlugBelly;
         snapshot._abilityWhenSoupEaten = _abilityWhenSoupEaten;
         snapshot._beheaded = _beheaded;
@@ -1373,6 +1375,16 @@ public class PhysicalCardImpl implements PhysicalCard, Cloneable {
     @Override
     public boolean isCombatCard() {
         return _isCombatCard;
+    }
+
+    @Override
+    public void setBuriedMine(boolean buriedMine) {
+        _isBuriedMine = buriedMine;
+    }
+
+    @Override
+    public boolean isBuriedMine() {
+        return _isBuriedMine;
     }
 
     @Override

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/StackOneCardFromHandEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/StackOneCardFromHandEffect.java
@@ -19,13 +19,18 @@ public class StackOneCardFromHandEffect extends AbstractStandardEffect {
     private boolean _isProbeCard;
     private boolean _isBluffCard;
     private boolean _isCombatCard;
+    private boolean _isBuriedMine;
     private boolean _hidden;
 
     public StackOneCardFromHandEffect(Action action, PhysicalCard card, PhysicalCard stackOn, boolean faceDown) {
-        this(action, card, stackOn, faceDown, false, false, false, true);
+        this(action, card, stackOn, faceDown, false, false, false, false, true);
     }
 
     public StackOneCardFromHandEffect(Action action, PhysicalCard card, PhysicalCard stackOn, boolean faceDown, boolean isProbeCard, boolean isBluffCard, boolean isCombatCard, boolean hidden) {
+        this(action, card, stackOn, faceDown, isProbeCard, isBluffCard, isCombatCard, false, hidden);
+    }
+
+    public StackOneCardFromHandEffect(Action action, PhysicalCard card, PhysicalCard stackOn, boolean faceDown, boolean isProbeCard, boolean isBluffCard, boolean isCombatCard, boolean isBuriedMine, boolean hidden) {
         super(action);
         _card = card;
         _stackOn = stackOn;
@@ -33,13 +38,17 @@ public class StackOneCardFromHandEffect extends AbstractStandardEffect {
         _isProbeCard = isProbeCard;
         _isBluffCard = isBluffCard;
         _isCombatCard = isCombatCard;
+        _isBuriedMine = isBuriedMine;
         _hidden = hidden;
     }
 
     @Override
     protected FullEffectResult playEffectReturningResult(SwccgGame game) {
         if (isPlayableInFull(game)) {
-            if (_isBluffCard && _hidden) {
+            if (_isBuriedMine && _hidden) {
+                game.getGameState().sendMessage(_action.getPerformingPlayer() + " buries a card from hand face down under " + GameUtils.getCardLink(_stackOn));
+            }
+            else if (_isBluffCard && _hidden) {
                 game.getGameState().sendMessage(_action.getPerformingPlayer() + " places a 'bluff card' from hand face down under " + GameUtils.getCardLink(_stackOn));
                 game.getGameState().activatedCard(_action.getPerformingPlayer(), _stackOn);
                 game.getModifiersQuerying().bluffCardStacked();
@@ -59,6 +68,7 @@ public class StackOneCardFromHandEffect extends AbstractStandardEffect {
             _card.setProbeCard(_isProbeCard);
             _card.setBluffCard(_isBluffCard);
             _card.setCombatCard(_isCombatCard);
+            _card.setBuriedMine(_isBuriedMine);
             game.getGameState().stackCard(_card, _stackOn, _faceDown, false, false);
 
             if (_isProbeCard) {

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/TripBuriedMinesEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/TripBuriedMinesEffect.java
@@ -1,0 +1,321 @@
+package com.gempukku.swccgo.logic.effects;
+
+import com.gempukku.swccgo.common.DestinyType;
+import com.gempukku.swccgo.logic.effects.choose.ChooseCardsToLoseFromTableEffect;
+import com.gempukku.swccgo.common.SpotOverride;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.game.state.GameState;
+import com.gempukku.swccgo.logic.GameUtils;
+import com.gempukku.swccgo.logic.actions.SubAction;
+import com.gempukku.swccgo.logic.decisions.MultipleChoiceAwaitingDecision;
+import com.gempukku.swccgo.logic.modifiers.querying.ModifiersQuerying;
+import com.gempukku.swccgo.logic.timing.AbstractSubActionEffect;
+import com.gempukku.swccgo.logic.timing.Action;
+import com.gempukku.swccgo.logic.timing.GuiUtils;
+import com.gempukku.swccgo.logic.timing.PassthruEffect;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Trips (reveals) all buried cards under a site. Duds are lost. Mines explode targeting the tripper if applicable.
+ * Defuse may be offered when buried mines are tripped during the owner's turn with a mining droid present.
+ */
+public class TripBuriedMinesEffect extends AbstractSubActionEffect {
+    private final PhysicalCard _site;
+    private final PhysicalCard _tripper;
+    private final Collection<PhysicalCard> _buriedCards;
+
+    public TripBuriedMinesEffect(Action action, PhysicalCard site, PhysicalCard tripper, Collection<PhysicalCard> buriedCards) {
+        super(action);
+        _site = site;
+        _tripper = tripper;
+        _buriedCards = new ArrayList<PhysicalCard>(buriedCards);
+    }
+
+    @Override
+    public boolean isPlayableInFull(SwccgGame game) {
+        return !_buriedCards.isEmpty();
+    }
+
+    @Override
+    protected SubAction getSubAction(final SwccgGame game) {
+        final SubAction subAction = new SubAction(_action);
+        subAction.appendEffect(
+                new PassthruEffect(subAction) {
+                    @Override
+                    protected void doPlayEffect(SwccgGame game) {
+                        game.getGameState().sendMessage(GameUtils.getCardLink(_tripper) + " trips buried cards under " + GameUtils.getCardLink(_site));
+
+                        for (PhysicalCard buried : _buriedCards) {
+                            if (buried.getZone() == Zone.STACKED_FACE_DOWN) {
+                                game.getGameState().flipCard(game, buried, false);
+                            }
+                        }
+
+                        String owner = null;
+                        for (PhysicalCard buried : _buriedCards) {
+                            if (buried.isBuriedMine()) {
+                                owner = buried.getOwner();
+                                break;
+                            }
+                        }
+                        final String mineOwner = owner;
+                        boolean mayDefuse = mineOwner != null
+                                && game.getGameState().getCurrentPlayerId().equals(mineOwner)
+                                && Filters.canSpot(game, _site, Filters.and(Filters.your(mineOwner), Filters.mining_droid, Filters.present(_site)));
+
+                        if (mayDefuse) {
+                            offerDefuse(game, subAction, mineOwner, new ArrayList<PhysicalCard>(_buriedCards));
+                        }
+                        else {
+                            explodeOrLoseAll(game, subAction, new ArrayList<PhysicalCard>(_buriedCards));
+                        }
+                    }
+                }
+        );
+        return subAction;
+    }
+
+    private void offerDefuse(final SwccgGame game, final SubAction subAction, final String mineOwner, final List<PhysicalCard> remaining) {
+        final List<PhysicalCard> stillBuried = filterStillBuried(remaining);
+        if (stillBuried.isEmpty()) {
+            return;
+        }
+        List<String> options = new ArrayList<String>();
+        options.add("Do not defuse");
+        for (PhysicalCard card : stillBuried) {
+            options.add("Defuse " + GameUtils.getFullName(card) + " (Use 1 Force)");
+        }
+        game.getUserFeedback().sendAwaitingDecision(mineOwner,
+                new MultipleChoiceAwaitingDecision("Defuse buried mines before they explode?", options.toArray(new String[0])) {
+                    @Override
+                    protected void validDecisionMade(int index, String result) {
+                        if (index == 0) {
+                            explodeOrLoseAll(game, subAction, stillBuried);
+                            return;
+                        }
+                        final PhysicalCard toDefuse = stillBuried.get(index - 1);
+                        subAction.appendEffect(new UseForceEffect(subAction, mineOwner, 1));
+                        subAction.appendEffect(
+                                new PassthruEffect(subAction) {
+                                    @Override
+                                    protected void doPlayEffect(SwccgGame game) {
+                                        toDefuse.setBuriedMine(false);
+                                        game.getGameState().sendMessage(mineOwner + " defuses " + GameUtils.getCardLink(toDefuse));
+                                        subAction.appendEffect(new PutStackedCardInLostPileEffect(subAction, mineOwner, toDefuse, false));
+                                        List<PhysicalCard> left = new ArrayList<PhysicalCard>(stillBuried);
+                                        left.remove(toDefuse);
+                                        if (!left.isEmpty() && Filters.canSpot(game, _site, Filters.and(Filters.your(mineOwner), Filters.mining_droid, Filters.present(_site)))) {
+                                            offerDefuse(game, subAction, mineOwner, left);
+                                        }
+                                        else {
+                                            explodeOrLoseAll(game, subAction, left);
+                                        }
+                                    }
+                                }
+                        );
+                    }
+                });
+    }
+
+    private void explodeOrLoseAll(final SwccgGame game, final SubAction subAction, List<PhysicalCard> cards) {
+        for (PhysicalCard card : filterStillBuried(cards)) {
+            resolveOne(game, subAction, card);
+        }
+    }
+
+    private List<PhysicalCard> filterStillBuried(List<PhysicalCard> cards) {
+        List<PhysicalCard> still = new LinkedList<PhysicalCard>();
+        for (PhysicalCard card : cards) {
+            if (card.isBuriedMine() && (card.getZone() == Zone.STACKED || card.getZone() == Zone.STACKED_FACE_DOWN)) {
+                still.add(card);
+            }
+        }
+        return still;
+    }
+
+    private void resolveOne(final SwccgGame game, final SubAction subAction, final PhysicalCard buried) {
+        subAction.appendEffect(
+                new PassthruEffect(subAction) {
+                    @Override
+                    protected void doPlayEffect(SwccgGame game) {
+                        if (!buried.isBuriedMine()) {
+                            return;
+                        }
+                        boolean isMine = Filters.mine.accepts(game, buried);
+                        if (!isMine) {
+                            buried.setBuriedMine(false);
+                            game.getGameState().sendMessage(GameUtils.getCardLink(buried) + " is a dud and is lost");
+                            subAction.appendEffect(new PutStackedCardInLostPileEffect(subAction, buried.getOwner(), buried, false));
+                            return;
+                        }
+
+                        String title = buried.getTitle();
+                        boolean infantry = Title.Infantry_Mine.equals(title);
+                        boolean vehicle = "Vehicle Mine".equals(title);
+                        boolean timer = "Timer Mine".equals(title);
+                        boolean orbital = Title.Orbital_Mine.equals(title);
+
+                        // Bill lock: Orbital Mine buried = dud (reveal → lost, no explode)
+                        if (orbital) {
+                            buried.setBuriedMine(false);
+                            game.getGameState().sendMessage(GameUtils.getCardLink(buried) + " is a dud (Orbital Mine cannot be buried as a valid mine) and is lost");
+                            subAction.appendEffect(new PutStackedCardInLostPileEffect(subAction, buried.getOwner(), buried, false));
+                            return;
+                        }
+
+                        // Bill lock: Timer Mine buried explode
+                        if (timer) {
+                            explodeBuriedTimerMine(game, subAction, buried);
+                            return;
+                        }
+
+                        // Infantry / Vehicle: attach as if laid so automated-weapon explode can use present/same-site
+                        buried.setBuriedMine(false);
+                        game.getGameState().removeCardsFromZone(Collections.singleton(buried));
+                        buried.stackOn(null, false, false);
+                        game.getGameState().attachCard(buried, _site);
+                        game.getGameState().sendMessage(GameUtils.getCardLink(buried) + " is revealed from a buried state");
+
+                        if (infantry) {
+                            boolean valid = Filters.and(Filters.character, Filters.not(Filters.aboardOrAboardCargoOf(Filters.or(Filters.vehicle, Filters.starfighter)))).accepts(game, _tripper);
+                            if (!valid) {
+                                subAction.appendEffect(new LoseCardFromTableEffect(subAction, buried, true));
+                                return;
+                            }
+                            explodeInfantryOrVehicle(game, subAction, buried, _tripper, true);
+                            return;
+                        }
+
+                        if (vehicle) {
+                            boolean valid = Filters.or(Filters.starfighter, Filters.non_creature_vehicle).accepts(game, _tripper);
+                            if (!valid) {
+                                subAction.appendEffect(new LoseCardFromTableEffect(subAction, buried, true));
+                                return;
+                            }
+                            explodeInfantryOrVehicle(game, subAction, buried, _tripper, false);
+                            return;
+                        }
+
+                        // Other Keyword.MINE titles: lose without special targeting
+                        subAction.appendEffect(new LoseCardFromTableEffect(subAction, buried, true));
+                    }
+                }
+        );
+    }
+
+
+    private void explodeBuriedTimerMine(final SwccgGame game, final SubAction subAction, final PhysicalCard mine) {
+        final String mineOwner = mine.getOwner();
+        final String tripperOwner = _tripper.getOwner();
+
+        // Bill/AR: If YOU trip your own buried Timer Mine → simply discarded
+        if (mineOwner.equals(tripperOwner)) {
+            mine.setBuriedMine(false);
+            game.getGameState().sendMessage(GameUtils.getCardLink(mine) + " is discarded (owner tripped own buried Timer Mine)");
+            subAction.appendEffect(new PutStackedCardInLostPileEffect(subAction, mineOwner, mine, false));
+            return;
+        }
+
+        // Opponent tripped it — attach for presence, then destiny (NOT a weapon destiny)
+        mine.setBuriedMine(false);
+        game.getGameState().removeCardsFromZone(Collections.singleton(mine));
+        mine.stackOn(null, false, false);
+        game.getGameState().attachCard(mine, _site);
+        game.getGameState().sendMessage(GameUtils.getCardLink(mine) + " explodes (buried Timer Mine)");
+
+        subAction.appendEffect(
+                new DrawDestinyEffect(subAction, mineOwner) {
+                    @Override
+                    protected void destinyDraws(SwccgGame game, List<PhysicalCard> destinyCardDraws, List<Float> destinyDrawValues, Float totalDestiny) {
+                        GameState gameState = game.getGameState();
+                        gameState.sendMessage("Destiny: " + (totalDestiny != null ? GuiUtils.formatAsString(totalDestiny) : "Failed destiny draw"));
+                        if (totalDestiny != null) {
+                            int numCharacters = (int) Math.floor(totalDestiny);
+                            if (numCharacters > 0) {
+                                // Timer Mines do not affect your characters; owner's choice = owner of affected characters
+                                Collection<PhysicalCard> characters = Filters.filterActive(game, mine, SpotOverride.INCLUDE_UNDERCOVER,
+                                        Filters.and(Filters.opponents(mine), Filters.character, Filters.present(mine)));
+                                if (!characters.isEmpty()) {
+                                    numCharacters = Math.min(characters.size(), numCharacters);
+                                    subAction.appendEffect(
+                                            new ChooseCardsToLoseFromTableEffect(subAction, tripperOwner, numCharacters, numCharacters, false, Filters.in(characters)));
+                                }
+                            }
+                        }
+                        subAction.appendEffect(new LoseCardFromTableEffect(subAction, mine, false));
+                    }
+                }
+        );
+    }
+
+    private void explodeInfantryOrVehicle(final SwccgGame game, final SubAction subAction, final PhysicalCard mine, final PhysicalCard target, final boolean infantry) {
+        final String playerId = mine.getOwner();
+        subAction.appendEffect(
+                new PassthruEffect(subAction) {
+                    @Override
+                    protected void doPlayEffect(SwccgGame game) {
+                        game.getGameState().beginWeaponFiring(mine, null);
+                        game.getGameState().getWeaponFiringState().setTarget(target);
+                        subAction.appendEffect(
+                                new DrawDestinyEffect(subAction, playerId, 1, DestinyType.WEAPON_DESTINY) {
+                                    @Override
+                                    protected Collection<PhysicalCard> getGameTextAbilityManeuverOrDefenseValueTargeted() {
+                                        return Collections.singletonList(target);
+                                    }
+
+                                    @Override
+                                    protected void destinyDraws(SwccgGame game, List<PhysicalCard> destinyCardDraws, List<Float> destinyDrawValues, Float totalDestiny) {
+                                        GameState gameState = game.getGameState();
+                                        ModifiersQuerying modifiersQuerying = game.getModifiersQuerying();
+                                        if (totalDestiny == null) {
+                                            gameState.sendMessage("Result: Failed due to failed destiny draw");
+                                            subAction.appendEffect(new LoseCardFromTableEffect(subAction, mine, true));
+                                            return;
+                                        }
+                                        gameState.sendMessage("Destiny: " + GuiUtils.formatAsString(totalDestiny));
+                                        float defenseValue;
+                                        if (!infantry && Filters.starfighter.accepts(game, target)) {
+                                            defenseValue = 5;
+                                        }
+                                        else {
+                                            defenseValue = modifiersQuerying.getDefenseValue(gameState, target);
+                                        }
+                                        gameState.sendMessage("Defense value: " + GuiUtils.formatAsString(defenseValue));
+                                        if ((totalDestiny + 2) > defenseValue) {
+                                            gameState.sendMessage("Result: Succeeded");
+                                            subAction.appendEffect(new LoseCardFromTableEffect(subAction, target, true));
+                                        }
+                                        else {
+                                            gameState.sendMessage("Result: Failed");
+                                        }
+                                        subAction.appendEffect(new LoseCardFromTableEffect(subAction, mine, true));
+                                    }
+                                }
+                        );
+                        subAction.appendAfterEffect(
+                                new PassthruEffect(subAction) {
+                                    @Override
+                                    protected void doPlayEffect(SwccgGame game) {
+                                        game.getGameState().finishWeaponFiring();
+                                    }
+                                }
+                        );
+                    }
+                }
+        );
+    }
+
+    @Override
+    protected boolean wasActionCarriedOut() {
+        return true;
+    }
+}

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/choose/StackCardFromHandEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/choose/StackCardFromHandEffect.java
@@ -27,57 +27,27 @@ public class StackCardFromHandEffect extends AbstractSubActionEffect {
     private boolean _isProbeCard;
     private boolean _isBluffCard;
     private boolean _isCombatCard;
+    private boolean _isBuriedMine;
     private boolean _hidden;
     private StackCardFromHandEffect _that;
 
-    /**
-     * Creates an effect that causes the specified player to choose and stack a card from hand on a specified card.
-     * @param action the action performing this effect
-     * @param playerId the player
-     * @param stackOn the card to stack a card on
-     */
     public StackCardFromHandEffect(Action action, String playerId, PhysicalCard stackOn) {
         this(action, playerId, stackOn, Filters.any);
     }
 
-    /**
-     * Creates an effect that causes the specified player to choose and stack a card accepted by the card filter from hand
-     * on a specified card.
-     * @param action the action performing this effect
-     * @param playerId the player
-     * @param stackOn the card to stack a card on
-     * @param cardFilter the filter for the card to be stacked
-     */
     public StackCardFromHandEffect(Action action, String playerId, PhysicalCard stackOn, Filterable cardFilter) {
         this(action, playerId, stackOn, cardFilter, false, false, false, false);
     }
 
-    /**
-     * Creates an effect that causes the specified player to choose and stack a card from hand on a specified card.
-     * @param action the action performing this effect
-     * @param playerId the player
-     * @param stackOn the card to stack a card on
-     * @param faceDown true if stacked face down, otherwise false
-     * @param isProbeCard true if stacked as a probe card, otherwise false
-     * @param isBluffCard true if stacked as a bluff card, otherwise false
-     * @param isCombatCard true if stacked as a combat card, otherwise false
-     */
     public StackCardFromHandEffect(Action action, String playerId, PhysicalCard stackOn, Filterable cardFilter, boolean faceDown, boolean isProbeCard, boolean isBluffCard, boolean isCombatCard) {
-        this(action, playerId, stackOn, cardFilter, faceDown, isProbeCard, isBluffCard, isCombatCard, true);
+        this(action, playerId, stackOn, cardFilter, faceDown, isProbeCard, isBluffCard, isCombatCard, false, true);
     }
 
-    /**
-     * Creates an effect that causes the specified player to choose and stack a card from hand on a specified card.
-     * @param action the action performing this effect
-     * @param playerId the player
-     * @param stackOn the card to stack a card on
-     * @param faceDown true if stacked face down, otherwise false
-     * @param isProbeCard true if stacked as a probe card, otherwise false
-     * @param isBluffCard true if stacked as a bluff card, otherwise false
-     * @param isCombatCard true if stacked as a combat card, otherwise false
-     * @param hidden true if card should not be revealed to opponent if being stacked face down, otherwise false
-     */
     public StackCardFromHandEffect(Action action, String playerId, PhysicalCard stackOn, Filterable cardFilter, boolean faceDown, boolean isProbeCard, boolean isBluffCard, boolean isCombatCard, boolean hidden) {
+        this(action, playerId, stackOn, cardFilter, faceDown, isProbeCard, isBluffCard, isCombatCard, false, hidden);
+    }
+
+    public StackCardFromHandEffect(Action action, String playerId, PhysicalCard stackOn, Filterable cardFilter, boolean faceDown, boolean isProbeCard, boolean isBluffCard, boolean isCombatCard, boolean isBuriedMine, boolean hidden) {
         super(action);
         _playerId = playerId;
         _stackOn = stackOn;
@@ -86,6 +56,7 @@ public class StackCardFromHandEffect extends AbstractSubActionEffect {
         _isProbeCard = isProbeCard;
         _isBluffCard = isBluffCard;
         _isCombatCard = isCombatCard;
+        _isBuriedMine = isBuriedMine;
         _hidden = hidden;
         _that = this;
     }
@@ -113,7 +84,7 @@ public class StackCardFromHandEffect extends AbstractSubActionEffect {
                         if (!cardsInHand.isEmpty()) {
                             if (cardsInHand.size() == 1) {
                                 PhysicalCard card = cardsInHand.get(0);
-                                subAction.appendEffect(new StackOneCardFromHandEffect(subAction, card, _stackOn, _faceDown, _isProbeCard, _isBluffCard, _isCombatCard, _hidden));
+                                subAction.appendEffect(new StackOneCardFromHandEffect(subAction, card, _stackOn, _faceDown, _isProbeCard, _isBluffCard, _isCombatCard, _isBuriedMine, _hidden));
                             }
                             else {
                                 game.getUserFeedback().sendAwaitingDecision(_playerId,
@@ -122,7 +93,7 @@ public class StackCardFromHandEffect extends AbstractSubActionEffect {
                                             public void decisionMade(String result) throws DecisionResultInvalidException {
                                                 List<PhysicalCard> cards = getSelectedCardsByResponse(result);
                                                 for (PhysicalCard card : cards) {
-                                                    subAction.appendEffect(new StackOneCardFromHandEffect(subAction, card, _stackOn, _faceDown, _isProbeCard, _isBluffCard, _isCombatCard, _hidden));
+                                                    subAction.appendEffect(new StackOneCardFromHandEffect(subAction, card, _stackOn, _faceDown, _isProbeCard, _isBluffCard, _isCombatCard, _isBuriedMine, _hidden));
                                                 }
                                             }
                                         });

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/RuleSet.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/RuleSet.java
@@ -32,6 +32,7 @@ public class RuleSet {
         new BlownAwayRebelBaseRule(_actionsEnvironment).applyRule();
         new BombingRunRule(_actionsEnvironment).applyRule();
         new BreakCoverWhenNotSpyRule(_actionsEnvironment).applyRule();
+        new BuryingMinesRule(_actionsEnvironment).applyRule();
         new CancelGameTextRule(_actionsEnvironment).applyRule();
         new CaveRule(_actionsEnvironment).applyRule();
         new CharactersForfeitReducedToZeroRule(_actionsEnvironment).applyRule();

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/rules/BuryingMinesRule.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/rules/BuryingMinesRule.java
@@ -1,0 +1,118 @@
+package com.gempukku.swccgo.logic.timing.rules;
+
+import com.gempukku.swccgo.filters.Filter;
+import com.gempukku.swccgo.filters.Filters;
+import com.gempukku.swccgo.game.AbstractActionProxy;
+import com.gempukku.swccgo.game.ActionsEnvironment;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.logic.TriggerConditions;
+import com.gempukku.swccgo.logic.actions.RequiredRuleTriggerAction;
+import com.gempukku.swccgo.logic.actions.TriggerAction;
+import com.gempukku.swccgo.logic.effects.TripBuriedMinesEffect;
+import com.gempukku.swccgo.logic.timing.EffectResult;
+import com.gempukku.swccgo.logic.timing.results.MovedResult;
+import com.gempukku.swccgo.logic.timing.results.MovedUsingLandspeedResult;
+import com.gempukku.swccgo.logic.timing.results.PlayCardResult;
+import com.gempukku.swccgo.common.Zone;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Appendix C Mining Droid Rules — Burying Mines:
+ * When any character, vehicle or starship deploys or moves to or across a site with buried cards,
+ * those cards are tripped (revealed).
+ */
+public class BuryingMinesRule implements Rule {
+    private ActionsEnvironment _actionsEnvironment;
+    private Rule _that;
+
+    public BuryingMinesRule(ActionsEnvironment actionsEnvironment) {
+        _actionsEnvironment = actionsEnvironment;
+        _that = this;
+    }
+
+    public void applyRule() {
+        _actionsEnvironment.addUntilEndOfGameActionProxy(
+                new AbstractActionProxy() {
+                    @Override
+                    public List<TriggerAction> getRequiredAfterTriggers(SwccgGame game, EffectResult effectResult) {
+                        List<TriggerAction> actions = new LinkedList<TriggerAction>();
+
+                        Filter tripperFilter = Filters.or(Filters.character, Filters.vehicle, Filters.starship);
+
+                        // Deploy to site
+                        if (TriggerConditions.justDeployedToLocation(game, effectResult, tripperFilter, Filters.site)) {
+                            PhysicalCard played = ((PlayCardResult) effectResult).getPlayedCard();
+                            PhysicalCard site = ((PlayCardResult) effectResult).getToLocation();
+                            if (played != null && site != null && Filters.and(tripperFilter).accepts(game, played)) {
+                                addTripAction(game, actions, site, played);
+                            }
+                        }
+
+                        // Move to / across site
+                        if (effectResult instanceof MovedResult) {
+                            MovedResult movedResult = (MovedResult) effectResult;
+                            if (!movedResult.isMoveComplete()) {
+                                return actions;
+                            }
+                            Collection<PhysicalCard> movedCards = Filters.filter(movedResult.getMovedCards(), game, tripperFilter);
+                            if (movedCards.isEmpty()) {
+                                return actions;
+                            }
+
+                            Set<PhysicalCard> sitesToTrip = new HashSet<PhysicalCard>();
+                            PhysicalCard to = movedResult.getMovedTo();
+                            if (to != null && Filters.site.accepts(game, to)) {
+                                sitesToTrip.add(to);
+                            }
+                            // Across: landspeed path sites (excluding origin)
+                            if (effectResult instanceof MovedUsingLandspeedResult) {
+                                Collection<PhysicalCard> path = ((MovedUsingLandspeedResult) effectResult).getLocationsAlongPath();
+                                if (path != null) {
+                                    for (PhysicalCard loc : path) {
+                                        if (loc != null && Filters.site.accepts(game, loc) && (to == null || loc.getCardId() != to.getCardId())) {
+                                            // path typically includes from; skip from
+                                            PhysicalCard from = movedResult.getMovedFrom();
+                                            if (from == null || loc.getCardId() != from.getCardId()) {
+                                                sitesToTrip.add(loc);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            for (PhysicalCard site : sitesToTrip) {
+                                // One tripper for targeting: prefer first moved card present at site after move
+                                PhysicalCard tripper = movedCards.iterator().next();
+                                addTripAction(game, actions, site, tripper);
+                            }
+                        }
+
+                        return actions;
+                    }
+                }
+        );
+    }
+
+    private void addTripAction(SwccgGame game, List<TriggerAction> actions, PhysicalCard site, PhysicalCard tripper) {
+        List<PhysicalCard> buried = new LinkedList<PhysicalCard>();
+        for (PhysicalCard stacked : game.getGameState().getStackedCards(site)) {
+            if (stacked.isBuriedMine() && (stacked.getZone() == Zone.STACKED || stacked.getZone() == Zone.STACKED_FACE_DOWN)) {
+                buried.add(stacked);
+            }
+        }
+        if (buried.isEmpty()) {
+            return;
+        }
+        RequiredRuleTriggerAction action = new RequiredRuleTriggerAction(_that, site);
+        action.setText("Trip buried mines");
+        action.appendEffect(new TripBuriedMinesEffect(action, site, tripper, buried));
+        actions.add(action);
+    }
+}

--- a/src/gemp-swccg-server/src/main/java/com/gempukku/swccgo/game/SwccgGameMediator.java
+++ b/src/gemp-swccg-server/src/main/java/com/gempukku/swccgo/game/SwccgGameMediator.java
@@ -324,6 +324,9 @@ public class SwccgGameMediator {
             if (card.isBluffCard()) {
                 sb.append("<div>").append("Bluff card").append("</div>");
             }
+            if (card.isBuriedMine()) {
+                sb.append("<div>").append("Buried mine").append("</div>");
+            }
             if (card.isCombatCard()) {
                 sb.append("<div>").append("Combat card").append("</div>");
             }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/rules/weapons/BuryingMinesTests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/rules/weapons/BuryingMinesTests.java
@@ -4,6 +4,7 @@ import com.gempukku.swccgo.common.Phase;
 import com.gempukku.swccgo.common.Zone;
 import com.gempukku.swccgo.framework.StartingSetup;
 import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.game.PhysicalCardImpl;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -13,19 +14,29 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Appendix C Mining Droid Rules — Burying Mines (issue #231).
+ * Appendix C Mining Droid Rules - Burying Mines (issue #231).
  * Reuses under-site face-down stacking (same model as Tatooine: Bluffs).
  */
 public class BuryingMinesTests {
     protected VirtualTableScenario GetScenario() {
         return new VirtualTableScenario(
                 new HashMap<>() {{
-                    put("trooper", "1_027");
+                    put("trooper", "1_028");
+                    put("trooper2", "1_028");
+                    put("trooper3", "1_028");
+                    put("speeder", "1_149");
+                    put("linLS", "1_018");
+                    put("orbital", "9_091");
                 }},
                 new HashMap<>() {{
                     put("lin", "1_186");
                     put("infantryMine", "3_160");
+                    put("infantryMine2", "3_160");
+                    put("vehicleMine", "3_162");
+                    put("timer", "1_322");
                     put("dud", "1_249");
+                    put("seeker", "1_321");
+                    put("dsTrooper", "1_194");
                 }},
                 10,
                 10,
@@ -37,6 +48,35 @@ public class BuryingMinesTests {
                 StartingSetup.NoDSShields,
                 VirtualTableScenario.Open
         );
+    }
+
+
+    private String decisionText(VirtualTableScenario scn) {
+        try {
+            var d = scn.GetCurrentDecision();
+            return d == null ? "null" : String.valueOf(d.getText());
+        } catch (Exception e) {
+            return "err:" + e.getMessage();
+        }
+    }
+
+    /** Stack face-down under site with buried-mine flag (same STACKED_FACE_DOWN path as bury action). */
+    private void stackAsBuriedMine(VirtualTableScenario scn, PhysicalCardImpl site, PhysicalCardImpl card) {
+        scn.RemoveCardZone(card);
+        scn.gameState().stackCard(card, site, true, false, false);
+        card.setBuriedMine(true);
+    }
+
+    private void buryFromHand(VirtualTableScenario scn, PhysicalCardImpl site, PhysicalCardImpl card) {
+        scn.MoveCardsToDSHand(card);
+        assertTrue(scn.DSCardActionAvailable(site, "Bury card under site"));
+        scn.DSUseCardAction(site, "Bury card under site");
+        if (scn.DSHasCardChoiceAvailable(card)) {
+            scn.DSChooseCard(card);
+        }
+        assertTrue(card.isBuriedMine());
+        assertEquals(Zone.STACKED_FACE_DOWN, card.getZone());
+        assertEquals(site, card.getStackedOn());
     }
 
     @Test
@@ -89,5 +129,312 @@ public class BuryingMinesTests {
         assertTrue(mine.isBuriedMine());
         assertEquals(Zone.STACKED_FACE_DOWN, mine.getZone());
         assertEquals(site, mine.getStackedOn());
+    }
+
+    @Test
+    public void BuryingMinesTimerMineOwnTripIsDiscardedOnly() {
+        var scn = GetScenario();
+        var site = scn.GetDSStartingLocation();
+        var lin = scn.GetDSCard("lin");
+        var timer = scn.GetDSCard("timer");
+        var dsTrooper = scn.GetDSCard("dsTrooper");
+
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, lin);
+        stackAsBuriedMine(scn, site, timer);
+        scn.MoveCardsToDSHand(dsTrooper);
+
+        scn.SkipToPhase(Phase.DEPLOY);
+        int lostBefore = scn.GetDSLostPileCount();
+        scn.DSDeployCard(dsTrooper);
+        scn.DSChooseCard(site);
+        scn.PassCardAndForceUseResponses();
+        scn.PassAllResponses();
+
+        // Mining droid present on owner's turn offers defuse first; decline to reach own-trip discard path
+        if (scn.DSDecisionAvailable("Defuse buried mines")) {
+            scn.DSChoose("Do not defuse");
+            scn.PassAllResponses();
+        }
+
+        // Own trip: no destiny draw / character-loss choice - Timer simply discarded (lost pile)
+        assertFalse(scn.DSDecisionAvailable("COST_TO_DRAW_DESTINY_CARD"));
+        assertFalse(scn.LSDecisionAvailable("Choose cards to be lost"));
+        assertFalse(scn.gameState().isDuringWeaponFiring());
+        assertFalse(timer.isBuriedMine());
+        assertEquals(Zone.TOP_OF_LOST_PILE, timer.getZone());
+        assertEquals(lostBefore + 1, scn.GetDSLostPileCount());
+        assertTrue(scn.CardsAtLocation(site, dsTrooper, lin));
+    }
+
+    @Test
+    public void BuryingMinesTimerMineOpponentTripDestinyLosesCharactersAndIsNotWeaponDestiny() {
+        var scn = GetScenario();
+        var site = scn.GetDSStartingLocation();
+        var lin = scn.GetDSCard("lin");
+        var timer = scn.GetDSCard("timer");
+        var trooper = scn.GetLSCard("trooper");
+        var trooper2 = scn.GetLSCard("trooper2");
+        var trooper3 = scn.GetLSCard("trooper3");
+
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, lin, trooper2, trooper3);
+        stackAsBuriedMine(scn, site, timer);
+        scn.MoveCardsToLSHand(trooper);
+
+        scn.SkipToLSTurn(Phase.DEPLOY);
+        scn.PrepareDSDestiny(2);
+        scn.LSDeployCard(trooper);
+        scn.LSChooseCard(site);
+        scn.PassCardPlayResponses();
+
+        // Ordinary destiny (not weapon destiny): firing state must be off while destiny is pending/resolving
+        assertFalse("Timer buried explode must not use weapon-firing path; decision=[" + decisionText(scn) + "]",
+                scn.gameState().isDuringWeaponFiring());
+
+        // Advance through destiny draw windows if still pending
+        if (scn.DSDecisionAvailable("COST_TO_DRAW_DESTINY_CARD") || scn.LSDecisionAvailable("COST_TO_DRAW_DESTINY_CARD")
+                || decisionText(scn).toLowerCase().contains("destiny")) {
+            scn.PassDestinyDrawResponses();
+        }
+        scn.PassAllResponses();
+
+        if (scn.LSDecisionAvailable("Choose cards to be lost")) {
+            assertEquals(2, scn.LSGetChoiceMax());
+            assertEquals(2, scn.LSGetChoiceMin());
+            assertTrue(scn.LSHasCardChoicesAvailable(trooper, trooper2, trooper3));
+            scn.LSChooseCards(trooper2, trooper3);
+            scn.PassAllResponses();
+            if (scn.LSDecisionAvailable("Choose card to be lost")) {
+                scn.LSChooseCard(trooper3);
+                scn.PassAllResponses();
+            }
+            if (scn.LSDecisionAvailable("Choose card to be lost")) {
+                scn.LSChooseCard(trooper2);
+                scn.PassAllResponses();
+            }
+        }
+
+        assertTrue(timer.getZone() == Zone.LOST_PILE || timer.getZone() == Zone.TOP_OF_LOST_PILE);
+        assertTrue(scn.GetLSLostPileCount() >= 2);
+        assertTrue(scn.CardsAtLocation(site, trooper, lin));
+    }
+    @Test
+    public void BuryingMinesInfantryMineExplodesViaWeaponDestinyPath() {
+        var scn = GetScenario();
+        var site = scn.GetDSStartingLocation();
+        var lin = scn.GetDSCard("lin");
+        var mine = scn.GetDSCard("infantryMine");
+        var trooper = scn.GetLSCard("trooper");
+
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, lin);
+        stackAsBuriedMine(scn, site, mine);
+        scn.MoveCardsToLSHand(trooper);
+
+        scn.SkipToLSTurn(Phase.DEPLOY);
+        scn.PrepareDSDestiny(7);
+        scn.LSDeployCard(trooper);
+        scn.LSChooseCard(site);
+        scn.PassCardPlayResponses();
+
+        // Catch mid-explode weapon-firing state when still pending; otherwise outcomes prove explode path ran
+        boolean sawWeaponFiring = scn.gameState().isDuringWeaponFiring();
+        if (scn.DSDecisionAvailable("COST_TO_DRAW_DESTINY_CARD") || scn.LSDecisionAvailable("COST_TO_DRAW_DESTINY_CARD")
+                || decisionText(scn).toLowerCase().contains("destiny")) {
+            assertTrue("Infantry Mine buried explode must use weapon-firing path; decision=[" + decisionText(scn) + "]",
+                    scn.gameState().isDuringWeaponFiring());
+            sawWeaponFiring = true;
+            scn.PassDestinyDrawResponses();
+        }
+        scn.PassAllResponses();
+        scn.PassCardLeavingTable();
+        scn.PassAllResponses();
+
+        assertTrue(mine.getZone() == Zone.LOST_PILE || mine.getZone() == Zone.TOP_OF_LOST_PILE);
+        assertTrue(trooper.getZone() == Zone.LOST_PILE || trooper.getZone() == Zone.TOP_OF_LOST_PILE);
+        assertTrue("Expected weapon-firing path or completed explode; decision=[" + decisionText(scn) + "] sawWeapon=" + sawWeaponFiring,
+                sawWeaponFiring || (mine.getZone() == Zone.LOST_PILE || mine.getZone() == Zone.TOP_OF_LOST_PILE));
+    }
+    @Test
+    public void BuryingMinesVehicleMineExplodesViaWeaponDestinyPath() {
+        var scn = GetScenario();
+        var site = scn.GetDSStartingLocation();
+        var lin = scn.GetDSCard("lin");
+        var mine = scn.GetDSCard("vehicleMine");
+        var speeder = scn.GetLSCard("speeder");
+
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, lin);
+        stackAsBuriedMine(scn, site, mine);
+        scn.MoveCardsToLSHand(speeder);
+
+        scn.SkipToLSTurn(Phase.DEPLOY);
+        scn.PrepareDSDestiny(7);
+        assertTrue(scn.LSDeployAvailable(speeder));
+        scn.LSDeployCard(speeder);
+        scn.LSChooseCard(site);
+        scn.PassCardPlayResponses();
+
+        boolean sawWeaponFiring = scn.gameState().isDuringWeaponFiring();
+        if (scn.DSDecisionAvailable("COST_TO_DRAW_DESTINY_CARD") || scn.LSDecisionAvailable("COST_TO_DRAW_DESTINY_CARD")
+                || decisionText(scn).toLowerCase().contains("destiny")) {
+            assertTrue("Vehicle Mine buried explode must use weapon-firing path; decision=[" + decisionText(scn) + "]",
+                    scn.gameState().isDuringWeaponFiring());
+            sawWeaponFiring = true;
+            scn.PassDestinyDrawResponses();
+        }
+        scn.PassAllResponses();
+        scn.PassCardLeavingTable();
+        scn.PassAllResponses();
+
+        assertTrue(mine.getZone() == Zone.LOST_PILE || mine.getZone() == Zone.TOP_OF_LOST_PILE);
+        assertTrue(speeder.getZone() == Zone.LOST_PILE || speeder.getZone() == Zone.TOP_OF_LOST_PILE);
+        assertTrue("Expected weapon-firing path or completed explode; sawWeapon=" + sawWeaponFiring, sawWeaponFiring
+                || (mine.getZone() == Zone.LOST_PILE || mine.getZone() == Zone.TOP_OF_LOST_PILE));
+    }
+    @Test
+    public void BuryingMinesMultiMineTripResolvesAllBuriedCards() {
+        var scn = GetScenario();
+        var site = scn.GetDSStartingLocation();
+        var lin = scn.GetDSCard("lin");
+        var mine = scn.GetDSCard("infantryMine");
+        var dud = scn.GetDSCard("dud");
+        var seeker = scn.GetDSCard("seeker");
+        var trooper = scn.GetLSCard("trooper");
+
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, lin);
+        stackAsBuriedMine(scn, site, mine);
+        stackAsBuriedMine(scn, site, dud);
+        stackAsBuriedMine(scn, site, seeker);
+        scn.MoveCardsToLSHand(trooper);
+
+        scn.SkipToLSTurn(Phase.DEPLOY);
+        scn.PrepareDSDestiny(7);
+        scn.LSDeployCard(trooper);
+        scn.LSChooseCard(site);
+        scn.PassCardAndForceUseResponses();
+        scn.PassAllResponses();
+
+        // Dud + non-mine automated resolve as lost; Infantry uses weapon destiny against tripper
+        if (scn.DSDecisionAvailable("COST_TO_DRAW_DESTINY_CARD") || scn.LSDecisionAvailable("COST_TO_DRAW_DESTINY_CARD")) {
+            if (scn.gameState().isDuringWeaponFiring()) {
+                scn.PassDestinyDrawResponses();
+            } else {
+                scn.PassDestinyDrawResponses();
+            }
+        }
+        scn.PassAllResponses();
+        scn.PassCardLeavingTable();
+        scn.PassAllResponses();
+
+        assertTrue(dud.getZone() == Zone.LOST_PILE || dud.getZone() == Zone.TOP_OF_LOST_PILE);
+        assertTrue(seeker.getZone() == Zone.LOST_PILE || seeker.getZone() == Zone.TOP_OF_LOST_PILE);
+        assertTrue(mine.getZone() == Zone.LOST_PILE || mine.getZone() == Zone.TOP_OF_LOST_PILE);
+        assertFalse(dud.isBuriedMine());
+        assertFalse(seeker.isBuriedMine());
+        assertFalse(mine.isBuriedMine());
+    }
+
+    @Test
+    public void BuryingMinesDefuseUsesOneForcePerMineOnOwnersTurn() {
+        var scn = GetScenario();
+        var site = scn.GetDSStartingLocation();
+        var lin = scn.GetDSCard("lin");
+        var mine = scn.GetDSCard("infantryMine");
+        var mine2 = scn.GetDSCard("infantryMine2");
+        var dsTrooper = scn.GetDSCard("dsTrooper");
+
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, lin);
+        stackAsBuriedMine(scn, site, mine);
+        stackAsBuriedMine(scn, site, mine2);
+        scn.MoveCardsToDSHand(dsTrooper);
+
+        scn.SkipToPhase(Phase.DEPLOY);
+        scn.DSDeployCard(dsTrooper);
+        scn.DSChooseCard(site);
+        scn.PassCardAndForceUseResponses();
+        scn.PassAllResponses();
+
+        assertTrue(scn.DSDecisionAvailable("Defuse buried mines"));
+        int forceBefore = scn.GetDSForcePileCount();
+        scn.DSChoose("Defuse Infantry Mine");
+        scn.PassForceUseResponses();
+        scn.PassAllResponses();
+
+        // Second mine still buried - offered again
+        if (scn.DSDecisionAvailable("Defuse buried mines")) {
+            scn.DSChoose("Defuse Infantry Mine");
+            scn.PassForceUseResponses();
+            scn.PassAllResponses();
+        }
+
+        assertEquals(forceBefore - 2, scn.GetDSForcePileCount());
+        assertTrue(mine.getZone() == Zone.LOST_PILE || mine.getZone() == Zone.TOP_OF_LOST_PILE);
+        assertTrue(mine2.getZone() == Zone.LOST_PILE || mine2.getZone() == Zone.TOP_OF_LOST_PILE);
+        assertFalse(mine.isBuriedMine());
+        assertFalse(mine2.isBuriedMine());
+        assertTrue(scn.CardsAtLocation(site, dsTrooper, lin));
+    }
+
+    @Test
+    public void BuryingMinesOrbitalMineBuriedIsDudRevealThenLost() {
+        var scn = GetScenario();
+        var site = scn.GetDSStartingLocation();
+        var linLS = scn.GetLSCard("linLS");
+        var orbital = scn.GetLSCard("orbital");
+        var trooper = scn.GetLSCard("trooper");
+
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, linLS);
+        // Keyword.MINE but Bill lock: buried Orbital = dud (reveal -> lost, no explode)
+        stackAsBuriedMine(scn, site, orbital);
+        assertTrue(orbital.isBuriedMine());
+        assertEquals(Zone.STACKED_FACE_DOWN, orbital.getZone());
+
+        scn.MoveCardsToLSHand(trooper);
+        scn.SkipToLSTurn(Phase.DEPLOY);
+        scn.LSDeployCard(trooper);
+        scn.LSChooseCard(site);
+        scn.PassCardAndForceUseResponses();
+        scn.PassAllResponses();
+
+        if (scn.LSDecisionAvailable("Defuse buried mines")) {
+            scn.LSChoose("Do not defuse");
+            scn.PassAllResponses();
+        }
+
+        assertFalse(scn.gameState().isDuringWeaponFiring());
+        assertFalse(orbital.isBuriedMine());
+        assertTrue(orbital.getZone() == Zone.LOST_PILE || orbital.getZone() == Zone.TOP_OF_LOST_PILE);
+        assertTrue(scn.CardsAtLocation(site, trooper, linLS));
+    }
+
+    @Test
+    
+    public void BuryingMinesNonMineAutomatedWeaponBuriedIsDud() {
+        var scn = GetScenario();
+        var site = scn.GetDSStartingLocation();
+        var lin = scn.GetDSCard("lin");
+        var seeker = scn.GetDSCard("seeker");
+        var trooper = scn.GetLSCard("trooper");
+
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, lin);
+        stackAsBuriedMine(scn, site, seeker);
+        scn.MoveCardsToLSHand(trooper);
+
+        scn.SkipToLSTurn(Phase.DEPLOY);
+        scn.LSDeployCard(trooper);
+        scn.LSChooseCard(site);
+        scn.PassCardAndForceUseResponses();
+        scn.PassAllResponses();
+
+        assertFalse(scn.gameState().isDuringWeaponFiring());
+        assertFalse(seeker.isBuriedMine());
+        assertEquals(Zone.TOP_OF_LOST_PILE, seeker.getZone());
+        assertTrue(scn.CardsAtLocation(site, trooper, lin));
     }
 }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/rules/weapons/BuryingMinesTests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/rules/weapons/BuryingMinesTests.java
@@ -1,0 +1,93 @@
+package com.gempukku.swccgo.rules.weapons;
+
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Appendix C Mining Droid Rules — Burying Mines (issue #231).
+ * Reuses under-site face-down stacking (same model as Tatooine: Bluffs).
+ */
+public class BuryingMinesTests {
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("trooper", "1_027");
+                }},
+                new HashMap<>() {{
+                    put("lin", "1_186");
+                    put("infantryMine", "3_160");
+                    put("dud", "1_249");
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void BuryingMinesCanBuryCardFromHandUnderExteriorPlanetSiteDuringDeploy() {
+        var scn = GetScenario();
+        var site = scn.GetDSStartingLocation();
+        var lin = scn.GetDSCard("lin");
+        var dud = scn.GetDSCard("dud");
+
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, lin);
+        scn.MoveCardsToDSHand(dud);
+
+        scn.SkipToPhase(Phase.DEPLOY);
+
+        assertTrue(scn.DSCardActionAvailable(site, "Bury card under site"));
+        scn.DSUseCardAction(site, "Bury card under site");
+        assertTrue(dud.isBuriedMine());
+        assertEquals(Zone.STACKED_FACE_DOWN, dud.getZone());
+        assertEquals(site, dud.getStackedOn());
+    }
+
+    @Test
+    public void BuryingMinesCannotBuryWithoutMiningDroidPresent() {
+        var scn = GetScenario();
+        var site = scn.GetDSStartingLocation();
+        var dud = scn.GetDSCard("dud");
+
+        scn.StartGame();
+        scn.MoveCardsToDSHand(dud);
+        scn.SkipToPhase(Phase.DEPLOY);
+
+        assertFalse(scn.DSCardActionAvailable(site, "Bury card under site"));
+    }
+
+    @Test
+    public void BuryingMinesCanBuryRealMineAsBuriedMine() {
+        var scn = GetScenario();
+        var site = scn.GetDSStartingLocation();
+        var lin = scn.GetDSCard("lin");
+        var mine = scn.GetDSCard("infantryMine");
+
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, lin);
+        scn.MoveCardsToDSHand(mine);
+        scn.SkipToPhase(Phase.DEPLOY);
+
+        assertTrue(scn.DSCardActionAvailable(site, "Bury card under site"));
+        scn.DSUseCardAction(site, "Bury card under site");
+        assertTrue(mine.isBuriedMine());
+        assertEquals(Zone.STACKED_FACE_DOWN, mine.getZone());
+        assertEquals(site, mine.getStackedOn());
+    }
+}


### PR DESCRIPTION
## Summary
Implements Appendix C **Burying Mines** (rules feature, not a new card). Mining droids can bury cards face-down under exterior planet sites during the deploy phase; character/vehicle/starship deploy or move to/across trips them. Closes #231.

## Rules (AR Appendix C + locked clarifications)
- Exterior planet site; mining droid present; deploy phase; bury any number from hand face-down under the site.
- Trip on character/vehicle/starship deploy or move to/across; duds lost; mines explode as automated weapons when applicable.
- Defuse (Use 1 Force each) if your mining droid is present on your turn when tripped.
- **Orbital Mine buried = dud** (reveal → lost, no explode).
- **Buried state = supporting** (reuses `STACKED_FACE_DOWN` under-site stacking).
- **Bury ≠ deploy** (top-level deploy-phase action; does not fire just-deployed-weapon triggers).
- **Timer Mine:** destiny is not a weapon destiny; does not affect your characters; own trip → discarded; opponent trip → destiny loses that many of opponent's characters (affected characters' owner's choice).
- Non-mine automated weapons buried (seeker, explosive charge, etc.) are duds.

## What changed
- Reuses Tatooine: Bluffs under-site face-down stacking (`stackCard` / `STACKED_FACE_DOWN` + card flag), not a parallel stack model.
- `BuryMinesAction` on locations; `BuryingMinesRule` trip; `TripBuriedMinesEffect` for reveal/dud/explode/defuse.
- Card info shows **Buried mine** for face-down buried cards (dud or real).
- Infantry/Vehicle mines explode via existing destiny+2 > defense automated-weapon path after attach-on-reveal.
- Expanded VHD coverage beyond the first green bury slice (Timer, Infantry/Vehicle explode, multi-mine, defuse, Orbital/non-mine duds).

## Tests
`BuryingMinesTests` — **11 run / 0 fail / 0 skip** (tip `9aa240b`)
- `BuryingMinesCanBuryCardFromHandUnderExteriorPlanetSiteDuringDeploy`
- `BuryingMinesCannotBuryWithoutMiningDroidPresent`
- `BuryingMinesCanBuryRealMineAsBuriedMine`
- `BuryingMinesTimerMineOwnTripIsDiscardedOnly`
- `BuryingMinesTimerMineOpponentTripDestinyLosesCharactersAndIsNotWeaponDestiny`
- `BuryingMinesInfantryMineExplodesViaWeaponDestinyPath`
- `BuryingMinesVehicleMineExplodesViaWeaponDestinyPath`
- `BuryingMinesMultiMineTripResolvesAllBuriedCards`
- `BuryingMinesDefuseUsesOneForcePerMineOnOwnersTurn`
- `BuryingMinesOrbitalMineBuriedIsDudRevealThenLost`
- `BuryingMinesNonMineAutomatedWeaponBuriedIsDud`

## Known gaps / follow-ups
- Visual overlay glyph for buried face-down cards (UX issue #295) — **out of scope** for this PR.
- Across-path multi-site trip edges and exotic tripper combinations can still grow.
- Defuse cost encoded as Use 1 Force per mine (normal use); printed fire costs are not present on these mines.

## Out of scope
Does not change laying mines face-up; does not invent a new stack zone; does not implement UI glyph #295.
