### PR TITLE
Fix Nysad react deploy to site when vehicle present (#315)

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/AbstractDeployable.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/AbstractDeployable.java
@@ -194,10 +194,16 @@ public abstract class AbstractDeployable extends AbstractNonLocationPlaysToTable
             return null;
         }
 
+        // Honor the react option target filter so e.g. aboard a vehicle does not also offer the site
+        Filter playTargetFilter = completeDeployTargetFilter;
+        if (reactActionOption.getTargetFilter() != null) {
+            playTargetFilter = Filters.and(completeDeployTargetFilter, reactActionOption.getTargetFilter());
+        }
+
         // Get the play card action using the react option, if any.
         PlayCardAction playCardAction = getPlayCardAction(playerId, game, self, reactActionFromOtherCard != null ? reactActionFromOtherCard.getSource() : self,
                 reactActionOption.isForFree() || (reactActionOption.getForFreeCardFilter() != null && reactActionOption.getForFreeCardFilter().accepts(game, self)),
-                reactActionOption.getChangeInCost(), null, null, null, reactActionOption, null, false, 0, completeDeployTargetFilter, null);
+                reactActionOption.getChangeInCost(), null, null, null, reactActionOption, null, false, 0, playTargetFilter, null);
         if (playCardAction == null) {
             return null;
         }

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/MayDeployAsReactToTargetModifier.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/MayDeployAsReactToTargetModifier.java
@@ -53,6 +53,11 @@ public class MayDeployAsReactToTargetModifier extends AbstractModifier {
     }
 
     @Override
+    public Filter getTargetFilter() {
+        return _targetFilter;
+    }
+
+    @Override
     public float getChangeInCost() {
         return _changeInCost;
     }

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/MayDeployWithPilotOrDriverAsReactToTargetModifier.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/MayDeployWithPilotOrDriverAsReactToTargetModifier.java
@@ -66,6 +66,11 @@ public class MayDeployWithPilotOrDriverAsReactToTargetModifier extends AbstractM
     }
 
     @Override
+    public Filter getTargetFilter() {
+        return _targetFilter;
+    }
+
+    @Override
     public float getChangeInCost() {
         return _changeInCost;
     }

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/Reacts.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/Reacts.java
@@ -51,8 +51,10 @@ public interface Reacts extends BaseQuery {
             for (PhysicalCard target : targets) {
                 if (modifier.isAffectedTarget(gameState, query(), target)) {
 
+                    // Restrict deploy choices to targets accepted by this react modifier (not all cards at the location)
+                    Filter reactTargetFilter = Filters.and(deployTargetFilter, modifier.getTargetFilter());
                     return new ReactActionOption(modifier.getSource(gameState), modifier.isReactForFree(),
-                            modifier.getChangeInCost(), false, modifier.getText(gameState, query(), card), card, deployTargetFilter, null, modifier.isGrantedToDeployToTarget());
+                            modifier.getChangeInCost(), false, modifier.getText(gameState, query(), card), card, reactTargetFilter, null, modifier.isGrantedToDeployToTarget());
                 }
             }
         }
@@ -60,8 +62,10 @@ public interface Reacts extends BaseQuery {
             for (PhysicalCard target : targets) {
                 if (modifier.isAffectedTarget(gameState, query(), target)) {
 
+                    // Restrict deploy choices to targets accepted by this react modifier (not all cards at the location)
+                    Filter reactTargetFilter = Filters.and(deployTargetFilter, modifier.getTargetFilter());
                     return new ReactActionOption(modifier.getSource(gameState), modifier.isReactForFree(),
-                            modifier.getChangeInCost(), false, modifier.getText(gameState, query(), card), card, deployTargetFilter, modifier.getPilotOrDriverFilter(), modifier.isGrantedToDeployToTarget());
+                            modifier.getChangeInCost(), false, modifier.getText(gameState, query(), card), card, reactTargetFilter, modifier.getPilotOrDriverFilter(), modifier.isGrantedToDeployToTarget());
                 }
             }
         }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set6/light/Card_6_117_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set6/light/Card_6_117_Tests.java
@@ -11,7 +11,6 @@ import com.gempukku.swccgo.common.Species;
 import com.gempukku.swccgo.common.Uniqueness;
 import com.gempukku.swccgo.framework.StartingSetup;
 import com.gempukku.swccgo.framework.VirtualTableScenario;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -182,14 +181,14 @@ public class Card_6_117_Tests {
         assertFalse(scn.DSCardPlayAvailable(nysad)); //test1 (no react to JP available)
     }
 
-    @Test @Ignore
+    @Test
     public void NysadDeployAsReactToVehicleAtTat() {
         //shows bug described in https://github.com/PlayersCommittee/gemp-swccg-public/issues/315
 
         //test coverage:
         // test1: can deploy as react to enclosed vehicle at non-JP site
         // test2: can deploy as react to non-enclosed vehicle at non-JP site
-        // test3: (CURRENTLY FAILS) cannot deploy as a react to tatooine site with a vehicle present
+        // test3: cannot deploy as a react to bare non-JP Tatooine site (must deploy aboard the vehicle)
         var scn = GetScenario();
 
         var rebeltrooper = scn.GetLSCard("rebeltrooper");
@@ -214,7 +213,7 @@ public class Card_6_117_Tests {
         scn.PassAllResponses();
         assertTrue(scn.DSHasCardChoicesAvailable(walker)); //test1 (react deploy to enclosed vehicle)
         assertTrue(scn.DSHasCardChoicesAvailable(bantha)); //test2 (react deploy to non-enclosed vehicle)
-        assertFalse(scn.DSHasCardChoicesAvailable(tat_site)); //test3 (CURRENTLY FAILS) (cannot react deploy to site)
+        assertFalse(scn.DSHasCardChoicesAvailable(tat_site)); //test3 (cannot react deploy to site)
         scn.DSChooseCards(walker); //(passenger)
         scn.PassAllResponses();
         assertFalse(scn.CardsAtLocation(tat_site,nysad));


### PR DESCRIPTION
## Summary
- Fixes Nysad (6_117) incorrectly being able to deploy as a react to a non-Jabba's Palace Tatooine *site* when a vehicle is present there. Rules require deploying *aboard the vehicle*.
- Root cause was shared react deploy-target resolution: once any modifier-accepted target (e.g. a vehicle) enabled the react, deploy choices used the broad `locationAndCardsAtLocation` filter, so the site was also offered.
- Narrows react deploy choices to targets accepted by `MayDeployAsReactToTargetModifier` / `MayDeployWithPilotOrDriverAsReactToTargetModifier` (via `getTargetFilter()`) and honors that filter in `AbstractDeployable.getDeployAsReactAction`.
- Card text / Nysad filter wording unchanged.

## Tests
Class: `Card_6_117_Tests` - **8/8 green**
- `NysadStatsAndKeywordsAreCorrect`
- `NysadDeploysOnlyOnTatooine`
- `NysadDeployAsReactToJP` (JP site path still works)
- `NysadNoDeployAsReactToNonJP` (bare non-JP site without vehicle not OK)
- `NysadDeployAsReactToVehicleAtTat` (vehicles OK; bare Tatooine site with vehicles present NOT OK) - un-ignored
- `NysadNoDeployAsReactToVehicleAtNonTat`
- `NysadPowerBonusDefendingAtJP`
- `NysadNoPowerBonusDefendingAtNonJP`

## Notes
- Independent PR vs master.
- Touches shared react-deploy path (`Reacts.getDeployAsReactOption`, `AbstractDeployable.getDeployAsReactAction`, react-to-target modifier `getTargetFilter`). Different symptom from Trash Compactor simultaneous ship+pilot presence leak (#736); no intentional overlap with that work.

Closes #315
