### PR TITLE
Fix #201: stop battle destiny after Program Trap clears presence

### DIFF
--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/actions/battle/BattlePowerSegmentAction.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/timing/actions/battle/BattlePowerSegmentAction.java
@@ -16,6 +16,7 @@ import com.gempukku.swccgo.logic.timing.AbstractSubActionEffect;
 import com.gempukku.swccgo.logic.timing.AbstractSuccessfulEffect;
 import com.gempukku.swccgo.logic.timing.Action;
 import com.gempukku.swccgo.logic.timing.PassthruEffect;
+import com.gempukku.swccgo.logic.timing.StandardEffect;
 import com.gempukku.swccgo.logic.timing.results.BattleDestinyDrawsCompleteForBothPlayersResult;
 import com.gempukku.swccgo.logic.timing.results.BattleDestinyDrawsCompleteForPlayerResult;
 import com.gempukku.swccgo.logic.timing.results.BeforeBattleDestinyDrawsResult;
@@ -46,38 +47,51 @@ public class BattlePowerSegmentAction extends SystemQueueAction {
                         String playerId = battleState.getPlayerInitiatedBattle();
                         String opponent = game.getOpponent(playerId);
 
-                        // Draw destinies to power only
-                        appendEffect(
-                                new DrawDestinyToPowerOnlyEffect(_action, playerId));
-                        appendEffect(
-                                new DrawDestinyToPowerOnlyEffect(_action, opponent));
+                        // Draw destinies to power only (gated: battle may end mid-power-segment)
+                        appendEffect(new ContinuePowerSegmentEffect(_action, new DrawDestinyToPowerOnlyEffect(_action, playerId)));
+                        appendEffect(new ContinuePowerSegmentEffect(_action, new DrawDestinyToPowerOnlyEffect(_action, opponent)));
 
-                        // Draw battle destinies
-                        appendEffect(
-                                new TriggeringResultEffect(_action, new BeforeBattleDestinyDrawsResult(playerId)));
-                        appendEffect(
-                                new CheckToDrawBattleDestinyEffect(_action, playerId));
-                        appendEffect(
-                                new TriggeringResultEffect(_action, new BattleDestinyDrawsCompleteForPlayerResult(playerId)));
-                        appendEffect(
-                                new CheckToDrawBattleDestinyEffect(_action, opponent));
-                        appendEffect(
-                                new TriggeringResultEffect(_action, new BattleDestinyDrawsCompleteForPlayerResult(opponent)));
-                        appendEffect(
-                                new TriggeringResultEffect(_action, new BattleDestinyDrawsCompleteForBothPlayersResult(playerId)));
+                        // Draw battle destinies (gated like weapons-segment canContinue checks)
+                        appendEffect(new ContinuePowerSegmentEffect(_action, new TriggeringResultEffect(_action, new BeforeBattleDestinyDrawsResult(playerId))));
+                        appendEffect(new ContinuePowerSegmentEffect(_action, new CheckToDrawBattleDestinyEffect(_action, playerId)));
+                        appendEffect(new ContinuePowerSegmentEffect(_action, new TriggeringResultEffect(_action, new BattleDestinyDrawsCompleteForPlayerResult(playerId))));
+                        appendEffect(new ContinuePowerSegmentEffect(_action, new CheckToDrawBattleDestinyEffect(_action, opponent)));
+                        appendEffect(new ContinuePowerSegmentEffect(_action, new TriggeringResultEffect(_action, new BattleDestinyDrawsCompleteForPlayerResult(opponent))));
+                        appendEffect(new ContinuePowerSegmentEffect(_action, new TriggeringResultEffect(_action, new BattleDestinyDrawsCompleteForBothPlayersResult(playerId))));
 
                         // Draw destinies to attrition only
-                        appendEffect(
-                                new DrawDestinyToAttritionOnlyEffect(_action, playerId));
-                        appendEffect(
-                                new DrawDestinyToAttritionOnlyEffect(_action, opponent));
+                        appendEffect(new ContinuePowerSegmentEffect(_action, new DrawDestinyToAttritionOnlyEffect(_action, playerId)));
+                        appendEffect(new ContinuePowerSegmentEffect(_action, new DrawDestinyToAttritionOnlyEffect(_action, opponent)));
 
                         // Calculate initial attrition
-                        appendEffect(
-                                new CalculateInitialAttritionEffect(_action));
+                        appendEffect(new ContinuePowerSegmentEffect(_action, new CalculateInitialAttritionEffect(_action)));
                     }
                 }
         );
+    }
+
+
+    /**
+     * Runs a queued power-segment step only if the battle can still continue
+     * (mirrors BattleCheckIfWeaponsSegmentFinishedEffect canContinue gating).
+     * Presence can be removed mid-segment (e.g. Program Trap exploding after a destiny draw).
+     */
+    private class ContinuePowerSegmentEffect extends PassthruEffect {
+        private final StandardEffect _effect;
+
+        private ContinuePowerSegmentEffect(Action action, StandardEffect effect) {
+            super(action);
+            _effect = effect;
+        }
+
+        @Override
+        protected void doPlayEffect(SwccgGame game) {
+            BattleState battleState = game.getGameState().getBattleState();
+            if (battleState != null && battleState.canContinue(game)) {
+                // Re-queue the gated effect to run next (before remaining queued power-segment steps)
+                _action.insertEffect(_effect);
+            }
+        }
     }
 
     /**

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/dark/Card_2_124_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/dark/Card_2_124_Tests.java
@@ -1,0 +1,161 @@
+package com.gempukku.swccgo.cards.set2.dark;
+
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.game.PhysicalCardImpl;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static com.gempukku.swccgo.framework.Assertions.assertInZone;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Regression for #201: Program Trap exploding mid-power-segment must stop remaining battle destiny draws.
+ */
+public class Card_2_124_Tests {
+	protected VirtualTableScenario GetScenario() {
+		return new VirtualTableScenario(
+				new HashMap<>()
+				{{
+					put("luke", "1_19");
+				}},
+				new HashMap<>()
+				{{
+					put("trap", "2_124");
+					put("septoid", "2_109");
+					put("vader", "1_168");
+				}},
+				10,
+				10,
+				StartingSetup.DefaultLSGroundLocation,
+				StartingSetup.DefaultDSGroundLocation,
+				StartingSetup.NoLSStartingInterrupts,
+				StartingSetup.NoDSStartingInterrupts,
+				StartingSetup.NoLSShields,
+				StartingSetup.NoDSShields,
+				VirtualTableScenario.Open
+		);
+	}
+
+	@Test
+	public void ProgramTrapStatsAndKeywordsAreCorrect() {
+		/**
+		 * Title: Program Trap
+		 * Uniqueness: UNIQUE
+		 * Side: Dark
+		 * Type: Effect
+		 * Destiny: 4
+		 * Game Text: Use 2 Force to deploy on an opponent's droid (except R2-D2 and C-3PO), 1 on your droid. When either
+		 * 		player draws a destiny matching the number of characters at same site, droid 'explodes' (all characters
+		 * 		present are lost).
+		 * Set: A New Hope
+		 * Rarity: U1
+		 */
+		var scn = GetScenario();
+		var card = scn.GetDSCard("trap").getBlueprint();
+		assertEquals("Program Trap", card.getTitle());
+		assertEquals(4, card.getDestiny(), scn.epsilon);
+	}
+
+	@Test
+	public void ProgramTrapExplodingMidPowerSegmentStopsFurtherBattleDestinyDraws() {
+		var scn = GetScenario();
+
+		var luke = scn.GetLSCard("luke");
+		var site = scn.GetLSStartingLocation();
+
+		var trap = scn.GetDSCard("trap");
+		var septoid = scn.GetDSCard("septoid");
+		var vader = scn.GetDSCard("vader");
+
+		scn.StartGame();
+
+		// 3 characters present: Vader, Septoid, Luke
+		scn.MoveCardsToLocation(site, luke, vader, septoid);
+		scn.AttachCardsTo(septoid, trap);
+
+		scn.SkipToPhase(Phase.BATTLE);
+		scn.DSInitiateBattle(site);
+		scn.SkipToPowerSegment();
+
+		assertTrue(scn.IsActiveBattle());
+		assertTrue(scn.IsReachedPowerSegment());
+
+		// Printed destiny 2 + Vader's +1 battle destiny = 3, matching character count → Program Trap explodes
+		scn.PrepareDSDestiny(2);
+		assertTrue(scn.DSDecisionAvailable("battle destiny?"));
+		scn.DSChooseYes();
+
+		scn.PassResponses("COST_TO_DRAW_DESTINY_CARD");
+		scn.PassResponses("ABOUT_TO_DRAW_DESTINY_CARD");
+		scn.PassResponses("EXPLODING_PROGRAM_TRAP");
+
+		resolveProgramTrapCharacterLosses(scn, luke, vader, septoid, trap);
+
+		assertInZone(Zone.LOST_PILE, luke, vader, septoid, trap);
+
+		assertFalse("LS must not draw battle destiny after Program Trap cleared the site",
+				scn.LSDecisionAvailable("battle destiny?"));
+		assertFalse("Battle must not continue after both sides lost presence mid-power-segment",
+				scn.IsActiveBattle());
+	}
+
+	private void resolveProgramTrapCharacterLosses(VirtualTableScenario scn, PhysicalCardImpl... cards) {
+		for (int safety = 0; safety < 25; safety++) {
+			if (allInLostPile(cards)) {
+				return;
+			}
+
+			if (scn.DSDecisionAvailable("Choose card to be lost")) {
+				scn.DSChooseCard(firstChoosable(scn, true, cards));
+				scn.PassAllResponses();
+				continue;
+			}
+			if (scn.LSDecisionAvailable("Choose card to be lost")) {
+				scn.LSChooseCard(firstChoosable(scn, false, cards));
+				scn.PassAllResponses();
+				continue;
+			}
+			if (scn.DSDecisionAvailable("Choose card to put on Lost Pile")) {
+				scn.DSChooseCard(firstChoosable(scn, true, cards));
+				scn.PassAllResponses();
+				continue;
+			}
+			if (scn.LSDecisionAvailable("Choose card to put on Lost Pile")) {
+				scn.LSChooseCard(firstChoosable(scn, false, cards));
+				scn.PassAllResponses();
+				continue;
+			}
+			if (scn.GetCurrentDecision() != null
+					&& scn.GetCurrentDecision().getText().toLowerCase().contains("optional")) {
+				scn.PassResponses("optional");
+				continue;
+			}
+			return;
+		}
+	}
+
+	private boolean allInLostPile(PhysicalCardImpl... cards) {
+		for (PhysicalCardImpl card : cards) {
+			if (card.getZone() != Zone.LOST_PILE && card.getZone() != Zone.TOP_OF_LOST_PILE) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private PhysicalCardImpl firstChoosable(VirtualTableScenario scn, boolean dark, PhysicalCardImpl... cards) {
+		for (PhysicalCardImpl card : cards) {
+			boolean available = dark ? scn.DSHasCardChoiceAvailable(card) : scn.LSHasCardChoiceAvailable(card);
+			if (available) {
+				return card;
+			}
+		}
+		throw new AssertionError("No choosable card among Program Trap losers");
+	}
+}


### PR DESCRIPTION
## Summary
Stops further battle destiny draws when a battle loses presence mid-power-segment (e.g. Program Trap exploding after a destiny draw). Closes #201.

## What changed
`BattlePowerSegmentAction` previously queued the whole power-segment destiny sequence up front. Presence can disappear mid-sequence (Program Trap, similar clears), but later battle destiny draws still ran.

Each queued power-segment destiny step is now wrapped in a `canContinue` gate (same idea as `BattleCheckIfWeaponsSegmentFinishedEffect` in the weapons segment). If the battle can no longer continue, remaining destiny draws / attrition / initial attrition calculation are skipped.

## Tests
`Card_2_124_Tests` — **2 run, 0 fail, 0 skip**
- `ProgramTrapStatsAndKeywordsAreCorrect`
- `ProgramTrapExplodingMidPowerSegmentStopsFurtherBattleDestinyDraws`

## Out of scope
Does not rewrite `BattleEffect` segment orchestration or address cancelled-battle immediacy (#691).