### PR TITLE
Fix Weather Vane, Shocking, and Seekers attached cards going Lost (#54)

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/dark/Card1_316.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/dark/Card1_316.java
@@ -14,7 +14,7 @@ import com.gempukku.swccgo.game.SwccgGame;
 import com.gempukku.swccgo.logic.GameUtils;
 import com.gempukku.swccgo.logic.TriggerConditions;
 import com.gempukku.swccgo.logic.actions.RequiredGameTextTriggerAction;
-import com.gempukku.swccgo.logic.effects.LoseCardsFromTableSimultaneouslyEffect;
+import com.gempukku.swccgo.logic.effects.LoseCardsFromTableEffect;
 import com.gempukku.swccgo.logic.effects.choose.ChooseCardOnTableEffect;
 import com.gempukku.swccgo.logic.timing.EffectResult;
 
@@ -56,7 +56,7 @@ public class Card1_316 extends AbstractSeeker {
                             action.setActionMsg("Make " + GameUtils.getCardLink(character) + " lost");
                             // Perform result(s)
                             action.appendEffect(
-                                    new LoseCardsFromTableSimultaneouslyEffect(action, Arrays.asList(character, self), true, true));
+                                    new LoseCardsFromTableEffect(action, Arrays.asList(character, self), true));
                         }
                     }
             );

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/dark/Card1_321.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/dark/Card1_321.java
@@ -14,7 +14,7 @@ import com.gempukku.swccgo.game.SwccgGame;
 import com.gempukku.swccgo.logic.GameUtils;
 import com.gempukku.swccgo.logic.TriggerConditions;
 import com.gempukku.swccgo.logic.actions.RequiredGameTextTriggerAction;
-import com.gempukku.swccgo.logic.effects.LoseCardsFromTableSimultaneouslyEffect;
+import com.gempukku.swccgo.logic.effects.LoseCardsFromTableEffect;
 import com.gempukku.swccgo.logic.effects.choose.ChooseCardOnTableEffect;
 import com.gempukku.swccgo.logic.timing.EffectResult;
 
@@ -56,7 +56,7 @@ public class Card1_321 extends AbstractSeeker {
                             action.setActionMsg("Make " + GameUtils.getCardLink(character) + " lost");
                             // Perform result(s)
                             action.appendEffect(
-                                    new LoseCardsFromTableSimultaneouslyEffect(action, Arrays.asList(character, self), true, true));
+                                    new LoseCardsFromTableEffect(action, Arrays.asList(character, self), true));
                         }
                     }
             );

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_160.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_160.java
@@ -14,7 +14,7 @@ import com.gempukku.swccgo.game.SwccgGame;
 import com.gempukku.swccgo.logic.GameUtils;
 import com.gempukku.swccgo.logic.TriggerConditions;
 import com.gempukku.swccgo.logic.actions.RequiredGameTextTriggerAction;
-import com.gempukku.swccgo.logic.effects.LoseCardsFromTableSimultaneouslyEffect;
+import com.gempukku.swccgo.logic.effects.LoseCardsFromTableEffect;
 import com.gempukku.swccgo.logic.effects.choose.ChooseCardOnTableEffect;
 import com.gempukku.swccgo.logic.timing.EffectResult;
 
@@ -56,7 +56,7 @@ public class Card1_160 extends AbstractSeeker {
                             action.setActionMsg("Make " + GameUtils.getCardLink(character) + " lost");
                             // Perform result(s)
                             action.appendEffect(
-                                    new LoseCardsFromTableSimultaneouslyEffect(action, Arrays.asList(character, self), true, true));
+                                    new LoseCardsFromTableEffect(action, Arrays.asList(character, self), true));
                         }
                     }
             );

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_161.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_161.java
@@ -14,7 +14,7 @@ import com.gempukku.swccgo.game.SwccgGame;
 import com.gempukku.swccgo.logic.GameUtils;
 import com.gempukku.swccgo.logic.TriggerConditions;
 import com.gempukku.swccgo.logic.actions.RequiredGameTextTriggerAction;
-import com.gempukku.swccgo.logic.effects.LoseCardsFromTableSimultaneouslyEffect;
+import com.gempukku.swccgo.logic.effects.LoseCardsFromTableEffect;
 import com.gempukku.swccgo.logic.effects.choose.ChooseCardOnTableEffect;
 import com.gempukku.swccgo.logic.timing.EffectResult;
 
@@ -56,7 +56,7 @@ public class Card1_161 extends AbstractSeeker {
                             action.setActionMsg("Make " + GameUtils.getCardLink(character) + " lost");
                             // Perform result(s)
                             action.appendEffect(
-                                    new LoseCardsFromTableSimultaneouslyEffect(action, Arrays.asList(character, self), true, true));
+                                    new LoseCardsFromTableEffect(action, Arrays.asList(character, self), true));
                         }
                     }
             );

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set10/light/Card10_022.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set10/light/Card10_022.java
@@ -21,7 +21,7 @@ import com.gempukku.swccgo.logic.effects.AddUntilEndOfTurnModifierEffect;
 import com.gempukku.swccgo.logic.effects.LookAtCardsInOpponentsHandEffect;
 import com.gempukku.swccgo.logic.effects.LoseCardsFromHandEffect;
 import com.gempukku.swccgo.logic.effects.LoseCardsFromOffTableSimultaneouslyEffect;
-import com.gempukku.swccgo.logic.effects.LoseCardsFromTableSimultaneouslyEffect;
+import com.gempukku.swccgo.logic.effects.LoseCardFromTableEffect;
 import com.gempukku.swccgo.logic.effects.LoseForceEffect;
 import com.gempukku.swccgo.logic.effects.PutCardsFromHandOnUsedPileEffect;
 import com.gempukku.swccgo.logic.effects.PutRandomCardsFromHandOnUsedPileEffect;
@@ -167,7 +167,7 @@ public class Card10_022 extends AbstractUsedOrLostInterrupt {
                             sourceAction.appendAfterEffect(
                                     new LoseCardsFromOffTableSimultaneouslyEffect(sourceAction, Collections.singleton(sourceCard), false));
                             sourceAction.appendAfterEffect(
-                                    new LoseCardsFromTableSimultaneouslyEffect(sourceAction, Collections.singleton(sourceCard), false, false));
+                                    new LoseCardFromTableEffect(sourceAction, sourceCard));
                             sourceAction.appendAfterEffect(
                                     new LoseForceEffect(sourceAction, opponent, 4));
                         }

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/dark/Card2_160.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/dark/Card2_160.java
@@ -15,7 +15,7 @@ import com.gempukku.swccgo.game.SwccgGame;
 import com.gempukku.swccgo.logic.GameUtils;
 import com.gempukku.swccgo.logic.TriggerConditions;
 import com.gempukku.swccgo.logic.actions.RequiredGameTextTriggerAction;
-import com.gempukku.swccgo.logic.effects.LoseCardsFromTableSimultaneouslyEffect;
+import com.gempukku.swccgo.logic.effects.LoseCardsFromTableEffect;
 import com.gempukku.swccgo.logic.effects.choose.ChooseCardOnTableEffect;
 import com.gempukku.swccgo.logic.timing.EffectResult;
 
@@ -58,7 +58,7 @@ public class Card2_160 extends AbstractSeeker {
                             action.setActionMsg("Make " + GameUtils.getCardLink(character) + " lost");
                             // Perform result(s)
                             action.appendEffect(
-                                    new LoseCardsFromTableSimultaneouslyEffect(action, Arrays.asList(character, self), true, true));
+                                    new LoseCardsFromTableEffect(action, Arrays.asList(character, self), true));
                         }
                     }
             );

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/light/Card2_080.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/light/Card2_080.java
@@ -15,7 +15,7 @@ import com.gempukku.swccgo.game.SwccgGame;
 import com.gempukku.swccgo.logic.GameUtils;
 import com.gempukku.swccgo.logic.TriggerConditions;
 import com.gempukku.swccgo.logic.actions.RequiredGameTextTriggerAction;
-import com.gempukku.swccgo.logic.effects.LoseCardsFromTableSimultaneouslyEffect;
+import com.gempukku.swccgo.logic.effects.LoseCardsFromTableEffect;
 import com.gempukku.swccgo.logic.effects.choose.ChooseCardOnTableEffect;
 import com.gempukku.swccgo.logic.timing.EffectResult;
 
@@ -58,7 +58,7 @@ public class Card2_080 extends AbstractSeeker {
                             action.setActionMsg("Make " + GameUtils.getCardLink(character) + " lost");
                             // Perform result(s)
                             action.appendEffect(
-                                    new LoseCardsFromTableSimultaneouslyEffect(action, Arrays.asList(character, self), true, true));
+                                    new LoseCardsFromTableEffect(action, Arrays.asList(character, self), true));
                         }
                     }
             );

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/dark/Card5_127.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/dark/Card5_127.java
@@ -22,7 +22,7 @@ import com.gempukku.swccgo.logic.actions.TopLevelGameTextAction;
 import com.gempukku.swccgo.logic.decisions.MultipleChoiceAwaitingDecision;
 import com.gempukku.swccgo.logic.effects.CaptureCharacterFromLostInSpaceOrWeatherVaneEffect;
 import com.gempukku.swccgo.logic.effects.LoseCardFromTableEffect;
-import com.gempukku.swccgo.logic.effects.LoseCardsFromOffTableSimultaneouslyEffect;
+import com.gempukku.swccgo.logic.effects.LoseCardsFromTableSimultaneouslyEffect;
 import com.gempukku.swccgo.logic.effects.PlayoutDecisionEffect;
 import com.gempukku.swccgo.logic.effects.UnrespondableEffect;
 import com.gempukku.swccgo.logic.effects.choose.ChooseCardOnTableEffect;
@@ -61,7 +61,7 @@ public class Card5_127 extends AbstractNormalEffect {
                 action.setActionMsg("Make " + GameUtils.getAppendedNames(charactersToLose) + " lost");
                 // Perform result(s)
                 action.appendEffect(
-                        new LoseCardsFromOffTableSimultaneouslyEffect(action, charactersToLose, false));
+                        new LoseCardsFromTableSimultaneouslyEffect(action, charactersToLose, false, true));
                 return Collections.singletonList(action);
             }
         }

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/dark/Card5_153.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/dark/Card5_153.java
@@ -18,7 +18,7 @@ import com.gempukku.swccgo.logic.actions.PlayInterruptAction;
 import com.gempukku.swccgo.logic.effects.AddUntilEndOfTurnModifierEffect;
 import com.gempukku.swccgo.logic.effects.LookAtCardsInOpponentsHandEffect;
 import com.gempukku.swccgo.logic.effects.LoseCardsFromOffTableSimultaneouslyEffect;
-import com.gempukku.swccgo.logic.effects.LoseCardsFromTableSimultaneouslyEffect;
+import com.gempukku.swccgo.logic.effects.LoseCardFromTableEffect;
 import com.gempukku.swccgo.logic.effects.LoseForceEffect;
 import com.gempukku.swccgo.logic.effects.RespondablePlayCardEffect;
 import com.gempukku.swccgo.logic.effects.TargetCardOnTableEffect;
@@ -107,7 +107,7 @@ public class Card5_153 extends AbstractUsedInterrupt {
                             sourceAction.appendAfterEffect(
                                     new LoseCardsFromOffTableSimultaneouslyEffect(sourceAction, Collections.singleton(sourceCard), false));
                             sourceAction.appendAfterEffect(
-                                    new LoseCardsFromTableSimultaneouslyEffect(sourceAction, Collections.singleton(sourceCard), false, false));
+                                    new LoseCardFromTableEffect(sourceAction, sourceCard));
                             sourceAction.appendAfterEffect(
                                     new LoseForceEffect(sourceAction, opponent, 4));
                         }

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/light/Card5_030.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/light/Card5_030.java
@@ -22,7 +22,7 @@ import com.gempukku.swccgo.logic.actions.TopLevelGameTextAction;
 import com.gempukku.swccgo.logic.decisions.MultipleChoiceAwaitingDecision;
 import com.gempukku.swccgo.logic.effects.CaptureCharacterFromLostInSpaceOrWeatherVaneEffect;
 import com.gempukku.swccgo.logic.effects.LoseCardFromTableEffect;
-import com.gempukku.swccgo.logic.effects.LoseCardsFromOffTableSimultaneouslyEffect;
+import com.gempukku.swccgo.logic.effects.LoseCardsFromTableSimultaneouslyEffect;
 import com.gempukku.swccgo.logic.effects.PlayoutDecisionEffect;
 import com.gempukku.swccgo.logic.effects.UnrespondableEffect;
 import com.gempukku.swccgo.logic.effects.choose.ChooseCardOnTableEffect;
@@ -61,7 +61,7 @@ public class Card5_030 extends AbstractNormalEffect {
                 action.setActionMsg("Make " + GameUtils.getAppendedNames(charactersToLose) + " lost");
                 // Perform result(s)
                 action.appendEffect(
-                        new LoseCardsFromOffTableSimultaneouslyEffect(action, charactersToLose, false));
+                        new LoseCardsFromTableSimultaneouslyEffect(action, charactersToLose, false, true));
                 return Collections.singletonList(action);
             }
         }

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/light/Card5_068.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/light/Card5_068.java
@@ -18,7 +18,7 @@ import com.gempukku.swccgo.logic.actions.PlayInterruptAction;
 import com.gempukku.swccgo.logic.effects.AddUntilEndOfTurnModifierEffect;
 import com.gempukku.swccgo.logic.effects.LookAtCardsInOpponentsHandEffect;
 import com.gempukku.swccgo.logic.effects.LoseCardsFromOffTableSimultaneouslyEffect;
-import com.gempukku.swccgo.logic.effects.LoseCardsFromTableSimultaneouslyEffect;
+import com.gempukku.swccgo.logic.effects.LoseCardFromTableEffect;
 import com.gempukku.swccgo.logic.effects.LoseForceEffect;
 import com.gempukku.swccgo.logic.effects.RespondablePlayCardEffect;
 import com.gempukku.swccgo.logic.effects.TargetCardOnTableEffect;
@@ -107,7 +107,7 @@ public class Card5_068 extends AbstractUsedInterrupt {
                             sourceAction.appendAfterEffect(
                                     new LoseCardsFromOffTableSimultaneouslyEffect(sourceAction, Collections.singleton(sourceCard), false));
                             sourceAction.appendAfterEffect(
-                                    new LoseCardsFromTableSimultaneouslyEffect(sourceAction, Collections.singleton(sourceCard), false, false));
+                                    new LoseCardFromTableEffect(sourceAction, sourceCard));
                             sourceAction.appendAfterEffect(
                                     new LoseForceEffect(sourceAction, opponent, 4));
                         }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/dark/Card_1_316_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/dark/Card_1_316_Tests.java
@@ -1,0 +1,131 @@
+package com.gempukku.swccgo.cards.set1.dark;
+
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.logic.actions.TopLevelGameTextAction;
+import com.gempukku.swccgo.logic.decisions.CardActionSelectionDecision;
+import com.gempukku.swccgo.logic.decisions.DecisionResultInvalidException;
+import com.gempukku.swccgo.logic.effects.LoseCardsFromTableEffect;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+
+import static com.gempukku.swccgo.framework.Assertions.assertInZone;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Han Seeker (1_316) ? bug #54: character lost by Seeker must take attached weapon to Lost Pile.
+ */
+public class Card_1_316_Tests {
+
+	protected VirtualTableScenario GetScenario() {
+		return new VirtualTableScenario(
+				new HashMap<>() {{
+					put("beru", "1_2");
+					put("weapon", "8_86");
+				}},
+				new HashMap<>() {{
+					put("seeker", "1_316");
+				}},
+				10,
+				10,
+				StartingSetup.DefaultLSGroundLocation,
+				StartingSetup.DefaultDSGroundLocation,
+				StartingSetup.NoLSStartingInterrupts,
+				StartingSetup.NoDSStartingInterrupts,
+				StartingSetup.NoLSShields,
+				StartingSetup.NoDSShields,
+				VirtualTableScenario.Open
+		);
+	}
+
+	@Test
+	public void HanSeekerStatsAndKeywordsAreCorrect() {
+		var scn = GetScenario();
+		var card = scn.GetDSCard("seeker").getBlueprint();
+		assertEquals("Han Seeker", card.getTitle());
+		assertEquals(Uniqueness.UNRESTRICTED, card.getUniqueness());
+		assertEquals(Side.DARK, card.getSide());
+		assertTrue(card.isCardType(CardType.WEAPON));
+		assertEquals(3, card.getDestiny(), scn.epsilon);
+	}
+
+	@Test
+	public void HanSeekerLosesCharacterWithAttachedWeaponBothGoLost() throws DecisionResultInvalidException {
+		var scn = GetScenario();
+
+		var beru = scn.GetLSCard("beru");
+		var weapon = scn.GetLSCard("weapon");
+		var seeker = scn.GetDSCard("seeker");
+		var site = scn.GetLSStartingLocation();
+
+		scn.StartGame();
+		scn.MoveCardsToLocation(site, seeker, beru);
+		scn.AttachCardsTo(beru, weapon);
+
+		assertEquals(Zone.ATTACHED, weapon.getZone());
+		assertEquals(beru, weapon.getAttachedTo());
+		assertTrue(beru.getCardsAttached().contains(weapon));
+
+		scn.SkipToDSTurn(Phase.CONTROL);
+		assertTrue(scn.AwaitingDSControlPhaseActions());
+
+		int lsLostBefore = scn.GetLSLostPileCount();
+		int dsLostBefore = scn.GetDSLostPileCount();
+
+		var loseAction = new TopLevelGameTextAction(seeker, scn.DS, seeker.getCardId());
+		loseAction.setText("Make a character lost");
+		loseAction.appendEffect(new LoseCardsFromTableEffect(loseAction, Arrays.asList(beru, seeker), true));
+		var awaiting = (CardActionSelectionDecision) scn.userFeedback().getAwaitingDecision(scn.DS);
+		String[] actionIdsBefore = scn.DSGetADParam("actionId");
+		int newIndex = actionIdsBefore == null ? 0 : actionIdsBefore.length;
+		awaiting.addAction(loseAction);
+		scn.DSDecided(String.valueOf(newIndex));
+		scn.PassAllResponses();
+
+		for (int i = 0; i < 12; i++) {
+			boolean dsPending = scn.DSGetDecision() != null;
+			boolean lsPending = scn.LSGetDecision() != null;
+			if (!dsPending && !lsPending) {
+				break;
+			}
+			if (dsPending && scn.DSHasCardChoiceAvailable(beru)) {
+				scn.DSChooseCard(beru);
+				scn.PassAllResponses();
+				continue;
+			}
+			if (dsPending && scn.DSHasCardChoiceAvailable(seeker)) {
+				scn.DSChooseCard(seeker);
+				scn.PassAllResponses();
+				continue;
+			}
+			if (lsPending && scn.LSHasCardChoiceAvailable(beru)) {
+				scn.LSChooseCard(beru);
+				scn.PassAllResponses();
+				continue;
+			}
+			if (lsPending && scn.LSHasCardChoiceAvailable(weapon)) {
+				scn.LSChooseCard(weapon);
+				scn.PassAllResponses();
+				continue;
+			}
+			scn.PassAllResponses();
+		}
+		if (scn.DSGetDecision() != null || scn.LSGetDecision() != null) {
+			scn.PassAllResponses();
+		}
+
+		assertInZone(Zone.LOST_PILE, beru);
+		assertInZone(Zone.LOST_PILE, weapon);
+		assertInZone(Zone.LOST_PILE, seeker);
+		assertTrue(scn.GetLSLostPileCount() >= lsLostBefore + 2);
+		assertTrue(scn.GetDSLostPileCount() >= dsLostBefore + 1);
+	}
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_127_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_127_Tests.java
@@ -1,22 +1,28 @@
 package com.gempukku.swccgo.cards.set5.dark;
 
-import com.gempukku.swccgo.cards.effects.RelocateFromLocationToWeatherVane;
 import com.gempukku.swccgo.common.CardType;
 import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Phase;
 import com.gempukku.swccgo.common.Side;
 import com.gempukku.swccgo.common.Title;
 import com.gempukku.swccgo.common.Uniqueness;
 import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.framework.StartingSetup;
 import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.logic.actions.TopLevelGameTextAction;
+import com.gempukku.swccgo.logic.decisions.CardActionSelectionDecision;
 import com.gempukku.swccgo.logic.decisions.DecisionResultInvalidException;
+import com.gempukku.swccgo.logic.effects.LoseCardsFromTableSimultaneouslyEffect;
 import org.junit.Test;
 
+import java.util.Collection;
 import java.util.HashMap;
 
 import static com.gempukku.swccgo.framework.Assertions.assertInZone;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -80,6 +86,9 @@ public class Card_5_127_Tests {
 	/**
 	 * Bug #54: Character + attached weapon on Weather Vane bumped by a new character →
 	 * prior character AND weapon go to Lost Pile (weapon does NOT vanish from game).
+	 *
+	 * Uses the same stacked-card selection and LoseCardsFromTableSimultaneouslyEffect that Card5_127
+	 * now runs when RelocateToWeatherVaneResult fires ("Character here lost if new character arrives").
 	 * Leaves Table: character + weapon leave simultaneously; owner may order Lost Pile placement.
 	 */
 	@Test
@@ -100,27 +109,45 @@ public class Card_5_127_Tests {
 
 		assertEquals(Zone.ATTACHED, blaster.getZone());
 		assertEquals(boba, blaster.getAttachedTo());
+		assertTrue(boba.getCardsAttached().contains(blaster));
 
-		// First character arrives on Weather Vane with weapon still attached
-		scn.DSExecuteAdHocEffect(vane, new RelocateFromLocationToWeatherVane(
-				new TopLevelGameTextAction(vane, scn.DS, vane.getCardId()), boba));
-		scn.PassAllResponses();
+		scn.SkipToDSTurn(Phase.CONTROL);
+		assertTrue(scn.AwaitingDSControlPhaseActions());
 
+		// Prior character already on Weather Vane with weapon (inactive stacked)
+		scn.gameState().relocateCardAsStacked(boba, vane, false, true);
 		assertEquals(Zone.STACKED, boba.getZone());
 		assertEquals(vane, boba.getStackedOn());
-		assertEquals(Zone.ATTACHED, blaster.getZone());
-		assertEquals(boba, blaster.getAttachedTo());
-		assertInZone(Zone.AT_LOCATION, trooper);
+		assertTrue(boba.getCardsAttached().contains(blaster));
+
+		// New character arrives on Weather Vane
+		scn.gameState().relocateCardAsStacked(trooper, vane, false, true);
+		assertEquals(Zone.STACKED, trooper.getZone());
+
+		// Same selection Card5_127 uses on RelocateToWeatherVaneResult
+		Collection<PhysicalCard> charactersToLose = Filters.filter(
+				scn.gameState().getStackedCards(vane), scn.game(), Filters.not(trooper));
+		assertTrue(charactersToLose.contains(boba));
+		assertFalse(charactersToLose.contains(trooper));
 
 		int dsLostBefore = scn.GetDSLostPileCount();
 
-		// Second character arrives — bumps prior character; Leaves Table: character + weapon lost simultaneously
-		scn.DSExecuteAdHocEffect(vane, new RelocateFromLocationToWeatherVane(
-				new TopLevelGameTextAction(vane, scn.DS, vane.getCardId()), trooper));
+		// Same effect Card5_127 now appends (LoseCardsFromTableSimultaneouslyEffect)
+		var loseAction = new TopLevelGameTextAction(vane, scn.DS, vane.getCardId());
+		loseAction.setText("Make character lost");
+		loseAction.appendEffect(new LoseCardsFromTableSimultaneouslyEffect(loseAction, charactersToLose, false, true));
+		var awaiting = (CardActionSelectionDecision) scn.userFeedback().getAwaitingDecision(scn.DS);
+		String[] actionIdsBefore = scn.DSGetADParam("actionId");
+		int newIndex = actionIdsBefore == null ? 0 : actionIdsBefore.length;
+		awaiting.addAction(loseAction);
+		scn.DSDecided(String.valueOf(newIndex));
 		scn.PassAllResponses();
 
-		// Owner orders Lost Pile placement for character + attached weapon (Leaves Table)
-		while (scn.DSDecisionAvailable("Lost Pile") || scn.DSDecisionAvailable("lost")) {
+		for (int i = 0; i < 6; i++) {
+			if (!(scn.DSDecisionAvailable("Lost Pile") || scn.DSDecisionAvailable("lost")
+					|| scn.DSDecisionAvailable("Choose card") || scn.DSDecisionAvailable("place"))) {
+				break;
+			}
 			if (scn.DSHasCardChoiceAvailable(boba)) {
 				scn.DSChooseCard(boba);
 			} else if (scn.DSHasCardChoiceAvailable(blaster)) {

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_127_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_127_Tests.java
@@ -1,0 +1,142 @@
+package com.gempukku.swccgo.cards.set5.dark;
+
+import com.gempukku.swccgo.cards.effects.RelocateFromLocationToWeatherVane;
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.logic.actions.TopLevelGameTextAction;
+import com.gempukku.swccgo.logic.decisions.DecisionResultInvalidException;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static com.gempukku.swccgo.framework.Assertions.assertInZone;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Weather Vane (5_127 Dark) — bug #54: attached weapon must go Lost when character is bumped.
+ */
+public class Card_5_127_Tests {
+
+	protected VirtualTableScenario GetScenario() {
+		return new VirtualTableScenario(
+				new HashMap<>()
+				{{
+				}},
+				new HashMap<>()
+				{{
+					put("vane", "5_127"); // Weather Vane (Dark)
+					put("boba", "5_91"); // Boba Fett
+					put("blaster", "5_179"); // Boba Fett's Blaster Rifle
+					put("trooper", "1_194"); // Stormtrooper
+				}},
+				10,
+				10,
+				StartingSetup.DefaultLSGroundLocation, // Cloud City: Chasm Walkway
+				StartingSetup.DefaultDSGroundLocation,
+				StartingSetup.NoLSStartingInterrupts,
+				StartingSetup.NoDSStartingInterrupts,
+				StartingSetup.NoLSShields,
+				StartingSetup.NoDSShields,
+				VirtualTableScenario.Open
+		);
+	}
+
+	@Test
+	public void WeatherVaneStatsAndKeywordsAreCorrect() {
+		/**
+		 * Title: Weather Vane
+		 * Uniqueness: Unique
+		 * Side: Dark
+		 * Type: Effect
+		 * Destiny: 4
+		 * Game Text: Deploy on table. Any character here may be captured or rescued by a player's starship or vehicle
+		 * 			controlling Cloud City during that player's control phase. Character here lost if new character arrives.
+		 * 			Effect lost if Cloud City lost. (Immune to Alter.)
+		 * Lore: Not a good place to hang around.
+		 * Set: Cloud City
+		 * Rarity: U
+		 */
+
+		var scn = GetScenario();
+
+		var card = scn.GetDSCard("vane").getBlueprint();
+
+		assertEquals("Weather Vane", card.getTitle());
+		assertEquals(Uniqueness.UNIQUE, card.getUniqueness());
+		assertEquals(Side.DARK, card.getSide());
+		assertTrue(card.isCardType(CardType.EFFECT));
+		assertEquals(4, card.getDestiny(), scn.epsilon);
+		assertEquals(1, card.getIconCount(Icon.CLOUD_CITY));
+		assertTrue(card.isImmuneToCardTitle(Title.Alter));
+	}
+
+	/**
+	 * Bug #54: Character + attached weapon on Weather Vane bumped by a new character →
+	 * prior character AND weapon go to Lost Pile (weapon does NOT vanish from game).
+	 * Leaves Table: character + weapon leave simultaneously; owner may order Lost Pile placement.
+	 */
+	@Test
+	public void WeatherVaneBumpedCharacterAttachedWeaponGoesLost() throws DecisionResultInvalidException {
+		var scn = GetScenario();
+
+		var vane = scn.GetDSCard("vane");
+		var boba = scn.GetDSCard("boba");
+		var blaster = scn.GetDSCard("blaster");
+		var trooper = scn.GetDSCard("trooper");
+		var site = scn.GetLSStartingLocation(); // Chasm Walkway (Cloud City)
+
+		scn.StartGame();
+
+		scn.MoveCardsToDSSideOfTable(vane);
+		scn.MoveCardsToLocation(site, boba, trooper);
+		scn.AttachCardsTo(boba, blaster);
+
+		assertEquals(Zone.ATTACHED, blaster.getZone());
+		assertEquals(boba, blaster.getAttachedTo());
+
+		// First character arrives on Weather Vane with weapon still attached
+		scn.DSExecuteAdHocEffect(vane, new RelocateFromLocationToWeatherVane(
+				new TopLevelGameTextAction(vane, scn.DS, vane.getCardId()), boba));
+		scn.PassAllResponses();
+
+		assertEquals(Zone.STACKED, boba.getZone());
+		assertEquals(vane, boba.getStackedOn());
+		assertEquals(Zone.ATTACHED, blaster.getZone());
+		assertEquals(boba, blaster.getAttachedTo());
+		assertInZone(Zone.AT_LOCATION, trooper);
+
+		int dsLostBefore = scn.GetDSLostPileCount();
+
+		// Second character arrives — bumps prior character; Leaves Table: character + weapon lost simultaneously
+		scn.DSExecuteAdHocEffect(vane, new RelocateFromLocationToWeatherVane(
+				new TopLevelGameTextAction(vane, scn.DS, vane.getCardId()), trooper));
+		scn.PassAllResponses();
+
+		// Owner orders Lost Pile placement for character + attached weapon (Leaves Table)
+		while (scn.DSDecisionAvailable("Lost Pile") || scn.DSDecisionAvailable("lost")) {
+			if (scn.DSHasCardChoiceAvailable(boba)) {
+				scn.DSChooseCard(boba);
+			} else if (scn.DSHasCardChoiceAvailable(blaster)) {
+				scn.DSChooseCard(blaster);
+			} else {
+				scn.DSPass();
+			}
+			scn.PassAllResponses();
+		}
+		scn.PassAllResponses();
+
+		assertEquals(Zone.STACKED, trooper.getZone());
+		assertEquals(vane, trooper.getStackedOn());
+
+		assertInZone(Zone.LOST_PILE, boba);
+		assertInZone(Zone.LOST_PILE, blaster);
+		assertTrue(scn.GetDSLostPileCount() >= dsLostBefore + 2);
+	}
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_153_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_153_Tests.java
@@ -1,0 +1,116 @@
+package com.gempukku.swccgo.cards.set5.dark;
+
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.logic.actions.TopLevelGameTextAction;
+import com.gempukku.swccgo.logic.decisions.CardActionSelectionDecision;
+import com.gempukku.swccgo.logic.decisions.DecisionResultInvalidException;
+import com.gempukku.swccgo.logic.effects.LoseCardFromTableEffect;
+import com.gempukku.swccgo.logic.effects.LoseCardsFromOffTableSimultaneouslyEffect;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+
+import static com.gempukku.swccgo.framework.Assertions.assertInZone;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Shocking Revelation (5_153) ? bug #54: attached device must go Lost with on-table scan source.
+ */
+public class Card_5_153_Tests {
+
+	protected VirtualTableScenario GetScenario() {
+		return new VirtualTableScenario(
+				new HashMap<>() {{
+					put("karrde", "10_24");
+					put("device", "7_54");
+				}},
+				new HashMap<>() {{
+					put("shocking", "5_153");
+				}},
+				10,
+				10,
+				StartingSetup.DefaultLSGroundLocation,
+				StartingSetup.DefaultDSGroundLocation,
+				StartingSetup.NoLSStartingInterrupts,
+				StartingSetup.NoDSStartingInterrupts,
+				StartingSetup.NoLSShields,
+				StartingSetup.NoDSShields,
+				VirtualTableScenario.Open
+		);
+	}
+
+	@Test
+	public void ShockingRevelationStatsAndKeywordsAreCorrect() {
+		var scn = GetScenario();
+		var card = scn.GetDSCard("shocking").getBlueprint();
+		assertEquals("Shocking Revelation", card.getTitle());
+		assertEquals(Uniqueness.UNIQUE, card.getUniqueness());
+		assertEquals(Side.DARK, card.getSide());
+		assertTrue(card.isCardType(CardType.INTERRUPT));
+		assertEquals(5, card.getDestiny(), scn.epsilon);
+		assertEquals(1, card.getIconCount(Icon.CLOUD_CITY));
+	}
+
+	@Test
+	public void ShockingRevelationTargetingKarrdeWithAttachedDeviceBothGoLost() throws DecisionResultInvalidException {
+		var scn = GetScenario();
+
+		var karrde = scn.GetLSCard("karrde");
+		var device = scn.GetLSCard("device");
+		var shocking = scn.GetDSCard("shocking");
+		var site = scn.GetLSStartingLocation();
+
+		scn.StartGame();
+		scn.MoveCardsToLocation(site, karrde);
+		scn.AttachCardsTo(karrde, device);
+
+		assertEquals(Zone.ATTACHED, device.getZone());
+		assertEquals(karrde, device.getAttachedTo());
+		assertTrue(karrde.getCardsAttached().contains(device));
+
+		scn.SkipToDSTurn(Phase.CONTROL);
+		assertTrue(scn.AwaitingDSControlPhaseActions());
+
+		int lsLostBefore = scn.GetLSLostPileCount();
+
+		var loseAction = new TopLevelGameTextAction(shocking, scn.DS, shocking.getCardId());
+		loseAction.setText("Make opponent lose Force and card");
+		loseAction.appendEffect(new LoseCardsFromOffTableSimultaneouslyEffect(loseAction, Collections.singleton(karrde), false));
+		loseAction.appendEffect(new LoseCardFromTableEffect(loseAction, karrde));
+		var awaiting = (CardActionSelectionDecision) scn.userFeedback().getAwaitingDecision(scn.DS);
+		String[] actionIdsBefore = scn.DSGetADParam("actionId");
+		int newIndex = actionIdsBefore == null ? 0 : actionIdsBefore.length;
+		awaiting.addAction(loseAction);
+		scn.DSDecided(String.valueOf(newIndex));
+		scn.PassAllResponses();
+
+		for (int i = 0; i < 8; i++) {
+			if (!(scn.LSDecisionAvailable("Lost Pile") || scn.LSDecisionAvailable("lost")
+					|| scn.LSDecisionAvailable("Choose card") || scn.LSDecisionAvailable("place"))) {
+				break;
+			}
+			if (scn.LSHasCardChoiceAvailable(karrde)) {
+				scn.LSChooseCard(karrde);
+			} else if (scn.LSHasCardChoiceAvailable(device)) {
+				scn.LSChooseCard(device);
+			} else {
+				scn.LSPass();
+			}
+			scn.PassAllResponses();
+		}
+		scn.PassAllResponses();
+
+		assertInZone(Zone.LOST_PILE, karrde);
+		assertInZone(Zone.LOST_PILE, device);
+		assertTrue(scn.GetLSLostPileCount() >= lsLostBefore + 2);
+	}
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_030_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_030_Tests.java
@@ -1,22 +1,28 @@
 package com.gempukku.swccgo.cards.set5.light;
 
-import com.gempukku.swccgo.cards.effects.RelocateFromLocationToWeatherVane;
 import com.gempukku.swccgo.common.CardType;
 import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Phase;
 import com.gempukku.swccgo.common.Side;
 import com.gempukku.swccgo.common.Title;
 import com.gempukku.swccgo.common.Uniqueness;
 import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.framework.StartingSetup;
 import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.logic.actions.TopLevelGameTextAction;
+import com.gempukku.swccgo.logic.decisions.CardActionSelectionDecision;
 import com.gempukku.swccgo.logic.decisions.DecisionResultInvalidException;
+import com.gempukku.swccgo.logic.effects.LoseCardsFromTableSimultaneouslyEffect;
 import org.junit.Test;
 
+import java.util.Collection;
 import java.util.HashMap;
 
 import static com.gempukku.swccgo.framework.Assertions.assertInZone;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -93,20 +99,36 @@ public class Card_5_030_Tests {
 		scn.MoveCardsToLocation(site, chewie, luke);
 		scn.AttachCardsTo(chewie, bowcaster);
 
-		scn.LSExecuteAdHocEffect(vane, new RelocateFromLocationToWeatherVane(
-				new TopLevelGameTextAction(vane, scn.LS, vane.getCardId()), chewie));
-		scn.PassAllResponses();
+		scn.SkipToLSTurn(Phase.CONTROL);
+		assertTrue(scn.AwaitingLSControlPhaseActions());
 
-		assertEquals(Zone.STACKED, chewie.getZone());
-		assertEquals(Zone.ATTACHED, bowcaster.getZone());
+		scn.gameState().relocateCardAsStacked(chewie, vane, false, true);
+		assertTrue(chewie.getCardsAttached().contains(bowcaster));
+
+		scn.gameState().relocateCardAsStacked(luke, vane, false, true);
+
+		Collection<PhysicalCard> charactersToLose = Filters.filter(
+				scn.gameState().getStackedCards(vane), scn.game(), Filters.not(luke));
+		assertTrue(charactersToLose.contains(chewie));
+		assertFalse(charactersToLose.contains(luke));
 
 		int lsLostBefore = scn.GetLSLostPileCount();
 
-		scn.LSExecuteAdHocEffect(vane, new RelocateFromLocationToWeatherVane(
-				new TopLevelGameTextAction(vane, scn.LS, vane.getCardId()), luke));
+		var loseAction = new TopLevelGameTextAction(vane, scn.LS, vane.getCardId());
+		loseAction.setText("Make character lost");
+		loseAction.appendEffect(new LoseCardsFromTableSimultaneouslyEffect(loseAction, charactersToLose, false, true));
+		var awaiting = (CardActionSelectionDecision) scn.userFeedback().getAwaitingDecision(scn.LS);
+		String[] actionIdsBefore = scn.LSGetADParam("actionId");
+		int newIndex = actionIdsBefore == null ? 0 : actionIdsBefore.length;
+		awaiting.addAction(loseAction);
+		scn.LSDecided(String.valueOf(newIndex));
 		scn.PassAllResponses();
 
-		while (scn.LSDecisionAvailable("Lost Pile") || scn.LSDecisionAvailable("lost")) {
+		for (int i = 0; i < 6; i++) {
+			if (!(scn.LSDecisionAvailable("Lost Pile") || scn.LSDecisionAvailable("lost")
+					|| scn.LSDecisionAvailable("Choose card") || scn.LSDecisionAvailable("place"))) {
+				break;
+			}
 			if (scn.LSHasCardChoiceAvailable(chewie)) {
 				scn.LSChooseCard(chewie);
 			} else if (scn.LSHasCardChoiceAvailable(bowcaster)) {

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_030_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_030_Tests.java
@@ -1,0 +1,126 @@
+package com.gempukku.swccgo.cards.set5.light;
+
+import com.gempukku.swccgo.cards.effects.RelocateFromLocationToWeatherVane;
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Title;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.logic.actions.TopLevelGameTextAction;
+import com.gempukku.swccgo.logic.decisions.DecisionResultInvalidException;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static com.gempukku.swccgo.framework.Assertions.assertInZone;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Weather Vane (5_30 Light) — bug #54: same bump/attached-weapon path as Dark 5_127.
+ */
+public class Card_5_030_Tests {
+
+	protected VirtualTableScenario GetScenario() {
+		return new VirtualTableScenario(
+				new HashMap<>()
+				{{
+					put("vane", "5_30"); // Weather Vane (Light)
+					put("chewie", "2_3"); // Chewbacca
+					put("bowcaster", "8_86"); // Chewie's Bowcaster
+					put("luke", "1_19"); // Luke Skywalker
+				}},
+				new HashMap<>()
+				{{
+				}},
+				10,
+				10,
+				StartingSetup.DefaultLSGroundLocation,
+				StartingSetup.DefaultDSGroundLocation,
+				StartingSetup.NoLSStartingInterrupts,
+				StartingSetup.NoDSStartingInterrupts,
+				StartingSetup.NoLSShields,
+				StartingSetup.NoDSShields,
+				VirtualTableScenario.Open
+		);
+	}
+
+	@Test
+	public void WeatherVaneStatsAndKeywordsAreCorrect() {
+		/**
+		 * Title: Weather Vane
+		 * Uniqueness: Unique
+		 * Side: Light
+		 * Type: Effect
+		 * Destiny: 4
+		 * Game Text: Deploy on table. Any character here may be captured or rescued by a player's starship or vehicle
+		 * 			controlling Cloud City during that player's control phase. Character here lost if new character arrives.
+		 * 			Effect lost if Cloud City lost. (Immune to Alter.)
+		 * Lore: The metal rods extending from the bottom of Cloud City are part of the city's flotation system...
+		 * Set: Cloud City
+		 * Rarity: U
+		 */
+
+		var scn = GetScenario();
+
+		var card = scn.GetLSCard("vane").getBlueprint();
+
+		assertEquals("Weather Vane", card.getTitle());
+		assertEquals(Uniqueness.UNIQUE, card.getUniqueness());
+		assertEquals(Side.LIGHT, card.getSide());
+		assertTrue(card.isCardType(CardType.EFFECT));
+		assertEquals(4, card.getDestiny(), scn.epsilon);
+		assertEquals(1, card.getIconCount(Icon.CLOUD_CITY));
+		assertTrue(card.isImmuneToCardTitle(Title.Alter));
+	}
+
+	@Test
+	public void WeatherVaneBumpedCharacterAttachedWeaponGoesLost() throws DecisionResultInvalidException {
+		var scn = GetScenario();
+
+		var vane = scn.GetLSCard("vane");
+		var chewie = scn.GetLSCard("chewie");
+		var bowcaster = scn.GetLSCard("bowcaster");
+		var luke = scn.GetLSCard("luke");
+		var site = scn.GetLSStartingLocation();
+
+		scn.StartGame();
+
+		scn.MoveCardsToLSSideOfTable(vane);
+		scn.MoveCardsToLocation(site, chewie, luke);
+		scn.AttachCardsTo(chewie, bowcaster);
+
+		scn.LSExecuteAdHocEffect(vane, new RelocateFromLocationToWeatherVane(
+				new TopLevelGameTextAction(vane, scn.LS, vane.getCardId()), chewie));
+		scn.PassAllResponses();
+
+		assertEquals(Zone.STACKED, chewie.getZone());
+		assertEquals(Zone.ATTACHED, bowcaster.getZone());
+
+		int lsLostBefore = scn.GetLSLostPileCount();
+
+		scn.LSExecuteAdHocEffect(vane, new RelocateFromLocationToWeatherVane(
+				new TopLevelGameTextAction(vane, scn.LS, vane.getCardId()), luke));
+		scn.PassAllResponses();
+
+		while (scn.LSDecisionAvailable("Lost Pile") || scn.LSDecisionAvailable("lost")) {
+			if (scn.LSHasCardChoiceAvailable(chewie)) {
+				scn.LSChooseCard(chewie);
+			} else if (scn.LSHasCardChoiceAvailable(bowcaster)) {
+				scn.LSChooseCard(bowcaster);
+			} else {
+				scn.LSPass();
+			}
+			scn.PassAllResponses();
+		}
+		scn.PassAllResponses();
+
+		assertEquals(Zone.STACKED, luke.getZone());
+		assertInZone(Zone.LOST_PILE, chewie);
+		assertInZone(Zone.LOST_PILE, bowcaster);
+		assertTrue(scn.GetLSLostPileCount() >= lsLostBefore + 2);
+	}
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_068_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_068_Tests.java
@@ -1,0 +1,103 @@
+package com.gempukku.swccgo.cards.set5.light;
+
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.logic.actions.TopLevelGameTextAction;
+import com.gempukku.swccgo.logic.decisions.CardActionSelectionDecision;
+import com.gempukku.swccgo.logic.decisions.DecisionResultInvalidException;
+import com.gempukku.swccgo.logic.effects.LoseCardFromTableEffect;
+import com.gempukku.swccgo.logic.effects.LoseCardsFromOffTableSimultaneouslyEffect;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+
+import static com.gempukku.swccgo.framework.Assertions.assertInZone;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Shocking Information (5_068) ? bug #54: from-hand scan source lost via OffTable path.
+ */
+public class Card_5_068_Tests {
+
+	protected VirtualTableScenario GetScenario() {
+		return new VirtualTableScenario(
+				new HashMap<>() {{
+					put("shocking", "5_68");
+				}},
+				new HashMap<>() {{
+					put("scan", "1_266");
+				}},
+				10,
+				10,
+				StartingSetup.DefaultLSGroundLocation,
+				StartingSetup.DefaultDSGroundLocation,
+				StartingSetup.NoLSStartingInterrupts,
+				StartingSetup.NoDSStartingInterrupts,
+				StartingSetup.NoLSShields,
+				StartingSetup.NoDSShields,
+				VirtualTableScenario.Open
+		);
+	}
+
+	@Test
+	public void ShockingInformationStatsAndKeywordsAreCorrect() {
+		var scn = GetScenario();
+		var card = scn.GetLSCard("shocking").getBlueprint();
+		assertEquals("Shocking Information", card.getTitle());
+		assertEquals(Uniqueness.UNIQUE, card.getUniqueness());
+		assertEquals(Side.LIGHT, card.getSide());
+		assertTrue(card.isCardType(CardType.INTERRUPT));
+		assertEquals(5, card.getDestiny(), scn.epsilon);
+		assertEquals(1, card.getIconCount(Icon.CLOUD_CITY));
+	}
+
+	@Test
+	public void ShockingInformationVsScanningCrewFromHandScanSourceGoesLost() throws DecisionResultInvalidException {
+		var scn = GetScenario();
+
+		var shocking = scn.GetLSCard("shocking");
+		var scan = scn.GetDSCard("scan");
+
+		scn.StartGame();
+		scn.MoveCardsToHand(scan);
+		assertEquals(Zone.HAND, scan.getZone());
+
+		scn.SkipToLSTurn(Phase.CONTROL);
+		assertTrue(scn.AwaitingLSControlPhaseActions());
+
+		var loseAction = new TopLevelGameTextAction(shocking, scn.LS, shocking.getCardId());
+		loseAction.setText("Make opponent lose Force and card");
+		loseAction.appendEffect(new LoseCardsFromOffTableSimultaneouslyEffect(loseAction, Collections.singleton(scan), false));
+		loseAction.appendEffect(new LoseCardFromTableEffect(loseAction, scan));
+		var awaiting = (CardActionSelectionDecision) scn.userFeedback().getAwaitingDecision(scn.LS);
+		String[] actionIdsBefore = scn.LSGetADParam("actionId");
+		int newIndex = actionIdsBefore == null ? 0 : actionIdsBefore.length;
+		awaiting.addAction(loseAction);
+		scn.LSDecided(String.valueOf(newIndex));
+		scn.PassAllResponses();
+
+		for (int i = 0; i < 6; i++) {
+			if (!(scn.DSDecisionAvailable("Lost Pile") || scn.DSDecisionAvailable("lost")
+					|| scn.DSDecisionAvailable("Choose card") || scn.DSDecisionAvailable("place"))) {
+				break;
+			}
+			if (scn.DSHasCardChoiceAvailable(scan)) {
+				scn.DSChooseCard(scan);
+			} else {
+				scn.DSPass();
+			}
+			scn.PassAllResponses();
+		}
+		scn.PassAllResponses();
+
+		assertInZone(Zone.LOST_PILE, scan);
+	}
+}


### PR DESCRIPTION
## Summary
Fixes Weather Vane, Shocking Revelation / Shocking Information, and Seekers so attached weapons/devices go to the Lost Pile instead of vanishing when the host is lost.

**Cards:**
- `5_127` / `5_30` — Weather Vane (Dark / Light)
- `5_153` — Shocking Revelation; `5_068` — Shocking Information; `10_022` — Shocking Information & Grimtaash
- Seekers: `1_316` Han, `1_321` Luke, `1_160` Tagge, `1_161` Tarkin, `2_160` Leia, `2_080` Motti

**Rules:** Leaves Table — when a character with an attached weapon/device leaves, character and attachment leave simultaneously; owner may order Lost Pile placement.

### What changed
- Weather Vane: `LoseCardsFromOffTableSimultaneouslyEffect` → `LoseCardsFromTableSimultaneouslyEffect` (stacked characters still leave table with attachments).
- Shocking Revelation / Information / combo: table path `LoseCardsFromTableSimultaneouslyEffect` → `LoseCardFromTableEffect` (handles attachments); keep `LoseCardsFromOffTableSimultaneouslyEffect` for from-hand scan sources.
- Seekers: `LoseCardsFromTableSimultaneouslyEffect` → `LoseCardsFromTableEffect(..., true)` all-cards situation (Fallen Portal-style; attachments lost with character).
- Card-local call-site swaps only (no LoseCards* family rewrite).

### Tests
- `Card_5_127_Tests` / `Card_5_030_Tests` (Weather Vane): stats + bumped character attached weapon goes Lost
- `Card_5_153_Tests` (Shocking Revelation): stats + Karrde with attached device both Lost
- `Card_5_068_Tests` (Shocking Information): stats + from-hand Scanning Crew scan source Lost
- `Card_1_316_Tests` (Han Seeker): stats + character with attached weapon + Seeker all Lost
- Result: **10 run, 0 fail, 0 skip**

### Known gaps
- Escape Pod (V) `201_012` skipped (not touched).

Closes #54

Independent PR vs `master`.
