### PR TITLE
Fix Trash Compactor system leak (#736) and Falcon+Captain Han Dagobah ride (#760)

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/AbstractStarship.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/AbstractStarship.java
@@ -21,8 +21,6 @@ import com.gempukku.swccgo.game.ReactActionOption;
 import com.gempukku.swccgo.game.SwccgGame;
 import com.gempukku.swccgo.game.state.GameState;
 import com.gempukku.swccgo.logic.actions.PlayCardAction;
-import com.gempukku.swccgo.logic.modifiers.Modifier;
-import com.gempukku.swccgo.logic.modifiers.ModifierType;
 import com.gempukku.swccgo.logic.modifiers.querying.ModifiersQuerying;
 
 import java.util.ArrayList;
@@ -572,30 +570,19 @@ public abstract class AbstractStarship extends AbstractDeployable {
         Filter pilotTargetFilter = Filters.any;
         boolean spyPilot = Filters.spy.accepts(game, character);
 
-
-        // By default, no 'deploymentRestrictionOption's are passed in. However, we want to honor the ability
-        // to deploy without presence or force icons on some starships. For those cases, build a DeploymentRestrictionOption
-        // on the fly (or update the one that was passed in (if any))
-        DeploymentRestrictionsOption updatedDeployementRestrictionOption = deploymentRestrictionsOption;
-        for (Modifier modifier: game.getModifiersQuerying().getModifiersAffecting(game.getGameState(), self)) {
-            if (modifier.getModifierType() == ModifierType.MAY_DEPLOY_WITHOUT_PRESENCE_OR_FORCE_ICONS) {
-                if (updatedDeployementRestrictionOption == null) {
-                    updatedDeployementRestrictionOption = DeploymentRestrictionsOption.evenWithoutPresenceOrForceIcons();
-                } else {
-                    updatedDeployementRestrictionOption.setEvenWithoutPresenceOrForceIcons(true);
-                }
-            }
-        }
-
+        // Do not promote location-scoped MAY_DEPLOY_WITHOUT_PRESENCE_OR_FORCE_ICONS modifiers
+        // (e.g. Trash Compactor) into a blanket DeploymentRestrictionsOption. Those are honored
+        // per-target via Filters.sufficientPresenceOrForceIconsToDeployTo / isAffectedTarget.
+        // Same root as issue #47 / #736.
 
         // Check if pilot can deploy to this card (regardless of its location), if not then need to check for locations that pilot is allowed to deploy to
         if (!character.getBlueprint().getValidSimultaneouslyDeployingStarshipOrVehicleToAnyLocationFilter(playerId, game, character).accepts(game.getGameState(), game.getModifiersQuerying(), self)) {
-            pilotTargetFilter = Filters.locationAndCardsAtLocation(character.getBlueprint().getValidLocationForSimultaneouslyDeployingAsPilotOrPassengerFilter(playerId, game, character, sourceCard, updatedDeployementRestrictionOption, reactActionOption));
+            pilotTargetFilter = Filters.locationAndCardsAtLocation(character.getBlueprint().getValidLocationForSimultaneouslyDeployingAsPilotOrPassengerFilter(playerId, game, character, sourceCard, deploymentRestrictionsOption, reactActionOption));
         }
 
         pilotTargetFilter = Filters.and(pilotTargetFilter, Filters.canUseForceToDeploySimultaneouslyToTarget(sourceCard, self, forFree, changeInCost, character, characterForFree, characterChangeInCost, reactActionOption));
 
-        return Filters.and(getValidDeployTargetFilter(playerId, game, self, sourceCard, null, forFree, changeInCost, updatedDeployementRestrictionOption, null, reactActionOption, true, spyPilot), pilotTargetFilter);
+        return Filters.and(getValidDeployTargetFilter(playerId, game, self, sourceCard, null, forFree, changeInCost, deploymentRestrictionsOption, null, reactActionOption, true, spyPilot), pilotTargetFilter);
     }
 
     /**

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/AbstractStarship.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/AbstractStarship.java
@@ -580,6 +580,29 @@ public abstract class AbstractStarship extends AbstractDeployable {
             pilotTargetFilter = Filters.locationAndCardsAtLocation(character.getBlueprint().getValidLocationForSimultaneouslyDeployingAsPilotOrPassengerFilter(playerId, game, character, sourceCard, deploymentRestrictionsOption, reactActionOption));
         }
 
+        // Even when the pilot may board this ship regardless of location (e.g. Captain Han
+        // "deploys only on Falcon"), still honor per-target Dagobah / Ahch-To prohibitions (#760).
+        // Same grantedToDeployToDagobahTarget check used by isProhibitedFromDeployingTo.
+        if (deploymentRestrictionsOption == null || !deploymentRestrictionsOption.isIgnoreLocationDeploymentRestrictions()) {
+            final PhysicalCard pilot = character;
+            pilotTargetFilter = Filters.and(pilotTargetFilter, new Filter() {
+                @Override
+                public boolean accepts(GameState gameState, ModifiersQuerying modifiersQuerying, PhysicalCard physicalCard) {
+                    PhysicalCard location = modifiersQuerying.getLocationHere(gameState, physicalCard);
+                    if (location == null) {
+                        return true;
+                    }
+                    if (Filters.Dagobah_location.accepts(gameState, modifiersQuerying, location)) {
+                        return modifiersQuerying.grantedToDeployToDagobahTarget(gameState, pilot, physicalCard);
+                    }
+                    if (Filters.AhchTo_location.accepts(gameState, modifiersQuerying, location)) {
+                        return modifiersQuerying.grantedToDeployToAhchToTarget(gameState, pilot, physicalCard);
+                    }
+                    return true;
+                }
+            });
+        }
+
         pilotTargetFilter = Filters.and(pilotTargetFilter, Filters.canUseForceToDeploySimultaneouslyToTarget(sourceCard, self, forFree, changeInCost, character, characterForFree, characterChangeInCost, reactActionOption));
 
         return Filters.and(getValidDeployTargetFilter(playerId, game, self, sourceCard, null, forFree, changeInCost, deploymentRestrictionsOption, null, reactActionOption, true, spyPilot), pilotTargetFilter);

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_125_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_125_Tests.java
@@ -8,6 +8,7 @@ import com.gempukku.swccgo.common.Side;
 import com.gempukku.swccgo.common.Uniqueness;
 import com.gempukku.swccgo.framework.StartingSetup;
 import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.game.PhysicalCardImpl;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -23,7 +24,10 @@ public class Card_1_125_Tests {
                 new HashMap<>() {{
                     put("trashCompactor", "1_125"); // Death Star: Trash Compactor
                     put("han", "1_011"); // Han Solo
+                    put("captainHan", "5_001"); // Captain Han Solo
+                    put("falcon", "1_143"); // Millennium Falcon
                     put("xwing", "1_146"); // X-wing
+                    put("ccDockingBay", "5_083"); // Cloud City: Platform 327 (Docking Bay)
                 }},
                 new HashMap<>() {{
                     put("deathStar", "2_143"); // Death Star system
@@ -38,6 +42,36 @@ public class Card_1_125_Tests {
                 StartingSetup.NoDSShields,
                 VirtualTableScenario.Open
         );
+    }
+
+    /**
+     * Activate Force before Deploy so the Falcon Deploy action is built with
+     * enough Force for Falcon + Captain Han (7). Cheating after SkipTo leaves
+     * a stale empty-ship-only action.
+     */
+    private void setupFalconAndPilotReadyToDeploy(VirtualTableScenario scn, PhysicalCardImpl... extraLocations) {
+        var falcon = scn.GetLSCard("falcon");
+        var captainHan = scn.GetLSCard("captainHan");
+        scn.StartGame();
+        for (PhysicalCardImpl location : extraLocations) {
+            scn.MoveLocationToTable(location);
+        }
+        scn.MoveCardsToLSHand(falcon, captainHan);
+        scn.LSActivateForceCheat(10);
+        scn.SkipToLSTurn(Phase.DEPLOY);
+    }
+
+    /**
+     * Drive the real UI: Deploy Falcon → Yes to simultaneous pilot → choose pilot.
+     * Fails if the action was empty-ship only (the stale-action / not-enough-Force path).
+     */
+    private void beginFalconSimultaneousDeployWithPilot(VirtualTableScenario scn, PhysicalCardImpl falcon, PhysicalCardImpl pilot) {
+        assertTrue(scn.LSDeployAvailable(falcon));
+        scn.LSDeployCard(falcon);
+        assertTrue(scn.LSDecisionAvailable("simultaneously deploy a pilot"));
+        scn.LSChooseYes();
+        assertTrue(scn.LSHasCardChoiceAvailable(pilot));
+        scn.LSChooseCard(pilot);
     }
 
     @Test
@@ -89,7 +123,7 @@ public class Card_1_125_Tests {
 
     @Test
     public void TrashCompactorDoesNotAllowPermanentPilotXwingDeployToDeathStarSystem() {
-        // #736 / same root #47: permanent-pilot ships stay correctly blocked at Death Star system
+        // Permanent-pilot ships stay correctly blocked at Death Star system
         var scn = GetScenario();
 
         var trashCompactor = scn.GetLSCard("trashCompactor");
@@ -111,5 +145,50 @@ public class Card_1_125_Tests {
         assertTrue(scn.LSDecisionAvailable("Choose where to deploy"));
         assertTrue(scn.LSHasCardChoiceAvailable(lsSystem));
         assertFalse(scn.LSHasCardChoiceAvailable(deathStar));
+    }
+
+    @Test
+    public void TrashCompactorDoesNotAllowFalconAndPilotSimultaneousDeployToDeathStarSystem() {
+        // #736 real bug path: empty Falcon + Captain Han from hand must not unlock Death Star system
+        var scn = GetScenario();
+
+        var trashCompactor = scn.GetLSCard("trashCompactor");
+        var captainHan = scn.GetLSCard("captainHan");
+        var falcon = scn.GetLSCard("falcon");
+        var ccDockingBay = scn.GetLSCard("ccDockingBay");
+        var deathStar = scn.GetDSCard("deathStar");
+
+        setupFalconAndPilotReadyToDeploy(scn, deathStar, trashCompactor, ccDockingBay);
+
+        beginFalconSimultaneousDeployWithPilot(scn, falcon, captainHan);
+
+        assertTrue(scn.LSDecisionAvailable("Choose where to deploy"));
+        assertTrue(scn.LSHasCardChoiceAvailable(ccDockingBay));
+        assertFalse(scn.LSHasCardChoiceAvailable(deathStar));
+        assertFalse(scn.LSHasCardChoiceAvailable(trashCompactor));
+    }
+
+    @Test
+    public void TrashCompactorStillAllowsFalconAndPilotSimultaneousDeployToLegalSite() {
+        // Legal contrast: Falcon + Captain Han may still deploy together to a Cloud City docking bay
+        var scn = GetScenario();
+
+        var trashCompactor = scn.GetLSCard("trashCompactor");
+        var captainHan = scn.GetLSCard("captainHan");
+        var falcon = scn.GetLSCard("falcon");
+        var ccDockingBay = scn.GetLSCard("ccDockingBay");
+        var deathStar = scn.GetDSCard("deathStar");
+
+        setupFalconAndPilotReadyToDeploy(scn, deathStar, trashCompactor, ccDockingBay);
+
+        beginFalconSimultaneousDeployWithPilot(scn, falcon, captainHan);
+
+        assertTrue(scn.LSHasCardChoiceAvailable(ccDockingBay));
+        assertFalse(scn.LSHasCardChoiceAvailable(deathStar));
+        scn.LSChooseCard(ccDockingBay);
+        scn.PassAllResponses();
+
+        assertTrue(scn.CardsAtLocation(ccDockingBay, falcon));
+        assertTrue(scn.IsAboardAsPilot(falcon, captainHan));
     }
 }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_125_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_125_Tests.java
@@ -1,0 +1,115 @@
+package com.gempukku.swccgo.cards.set1.light;
+
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Card_1_125_Tests {
+
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("trashCompactor", "1_125"); // Death Star: Trash Compactor
+                    put("han", "1_011"); // Han Solo
+                    put("xwing", "1_146"); // X-wing
+                }},
+                new HashMap<>() {{
+                    put("deathStar", "2_143"); // Death Star system
+                }},
+                20,
+                20,
+                StartingSetup.DefaultLSSpaceSystem,
+                StartingSetup.DefaultDSSpaceSystem,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void TrashCompactorStatsAndKeywordsAreCorrect() {
+        /**
+         * Title: Death Star: Trash Compactor
+         * Uniqueness: Unique
+         * Side: Light
+         * Type: Location
+         * Subtype: Site
+         * Icons: Interior site, Mobile
+         * Game Text: You may deploy here without presence. If you control, Force drain +1 here.
+         * Set: Premiere
+         * Rarity: U1
+         */
+        var scn = GetScenario();
+        var card = scn.GetLSCard("trashCompactor").getBlueprint();
+        assertEquals("Death Star: Trash Compactor", card.getTitle());
+        assertEquals(Uniqueness.UNIQUE, card.getUniqueness());
+        assertEquals(Side.LIGHT, card.getSide());
+        assertEquals(ExpansionSet.PREMIERE, card.getExpansionSet());
+        assertEquals(Rarity.U1, card.getRarity());
+        assertTrue(card.hasIcon(Icon.INTERIOR_SITE));
+        assertTrue(card.hasIcon(Icon.MOBILE));
+    }
+
+    @Test
+    public void TrashCompactorStillAllowsHanDeployToTrashCompactorSite() {
+        // Site-only ignore presence still works at Trash Compactor; not at Death Star system
+        var scn = GetScenario();
+
+        var trashCompactor = scn.GetLSCard("trashCompactor");
+        var han = scn.GetLSCard("han");
+        var deathStar = scn.GetDSCard("deathStar");
+
+        scn.StartGame();
+        scn.MoveLocationToTable(deathStar);
+        scn.MoveLocationToTable(trashCompactor);
+        scn.MoveCardsToLSHand(han);
+
+        scn.SkipToLSTurn(Phase.DEPLOY);
+        scn.LSActivateForceCheat(5);
+
+        assertTrue(scn.LSDeployAvailable(han));
+        scn.LSDeployCard(han);
+        assertTrue(scn.LSHasCardChoiceAvailable(trashCompactor));
+        assertFalse(scn.LSHasCardChoiceAvailable(deathStar));
+    }
+
+    @Test
+    public void TrashCompactorDoesNotAllowPermanentPilotXwingDeployToDeathStarSystem() {
+        // #736 / same root #47: permanent-pilot ships stay correctly blocked at Death Star system
+        var scn = GetScenario();
+
+        var trashCompactor = scn.GetLSCard("trashCompactor");
+        var xwing = scn.GetLSCard("xwing");
+        var deathStar = scn.GetDSCard("deathStar");
+        var lsSystem = scn.GetLSStartingLocation();
+
+        scn.StartGame();
+        scn.MoveLocationToTable(deathStar);
+        scn.MoveLocationToTable(trashCompactor);
+        scn.MoveCardsToLSHand(xwing);
+
+        scn.SkipToLSTurn(Phase.DEPLOY);
+        scn.LSActivateForceCheat(5);
+
+        assertTrue(scn.LSDeployAvailable(xwing));
+        scn.LSDeployCard(xwing);
+
+        assertTrue(scn.LSDecisionAvailable("Choose where to deploy"));
+        assertTrue(scn.LSHasCardChoiceAvailable(lsSystem));
+        assertFalse(scn.LSHasCardChoiceAvailable(deathStar));
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set4/light/Card_4_085_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set4/light/Card_4_085_Tests.java
@@ -1,0 +1,161 @@
+package com.gempukku.swccgo.cards.set4.light;
+
+import com.gempukku.swccgo.common.CardSubtype;
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.game.PhysicalCardImpl;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Card_4_085_Tests {
+
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("bogClearing", "4_085"); // Dagobah: Bog Clearing
+                    put("captainHan", "5_001"); // Captain Han Solo
+                    put("falcon", "1_143"); // Millennium Falcon
+                    put("ccDockingBay", "5_083"); // Cloud City: Platform 327 (Docking Bay)
+                }},
+                new HashMap<>() {{
+                }},
+                20,
+                20,
+                StartingSetup.DefaultLSSpaceSystem,
+                StartingSetup.DefaultDSSpaceSystem,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    /**
+     * Activate Force before Deploy so the Falcon Deploy action is built with
+     * enough Force for Falcon + Captain Han (7). Cheating after SkipTo leaves
+     * a stale empty-ship-only action.
+     */
+    private void setupFalconAndPilotReadyToDeploy(VirtualTableScenario scn, PhysicalCardImpl... extraLocations) {
+        var falcon = scn.GetLSCard("falcon");
+        var captainHan = scn.GetLSCard("captainHan");
+        scn.StartGame();
+        for (PhysicalCardImpl location : extraLocations) {
+            scn.MoveLocationToTable(location);
+        }
+        scn.MoveCardsToLSHand(falcon, captainHan);
+        scn.LSActivateForceCheat(10);
+        scn.SkipToLSTurn(Phase.DEPLOY);
+    }
+
+    /**
+     * Drive the real UI: Deploy Falcon → Yes to simultaneous pilot → choose pilot.
+     */
+    private void beginFalconSimultaneousDeployWithPilot(VirtualTableScenario scn, PhysicalCardImpl falcon, PhysicalCardImpl pilot) {
+        assertTrue(scn.LSDeployAvailable(falcon));
+        scn.LSDeployCard(falcon);
+        assertTrue(scn.LSDecisionAvailable("simultaneously deploy a pilot"));
+        scn.LSChooseYes();
+        assertTrue(scn.LSHasCardChoiceAvailable(pilot));
+        scn.LSChooseCard(pilot);
+    }
+
+    @Test
+    public void BogClearingStatsAndKeywordsAreCorrect() {
+        /**
+         * Title: Dagobah: Bog Clearing
+         * Uniqueness: Unique
+         * Side: Light
+         * Type: Location
+         * Subtype: Site
+         * Icons: Dagobah, Exterior site, Planet
+         * Light Force Icons: 1
+         * Dark Force Icons: 0
+         * Game Text: Dark: If you occupy, Force generation +1 for you here.
+         *            Light: Your starfighters may deploy here and immune to Awwww, Cannot Get Your Ship Out here.
+         * Set: Dagobah
+         * Rarity: R
+         */
+        var scn = GetScenario();
+        var card = scn.GetLSCard("bogClearing").getBlueprint();
+        assertEquals("Dagobah: Bog Clearing", card.getTitle());
+        assertEquals(Uniqueness.UNIQUE, card.getUniqueness());
+        assertEquals(Side.LIGHT, card.getSide());
+        scn.BlueprintCardTypeCheck(card, new ArrayList<>() {{
+            add(CardType.LOCATION);
+        }});
+        assertEquals(CardSubtype.SITE, card.getCardSubtype());
+        scn.BlueprintIconCheck(card, new ArrayList<>() {{
+            add(Icon.DAGOBAH);
+            add(Icon.EXTERIOR_SITE);
+            add(Icon.PLANET);
+            add(Icon.LIGHT_FORCE);
+        }});
+        assertEquals(1, card.getIconCount(Icon.LIGHT_FORCE));
+        assertEquals(0, card.getIconCount(Icon.DARK_FORCE));
+        assertEquals(ExpansionSet.DAGOBAH, card.getExpansionSet());
+        assertEquals(Rarity.R, card.getRarity());
+    }
+
+    @Test
+    public void BogClearingDoesNotAllowCaptainHanToRideFalconThere() {
+        // #760: Falcon may land here, but Captain Han must not deploy to Dagobah with it
+        var scn = GetScenario();
+
+        var bogClearing = scn.GetLSCard("bogClearing");
+        var captainHan = scn.GetLSCard("captainHan");
+        var falcon = scn.GetLSCard("falcon");
+        var ccDockingBay = scn.GetLSCard("ccDockingBay");
+
+        setupFalconAndPilotReadyToDeploy(scn, bogClearing, ccDockingBay);
+
+        beginFalconSimultaneousDeployWithPilot(scn, falcon, captainHan);
+
+        assertTrue(scn.LSDecisionAvailable("Choose where to deploy"));
+        assertTrue(scn.LSHasCardChoiceAvailable(ccDockingBay));
+        assertFalse(scn.LSHasCardChoiceAvailable(bogClearing));
+
+        scn.LSChooseCard(ccDockingBay);
+        scn.PassAllResponses();
+
+        assertTrue(scn.CardsAtLocation(ccDockingBay, falcon));
+        assertTrue(scn.IsAboardAsPilot(falcon, captainHan));
+    }
+
+    @Test
+    public void BogClearingStillAllowsEmptyFalconToDeployThere() {
+        // Legal contrast: empty Falcon may still land at Bog Clearing
+        var scn = GetScenario();
+
+        var bogClearing = scn.GetLSCard("bogClearing");
+        var captainHan = scn.GetLSCard("captainHan");
+        var falcon = scn.GetLSCard("falcon");
+
+        setupFalconAndPilotReadyToDeploy(scn, bogClearing);
+
+        assertTrue(scn.LSDeployAvailable(falcon));
+        scn.LSDeployCard(falcon);
+        assertTrue(scn.LSDecisionAvailable("simultaneously deploy a pilot"));
+        scn.LSChooseNo();
+        assertTrue(scn.LSDecisionAvailable("Choose where to deploy"));
+        assertTrue(scn.LSHasCardChoiceAvailable(bogClearing));
+        scn.LSChooseCard(bogClearing);
+        scn.PassAllResponses();
+
+        assertTrue(scn.CardsAtLocation(bogClearing, falcon));
+        assertFalse(scn.IsAboardAsPilot(falcon, captainHan));
+    }
+}


### PR DESCRIPTION
## Summary
Trash Compactor's site-only "deploy without presence" text was unlocking the Death Star *system* for simultaneous empty-ship + pilot deploy. Separately, Captain Han Solo's "deploys only on Falcon" text let him ride Millennium Falcon onto Dagobah: Bog Clearing, which characters cannot deploy to.

## Cards
- **1_125 Death Star: Trash Compactor** — You may deploy here without presence.
- **4_085 Dagobah: Bog Clearing** — Light starfighters may deploy here; characters still may not.
- **5_001 Captain Han Solo** — Deploys only on Falcon, Hoth or Cloud City.
- **1_143 Millennium Falcon** — empty starfighter, no permanent pilot.

Closes #736
Closes #760
Related: #47

## What changed
- Stop promoting location-scoped `MAY_DEPLOY_WITHOUT_PRESENCE_OR_FORCE_ICONS` (Trash Compactor) into a blanket `DeploymentRestrictionsOption` on the simultaneous ship+pilot path. Per-target presence/icons stay on `Filters.sufficientPresenceOrForceIconsToDeployTo` / `isAffectedTarget`.
- When a pilot may board the ship regardless of location (Captain Han → Falcon), still honor per-target Dagobah / Ahch-To prohibitions via the same `grantedToDeployToDagobahTarget` / `grantedToDeployToAhchToTarget` checks used by `isProhibitedFromDeployingTo`. Does not use the full location filter (that would also block legal systems).
- AbstractVehicle / #315 Nysad is untouched.

## Tests
`Card_1_125_Tests` + `Card_4_085_Tests`: **8 run / 0 fail / 0 skip**

- Trash Compactor stats
- Solo Han still deploys to Trash Compactor, not Death Star system
- Permanent-pilot X-wing still cannot choose Death Star system
- Empty Falcon + Captain Han simultaneous deploy: Death Star system **not offered**; Cloud City docking bay remains legal and Han is aboard
- Falcon + Captain Han simultaneous deploy: Bog Clearing **not offered**; docking bay works and Han is aboard
- Empty Falcon (choose No) may still land at Bog Clearing

The simultaneous cases drive the real UI (Deploy Falcon → Yes to pilot → choose Captain Han → choose location). Force is activated before Deploy so the action is built with enough Force for Falcon+Han (7).