### PR TITLE
Fix Oh, Switch Off not preventing U-3PO steal (#50)

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/dark/Card2_107.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/dark/Card2_107.java
@@ -11,6 +11,7 @@ import com.gempukku.swccgo.common.Keyword;
 import com.gempukku.swccgo.common.ModelType;
 import com.gempukku.swccgo.common.Rarity;
 import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.TargetingReason;
 import com.gempukku.swccgo.common.Uniqueness;
 import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.game.PhysicalCard;
@@ -18,12 +19,17 @@ import com.gempukku.swccgo.game.SwccgGame;
 import com.gempukku.swccgo.logic.GameUtils;
 import com.gempukku.swccgo.logic.TriggerConditions;
 import com.gempukku.swccgo.logic.actions.RequiredGameTextTriggerAction;
+import com.gempukku.swccgo.logic.actions.SubAction;
 import com.gempukku.swccgo.logic.conditions.AndCondition;
 import com.gempukku.swccgo.logic.decisions.YesNoDecision;
 import com.gempukku.swccgo.logic.effects.PlayoutDecisionEffect;
+import com.gempukku.swccgo.logic.effects.RespondableEffect;
+import com.gempukku.swccgo.logic.effects.StackActionEffect;
+import com.gempukku.swccgo.logic.effects.TargetCardOnTableEffect;
 import com.gempukku.swccgo.logic.effects.choose.StealCardToLocationEffect;
 import com.gempukku.swccgo.logic.modifiers.Modifier;
 import com.gempukku.swccgo.logic.modifiers.TotalPowerModifier;
+import com.gempukku.swccgo.logic.timing.Action;
 import com.gempukku.swccgo.logic.timing.EffectResult;
 
 import java.util.Collections;
@@ -66,6 +72,8 @@ public class Card2_107 extends AbstractDroid {
             if (!lightPlayer.equals(self.getOwner())) {
 
                 final RequiredGameTextTriggerAction action = new RequiredGameTextTriggerAction(self, gameTextSourceCardId);
+                // Light Side is the player performing the steal so responses such as Oh, Switch Off can cancel it
+                action.setPerformingPlayer(lightPlayer);
                 action.setText("Choose whether to 'steal'");
                 action.setActionMsg("Have " + lightPlayer + " choose whether to 'steal'" + GameUtils.getCardLink(self));
                 // Perform result(s)
@@ -74,8 +82,34 @@ public class Card2_107 extends AbstractDroid {
                                 new YesNoDecision("Do you want to 'steal' " + GameUtils.getCardLink(self) + "?") {
                                     @Override
                                     protected void yes() {
+                                        // Target for TO_BE_STOLEN with allowResponses so Oh, Switch Off can cancel (Caller-style)
+                                        final SubAction stealAction = new SubAction(action, lightPlayer);
+                                        stealAction.appendTargeting(
+                                                new TargetCardOnTableEffect(stealAction, lightPlayer, "Choose droid to steal", TargetingReason.TO_BE_STOLEN, self) {
+                                                    @Override
+                                                    protected void cardTargeted(final int targetGroupId, PhysicalCard targetedCard) {
+                                                        stealAction.addAnimationGroup(targetedCard);
+                                                        // Allow response(s)
+                                                        stealAction.allowResponses("Steal " + GameUtils.getCardLink(targetedCard),
+                                                                new RespondableEffect(stealAction) {
+                                                                    @Override
+                                                                    protected void performActionResults(Action targetingAction) {
+                                                                        final PhysicalCard cardToSteal = stealAction.getPrimaryTargetCard(targetGroupId);
+                                                                        // Perform result(s)
+                                                                        stealAction.appendEffect(
+                                                                                new StealCardToLocationEffect(stealAction, lightPlayer, cardToSteal));
+                                                                    }
+                                                                }
+                                                        );
+                                                    }
+                                                    @Override
+                                                    protected boolean getUseShortcut() {
+                                                        return true;
+                                                    }
+                                                }
+                                        );
                                         action.appendEffect(
-                                                new StealCardToLocationEffect(action, lightPlayer, self));
+                                                new StackActionEffect(action, stealAction));
                                     }
 
                                     @Override

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/dark/Card2_107.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/dark/Card2_107.java
@@ -11,7 +11,6 @@ import com.gempukku.swccgo.common.Keyword;
 import com.gempukku.swccgo.common.ModelType;
 import com.gempukku.swccgo.common.Rarity;
 import com.gempukku.swccgo.common.Side;
-import com.gempukku.swccgo.common.TargetingReason;
 import com.gempukku.swccgo.common.Uniqueness;
 import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.game.PhysicalCard;
@@ -19,17 +18,12 @@ import com.gempukku.swccgo.game.SwccgGame;
 import com.gempukku.swccgo.logic.GameUtils;
 import com.gempukku.swccgo.logic.TriggerConditions;
 import com.gempukku.swccgo.logic.actions.RequiredGameTextTriggerAction;
-import com.gempukku.swccgo.logic.actions.SubAction;
 import com.gempukku.swccgo.logic.conditions.AndCondition;
 import com.gempukku.swccgo.logic.decisions.YesNoDecision;
 import com.gempukku.swccgo.logic.effects.PlayoutDecisionEffect;
-import com.gempukku.swccgo.logic.effects.RespondableEffect;
-import com.gempukku.swccgo.logic.effects.StackActionEffect;
-import com.gempukku.swccgo.logic.effects.TargetCardOnTableEffect;
 import com.gempukku.swccgo.logic.effects.choose.StealCardToLocationEffect;
 import com.gempukku.swccgo.logic.modifiers.Modifier;
 import com.gempukku.swccgo.logic.modifiers.TotalPowerModifier;
-import com.gempukku.swccgo.logic.timing.Action;
 import com.gempukku.swccgo.logic.timing.EffectResult;
 
 import java.util.Collections;
@@ -72,51 +66,25 @@ public class Card2_107 extends AbstractDroid {
             if (!lightPlayer.equals(self.getOwner())) {
 
                 final RequiredGameTextTriggerAction action = new RequiredGameTextTriggerAction(self, gameTextSourceCardId);
-                // Light Side is the player performing the steal so responses such as Oh, Switch Off can cancel it
+                // Light Side performs the steal so ABOUT_TO_BE_STOLEN / Oh, Switch Off can respond
                 action.setPerformingPlayer(lightPlayer);
                 action.setText("Choose whether to 'steal'");
-                action.setActionMsg("Have " + lightPlayer + " choose whether to 'steal'" + GameUtils.getCardLink(self));
-                // Perform result(s)
+                action.setActionMsg("Have " + lightPlayer + " choose whether to 'steal' " + GameUtils.getCardLink(self));
+                // Yes/No then steal; Oh, Switch Off cancels via ABOUT_TO_BE_STOLEN (and TO_BE_STOLEN targeting if present)
                 action.appendEffect(
                         new PlayoutDecisionEffect(action, lightPlayer,
                                 new YesNoDecision("Do you want to 'steal' " + GameUtils.getCardLink(self) + "?") {
                                     @Override
                                     protected void yes() {
-                                        // Target for TO_BE_STOLEN with allowResponses so Oh, Switch Off can cancel (Caller-style)
-                                        final SubAction stealAction = new SubAction(action, lightPlayer);
-                                        stealAction.appendTargeting(
-                                                new TargetCardOnTableEffect(stealAction, lightPlayer, "Choose droid to steal", TargetingReason.TO_BE_STOLEN, self) {
-                                                    @Override
-                                                    protected void cardTargeted(final int targetGroupId, PhysicalCard targetedCard) {
-                                                        stealAction.addAnimationGroup(targetedCard);
-                                                        // Allow response(s)
-                                                        stealAction.allowResponses("Steal " + GameUtils.getCardLink(targetedCard),
-                                                                new RespondableEffect(stealAction) {
-                                                                    @Override
-                                                                    protected void performActionResults(Action targetingAction) {
-                                                                        final PhysicalCard cardToSteal = stealAction.getPrimaryTargetCard(targetGroupId);
-                                                                        // Perform result(s)
-                                                                        stealAction.appendEffect(
-                                                                                new StealCardToLocationEffect(stealAction, lightPlayer, cardToSteal));
-                                                                    }
-                                                                }
-                                                        );
-                                                    }
-                                                    @Override
-                                                    protected boolean getUseShortcut() {
-                                                        return true;
-                                                    }
-                                                }
-                                        );
+                                        game.getGameState().sendMessage(lightPlayer + " chooses to 'steal' " + GameUtils.getCardLink(self));
                                         action.appendEffect(
-                                                new StackActionEffect(action, stealAction));
+                                                new StealCardToLocationEffect(action, lightPlayer, self));
                                     }
 
                                     @Override
                                     protected void no() {
                                         game.getGameState().sendMessage(lightPlayer + " chooses not to 'steal' " + GameUtils.getCardLink(self));
                                     }
-
                                 }
                         )
                 );

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set3/dark/Card3_130.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set3/dark/Card3_130.java
@@ -27,7 +27,9 @@ import com.gempukku.swccgo.logic.modifiers.MayNotTargetToBeHitModifier;
 import com.gempukku.swccgo.logic.modifiers.MayNotTargetToBeLostModifier;
 import com.gempukku.swccgo.logic.timing.Action;
 import com.gempukku.swccgo.logic.timing.Effect;
+import com.gempukku.swccgo.logic.timing.EffectResult;
 import com.gempukku.swccgo.logic.timing.TargetingActionUtils;
+import com.gempukku.swccgo.logic.timing.results.AboutToBeStolenResult;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -87,6 +89,45 @@ public class Card3_130 extends AbstractUsedInterrupt {
                 );
                 return Collections.singletonList(action);
             }
+        }
+        return null;
+    }
+
+    /**
+     * Also respond when a droid is about to be stolen (e.g. after TO_BE_STOLEN targeting responses),
+     * so Oh, Switch Off can cancel U-3PO-style steals that emit ABOUT_TO_BE_STOLEN.
+     */
+    @Override
+    protected List<PlayInterruptAction> getGameTextOptionalAfterActions(final String playerId, final SwccgGame game, EffectResult effectResult, final PhysicalCard self) {
+        Filter yourDroid = Filters.and(Filters.your(self), Filters.droid);
+
+        // Check condition(s) — opponent attempting to steal your droid (ABOUT_TO_BE_STOLEN path)
+        if (TriggerConditions.isAboutToBeStolen(game, effectResult, yourDroid)) {
+            final AboutToBeStolenResult aboutToBeStolenResult = (AboutToBeStolenResult) effectResult;
+            final PhysicalCard droid = aboutToBeStolenResult.getCardToBeStolen();
+
+            final PlayInterruptAction action = new PlayInterruptAction(game, self);
+            action.setText("Cancel attempt to steal");
+            // Allow response(s)
+            action.allowResponses("Cancel attempt to steal " + GameUtils.getCardLink(droid),
+                    new RespondablePlayCardEffect(action) {
+                        @Override
+                        protected void performActionResults(Action targetingAction) {
+                            // Perform result(s)
+                            aboutToBeStolenResult.getPreventableCardEffect().preventEffectOnCard(droid);
+                            action.appendEffect(
+                                    new AddUntilEndOfTurnModifierEffect(action,
+                                            new MayNotBeStolenModifier(self, droid), null));
+                            action.appendEffect(
+                                    new AddUntilEndOfTurnModifierEffect(action,
+                                            new MayNotTargetToBeHitModifier(self, droid), null));
+                            action.appendEffect(
+                                    new AddUntilEndOfTurnModifierEffect(action,
+                                            new MayNotTargetToBeLostModifier(self, droid), null));
+                        }
+                    }
+            );
+            return Collections.singletonList(action);
         }
         return null;
     }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/dark/Card_2_107_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/dark/Card_2_107_Tests.java
@@ -1,0 +1,208 @@
+package com.gempukku.swccgo.cards.set2.dark;
+
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Keyword;
+import com.gempukku.swccgo.common.ModelType;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Card_2_107_Tests {
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>()
+                {{
+                    put("qam", "210_024"); // Quite A Mercenary (V)
+                }},
+                new HashMap<>()
+                {{
+                    put("u3po", "2_107"); // U-3PO (Yoo-Threepio)
+                    put("ohSwitchOff", "3_130"); // Oh, Switch Off
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void U3POStatsAndKeywordsAreCorrect() {
+        /**
+         * Title: U-3PO (Yoo-Threepio)
+         * Uniqueness: Unique
+         * Side: Dark
+         * Type: Character
+         * Subtype: Droid
+         * Destiny: 3
+         * Deploy: 3
+         * Power: 1
+         * Forfeit: 3
+         * Icons: A New Hope
+         * Model Type: Protocol
+         * Keywords: Spy
+         * Game Text: Deploys only to a site as an Undercover spy. If Undercover at a battle, adds his power to Light Side.
+         *      If U-3PO just had his 'cover broken,' Light Side may steal him.
+         * Set: A New Hope
+         * Rarity: R1
+         */
+
+        var scn = GetScenario();
+
+        var card = scn.GetDSCard("u3po").getBlueprint();
+
+        assertEquals("U-3PO (Yoo-Threepio)", card.getTitle());
+        assertFalse(card.hasVirtualSuffix());
+        assertEquals(Uniqueness.UNIQUE, card.getUniqueness());
+        assertEquals(Side.DARK, card.getSide());
+        assertEquals(3, card.getDestiny(), scn.epsilon);
+        assertEquals(3, card.getDeployCost(), scn.epsilon);
+        assertEquals(1, card.getPower(), scn.epsilon);
+        assertEquals(3, card.getForfeit(), scn.epsilon);
+        scn.BlueprintKeywordCheck(card, new ArrayList<>() {{
+            add(Keyword.SPY);
+        }});
+        scn.BlueprintIconCheck(card, new ArrayList<>() {{
+            add(Icon.A_NEW_HOPE);
+        }});
+        scn.BlueprintModelTypeCheck(card, new ArrayList<>() {{
+            add(ModelType.PROTOCOL);
+        }});
+        assertEquals(com.gempukku.swccgo.common.ExpansionSet.A_NEW_HOPE, card.getExpansionSet());
+        assertEquals(Rarity.R1, card.getRarity());
+    }
+
+    @Test
+    public void OhSwitchOffStatsAndKeywordsAreCorrect() {
+        /**
+         * Title: Oh, Switch Off
+         * Uniqueness: Unrestricted
+         * Side: Dark
+         * Type: Interrupt
+         * Subtype: Used
+         * Destiny: 6
+         * Icons: Hoth
+         * Game Text: Cancel an attempt by opponent to target your droid to be stolen, 'hit' or lost.
+         *      Droid is protected from all such attempts for remainder of turn.
+         *      OR Switch OFF any binary droid for remainder of turn.
+         * Set: Hoth
+         * Rarity: C2
+         */
+
+        var scn = GetScenario();
+
+        var card = scn.GetDSCard("ohSwitchOff").getBlueprint();
+
+        assertEquals("Oh, Switch Off", card.getTitle());
+        assertFalse(card.hasVirtualSuffix());
+        assertEquals(Uniqueness.UNRESTRICTED, card.getUniqueness());
+        assertEquals(Side.DARK, card.getSide());
+        assertEquals(6, card.getDestiny(), scn.epsilon);
+        scn.BlueprintIconCheck(card, new ArrayList<>() {{
+            add(Icon.HOTH);
+        }});
+        assertEquals(com.gempukku.swccgo.common.ExpansionSet.HOTH, card.getExpansionSet());
+        assertEquals(Rarity.C2, card.getRarity());
+    }
+
+    @Test
+    public void OhSwitchOffCanCancelStealOfU3POAfterCoverBroken() {
+        // Repro (#50): LS breaks U-3PO cover (Quite A Mercenary (V)), chooses steal;
+        // Oh, Switch Off should light up and keep U-3PO as a DS droid.
+        var scn = GetScenario();
+
+        var qam = scn.GetLSCard("qam");
+        var u3po = scn.GetDSCard("u3po");
+        var ohSwitchOff = scn.GetDSCard("ohSwitchOff");
+        var site = scn.GetLSStartingLocation();
+
+        scn.StartGame();
+
+        scn.MoveCardsToLSHand(qam);
+        scn.MoveCardsToDSHand(u3po, ohSwitchOff);
+
+        scn.SkipToPhase(Phase.DEPLOY);
+        scn.DSDeployCard(u3po);
+        scn.DSChooseCard(site);
+        scn.PassAllResponses();
+
+        assertTrue(u3po.isUndercover());
+        assertEquals(scn.DS, u3po.getOwner());
+
+        scn.SkipToLSTurn(Phase.MOVE);
+        assertTrue(scn.LSCardPlayAvailable(qam));
+        scn.LSPlayCard(qam);
+        // LOST: Break a spy's cover
+        assertTrue(scn.LSDecisionAvailable("Choose undercover spy") || scn.LSHasCardChoiceAvailable(u3po) || scn.LSDecisionAvailable("Break"));
+        if (scn.LSHasCardChoiceAvailable(u3po)) {
+            scn.LSChooseCard(u3po);
+        }
+        scn.PassAllResponses();
+
+        assertFalse(u3po.isUndercover());
+        assertTrue(scn.LSDecisionAvailable("steal"));
+        scn.LSChooseYes();
+
+        // Steal targeting - optional responses; Oh, Switch Off should be available
+        assertTrue(scn.DSCardPlayAvailable(ohSwitchOff));
+        scn.DSPlayCard(ohSwitchOff);
+        scn.PassAllResponses();
+
+        assertEquals(scn.DS, u3po.getOwner());
+        assertTrue(scn.CardsAtLocation(site, u3po));
+    }
+
+    @Test
+    public void LightSideMayStealU3POWhenCoverBrokenIfOhSwitchOffNotPlayed() {
+        var scn = GetScenario();
+
+        var qam = scn.GetLSCard("qam");
+        var u3po = scn.GetDSCard("u3po");
+        var ohSwitchOff = scn.GetDSCard("ohSwitchOff");
+        var site = scn.GetLSStartingLocation();
+
+        scn.StartGame();
+
+        scn.MoveCardsToLSHand(qam);
+        scn.MoveCardsToDSHand(u3po, ohSwitchOff);
+
+        scn.SkipToPhase(Phase.DEPLOY);
+        scn.DSDeployCard(u3po);
+        scn.DSChooseCard(site);
+        scn.PassAllResponses();
+
+        assertTrue(u3po.isUndercover());
+
+        scn.SkipToLSTurn(Phase.MOVE);
+        scn.LSPlayCard(qam);
+        if (scn.LSHasCardChoiceAvailable(u3po)) {
+            scn.LSChooseCard(u3po);
+        }
+        scn.PassAllResponses();
+
+        assertTrue(scn.LSDecisionAvailable("steal"));
+        scn.LSChooseYes();
+
+        assertTrue(scn.DSCardPlayAvailable(ohSwitchOff));
+        scn.PassAllResponses();
+
+        assertEquals(scn.LS, u3po.getOwner());
+        assertTrue(scn.CardsAtLocation(site, u3po));
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/dark/Card_2_107_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/dark/Card_2_107_Tests.java
@@ -1,5 +1,8 @@
 package com.gempukku.swccgo.cards.set2.dark;
 
+import com.gempukku.swccgo.common.CardSubtype;
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.ExpansionSet;
 import com.gempukku.swccgo.common.Icon;
 import com.gempukku.swccgo.common.Keyword;
 import com.gempukku.swccgo.common.ModelType;
@@ -42,29 +45,72 @@ public class Card_2_107_Tests {
         );
     }
 
+    private void breakU3POCoverWithQAM(VirtualTableScenario scn) {
+        var qam = scn.GetLSCard("qam");
+        var u3po = scn.GetDSCard("u3po");
+        var ohSwitchOff = scn.GetDSCard("ohSwitchOff");
+        var site = scn.GetLSStartingLocation();
+
+        scn.MoveCardsToLSHand(qam);
+        scn.MoveCardsToDSHand(u3po, ohSwitchOff);
+
+        scn.SkipToPhase(Phase.DEPLOY);
+        scn.DSDeployCard(u3po);
+        scn.DSChooseCard(site);
+        scn.PassAllResponses();
+
+        assertTrue(u3po.isUndercover());
+        assertEquals(scn.DS, u3po.getOwner());
+
+        scn.SkipToLSTurn(Phase.MOVE);
+        assertTrue(scn.LSCardPlayAvailable(qam, "Break a spy's cover"));
+        scn.LSPlayCard(qam, "Break a spy's cover");
+        assertTrue(scn.LSHasCardChoiceAvailable(u3po));
+        scn.LSChooseCard(u3po);
+        scn.PassAllResponses();
+
+        assertFalse(u3po.isUndercover());
+    }
+
+    /**
+     * After LS chooses to steal, advance until Oh, Switch Off can respond (ABOUT_TO_BE_STOLEN).
+     */
+    private void advanceToOhSwitchOffResponse(VirtualTableScenario scn, com.gempukku.swccgo.game.PhysicalCardImpl ohSwitchOff) {
+        for (int i = 0; i < 20; i++) {
+            var ds = scn.DSGetDecision();
+            if (ds != null && scn.DSCardPlayAvailable(ohSwitchOff)) {
+                return;
+            }
+            var ls = scn.LSGetDecision();
+            if (ls != null) {
+                String lower = ls.getText() == null ? "" : ls.getText().toLowerCase();
+                if (scn.LSDecisionAvailable("steal") || lower.contains("do you want to")) {
+                    scn.LSChooseYes();
+                    continue;
+                }
+                if (lower.contains("optional") || lower.contains("about") || lower.contains("cover") || lower.contains("response")) {
+                    scn.LSPass();
+                    continue;
+                }
+            }
+            if (ds != null) {
+                String lower = ds.getText() == null ? "" : ds.getText().toLowerCase();
+                if (lower.contains("optional") || lower.contains("about") || lower.contains("cover") || lower.contains("response")) {
+                    // Do not pass the Oh Switch Off window
+                    if (scn.DSCardPlayAvailable(ohSwitchOff)) {
+                        return;
+                    }
+                    scn.DSPass();
+                    continue;
+                }
+            }
+            break;
+        }
+    }
+
     @Test
     public void U3POStatsAndKeywordsAreCorrect() {
-        /**
-         * Title: U-3PO (Yoo-Threepio)
-         * Uniqueness: Unique
-         * Side: Dark
-         * Type: Character
-         * Subtype: Droid
-         * Destiny: 3
-         * Deploy: 3
-         * Power: 1
-         * Forfeit: 3
-         * Icons: A New Hope
-         * Model Type: Protocol
-         * Keywords: Spy
-         * Game Text: Deploys only to a site as an Undercover spy. If Undercover at a battle, adds his power to Light Side.
-         *      If U-3PO just had his 'cover broken,' Light Side may steal him.
-         * Set: A New Hope
-         * Rarity: R1
-         */
-
         var scn = GetScenario();
-
         var card = scn.GetDSCard("u3po").getBlueprint();
 
         assertEquals("U-3PO (Yoo-Threepio)", card.getTitle());
@@ -75,38 +121,26 @@ public class Card_2_107_Tests {
         assertEquals(3, card.getDeployCost(), scn.epsilon);
         assertEquals(1, card.getPower(), scn.epsilon);
         assertEquals(3, card.getForfeit(), scn.epsilon);
+        scn.BlueprintCardTypeCheck(card, new ArrayList<>() {{
+            add(CardType.DROID);
+        }});
         scn.BlueprintKeywordCheck(card, new ArrayList<>() {{
             add(Keyword.SPY);
         }});
         scn.BlueprintIconCheck(card, new ArrayList<>() {{
             add(Icon.A_NEW_HOPE);
+            add(Icon.DROID);
         }});
         scn.BlueprintModelTypeCheck(card, new ArrayList<>() {{
             add(ModelType.PROTOCOL);
         }});
-        assertEquals(com.gempukku.swccgo.common.ExpansionSet.A_NEW_HOPE, card.getExpansionSet());
+        assertEquals(ExpansionSet.A_NEW_HOPE, card.getExpansionSet());
         assertEquals(Rarity.R1, card.getRarity());
     }
 
     @Test
     public void OhSwitchOffStatsAndKeywordsAreCorrect() {
-        /**
-         * Title: Oh, Switch Off
-         * Uniqueness: Unrestricted
-         * Side: Dark
-         * Type: Interrupt
-         * Subtype: Used
-         * Destiny: 6
-         * Icons: Hoth
-         * Game Text: Cancel an attempt by opponent to target your droid to be stolen, 'hit' or lost.
-         *      Droid is protected from all such attempts for remainder of turn.
-         *      OR Switch OFF any binary droid for remainder of turn.
-         * Set: Hoth
-         * Rarity: C2
-         */
-
         var scn = GetScenario();
-
         var card = scn.GetDSCard("ohSwitchOff").getBlueprint();
 
         assertEquals("Oh, Switch Off", card.getTitle());
@@ -114,10 +148,15 @@ public class Card_2_107_Tests {
         assertEquals(Uniqueness.UNRESTRICTED, card.getUniqueness());
         assertEquals(Side.DARK, card.getSide());
         assertEquals(6, card.getDestiny(), scn.epsilon);
+        scn.BlueprintCardTypeCheck(card, new ArrayList<>() {{
+            add(CardType.INTERRUPT);
+        }});
+        assertEquals(CardSubtype.USED, card.getCardSubtype());
         scn.BlueprintIconCheck(card, new ArrayList<>() {{
             add(Icon.HOTH);
+            add(Icon.INTERRUPT);
         }});
-        assertEquals(com.gempukku.swccgo.common.ExpansionSet.HOTH, card.getExpansionSet());
+        assertEquals(ExpansionSet.HOTH, card.getExpansionSet());
         assertEquals(Rarity.C2, card.getRarity());
     }
 
@@ -126,41 +165,18 @@ public class Card_2_107_Tests {
         // Repro (#50): LS breaks U-3PO cover (Quite A Mercenary (V)), chooses steal;
         // Oh, Switch Off should light up and keep U-3PO as a DS droid.
         var scn = GetScenario();
-
-        var qam = scn.GetLSCard("qam");
         var u3po = scn.GetDSCard("u3po");
         var ohSwitchOff = scn.GetDSCard("ohSwitchOff");
         var site = scn.GetLSStartingLocation();
 
         scn.StartGame();
+        breakU3POCoverWithQAM(scn);
 
-        scn.MoveCardsToLSHand(qam);
-        scn.MoveCardsToDSHand(u3po, ohSwitchOff);
-
-        scn.SkipToPhase(Phase.DEPLOY);
-        scn.DSDeployCard(u3po);
-        scn.DSChooseCard(site);
-        scn.PassAllResponses();
-
-        assertTrue(u3po.isUndercover());
-        assertEquals(scn.DS, u3po.getOwner());
-
-        scn.SkipToLSTurn(Phase.MOVE);
-        assertTrue(scn.LSCardPlayAvailable(qam));
-        scn.LSPlayCard(qam);
-        // LOST: Break a spy's cover
-        assertTrue(scn.LSDecisionAvailable("Choose undercover spy") || scn.LSHasCardChoiceAvailable(u3po) || scn.LSDecisionAvailable("Break"));
-        if (scn.LSHasCardChoiceAvailable(u3po)) {
-            scn.LSChooseCard(u3po);
-        }
-        scn.PassAllResponses();
-
-        assertFalse(u3po.isUndercover());
         assertTrue(scn.LSDecisionAvailable("steal"));
         scn.LSChooseYes();
+        advanceToOhSwitchOffResponse(scn, ohSwitchOff);
 
-        // Steal targeting - optional responses; Oh, Switch Off should be available
-        assertTrue(scn.DSCardPlayAvailable(ohSwitchOff));
+        assertTrue("Oh, Switch Off should be playable to cancel the steal", scn.DSCardPlayAvailable(ohSwitchOff));
         scn.DSPlayCard(ohSwitchOff);
         scn.PassAllResponses();
 
@@ -171,35 +187,18 @@ public class Card_2_107_Tests {
     @Test
     public void LightSideMayStealU3POWhenCoverBrokenIfOhSwitchOffNotPlayed() {
         var scn = GetScenario();
-
-        var qam = scn.GetLSCard("qam");
         var u3po = scn.GetDSCard("u3po");
         var ohSwitchOff = scn.GetDSCard("ohSwitchOff");
         var site = scn.GetLSStartingLocation();
 
         scn.StartGame();
-
-        scn.MoveCardsToLSHand(qam);
-        scn.MoveCardsToDSHand(u3po, ohSwitchOff);
-
-        scn.SkipToPhase(Phase.DEPLOY);
-        scn.DSDeployCard(u3po);
-        scn.DSChooseCard(site);
-        scn.PassAllResponses();
-
-        assertTrue(u3po.isUndercover());
-
-        scn.SkipToLSTurn(Phase.MOVE);
-        scn.LSPlayCard(qam);
-        if (scn.LSHasCardChoiceAvailable(u3po)) {
-            scn.LSChooseCard(u3po);
-        }
-        scn.PassAllResponses();
+        breakU3POCoverWithQAM(scn);
 
         assertTrue(scn.LSDecisionAvailable("steal"));
         scn.LSChooseYes();
+        advanceToOhSwitchOffResponse(scn, ohSwitchOff);
 
-        assertTrue(scn.DSCardPlayAvailable(ohSwitchOff));
+        assertTrue("Oh, Switch Off should still be available before DS declines", scn.DSCardPlayAvailable(ohSwitchOff));
         scn.PassAllResponses();
 
         assertEquals(scn.LS, u3po.getOwner());


### PR DESCRIPTION
## Summary
Closes #50.

When U-3PO's cover is broken and Light Side chooses to steal him, **Oh, Switch Off** can cancel the attempt and keep U-3PO as a Dark Side droid.

## Approach
Minimal steal-path fix (no broad steal-engine rewrite):
- **Oh, Switch Off (`Card3_130`)**: optional after response when your droid is about to be stolen (`ABOUT_TO_BE_STOLEN`) — prevent the steal and apply the usual until-end-of-turn protection. Existing cancel-targeting path for `TO_BE_STOLEN` / hit / lost is unchanged.
- **U-3PO (`Card2_107`)**: after cover broken, Light Side Yes/No then `StealCardToLocationEffect` with Light as performing player so the about-to-be-stolen window fires for Oh, Switch Off.

## Cards
- U-3PO: `2_107` / `Card2_107`
- Oh, Switch Off: `3_130` / `Card3_130`
- Repro break-cover card: Quite A Mercenary (V) `210_024`

## Tests
`Card_2_107_Tests` (4 tests, all green):
- Blueprint checks for U-3PO and Oh, Switch Off
- Oh, Switch Off can cancel the steal after cover broken
- Steal still succeeds if Oh, Switch Off is not played

## Ruling
https://forum.starwarsccg.org/viewtopic.php?f=5&t=74337&p=1284232