### PR TITLE
Fix Effect relocate deploy-target and immunity checks (#241)

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/AbstractEffect.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/AbstractEffect.java
@@ -46,8 +46,10 @@ public abstract class AbstractEffect extends AbstractDeployable {
     @Override
     public final Filter getValidRelocateEffectTargetFilter(final String playerId, final SwccgGame game, final PhysicalCard self) {
         // Filter cards that this card is not prohibited from being at
+        // Same restrictions as deploy: MayNotDeployToTarget and immunity (canBeTargetedBy).
         Filter filter = Filters.and(Filters.not(Filters.or(Filters.holosite, Filters.hasAttached(self), Filters.attachedToWithRecursiveChecking(self))),
-                Filters.notProhibitedFromTarget(self), Filters.notProhibitedFromCarrying(self), Filters.canBeTargetedBy(self));
+                Filters.notProhibitedFromTarget(self), Filters.notProhibitedFromDeployingTo(self, null),
+                Filters.notProhibitedFromCarrying(self), Filters.canBeTargetedBy(self));
 
         // Filter cards that a this type of card can be placed (based on game rules for that card type/subtype, etc.)
         filter = Filters.and(filter, getValidDeployTargetFilterForCardType(playerId, game, self, false, false, null, null),

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
@@ -13809,8 +13809,12 @@ public class Filters {
             public boolean accepts(GameState gameState, ModifiersQuerying modifiersQuerying, PhysicalCard physicalCard) {
                 PhysicalCard effectToRelocate = gameState.findCardByPermanentId(permEffectToRelocateCardId);
 
+                // Leaf for effectCanBeRelocatedTo / canRelocateEffectTo(Filter) — keep checks here, not in the
+                // Filter overloads, to avoid circular recursion between those two helpers.
                 return Filters.and(Filters.Effect, Filters.zone(Zone.ATTACHED)).accepts(gameState, modifiersQuerying, effectToRelocate)
-                        && effectToRelocate.getBlueprint().getValidRelocateEffectTargetFilter(playerId, gameState.getGame(), effectToRelocate).accepts(gameState, modifiersQuerying, physicalCard);
+                        && effectToRelocate.getBlueprint().getValidRelocateEffectTargetFilter(playerId, gameState.getGame(), effectToRelocate).accepts(gameState, modifiersQuerying, physicalCard)
+                        && !modifiersQuerying.isProhibitedFromDeployingTo(gameState, effectToRelocate, physicalCard, null)
+                        && modifiersQuerying.canBeTargetedBy(gameState, physicalCard, effectToRelocate);
             }
         };
     }

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/MayNotDeployToTargetModifier.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/MayNotDeployToTargetModifier.java
@@ -41,7 +41,9 @@ public class MayNotDeployToTargetModifier extends AbstractModifier {
      * @param targetFilter the filter for targets that affected cards may not deploy to
      */
     public MayNotDeployToTargetModifier(PhysicalCard source, Filterable affectFilter, Condition condition, Filterable targetFilter) {
-        super(source, null, Filters.and(Filters.not(Filters.in_play), affectFilter), condition, ModifierType.MAY_NOT_DEPLOY_TO_TARGET, true);
+        // Include in-play cards so Effect relocate/transfer uses the same deploy-to-target restrictions
+        // as initial deploy (Appendix B / Surprise primary target must be a legal deploy target).
+        super(source, null, affectFilter, condition, ModifierType.MAY_NOT_DEPLOY_TO_TARGET, true);
         _targetFilter = Filters.and(targetFilter);
     }
 

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_156_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_156_Tests.java
@@ -1,0 +1,161 @@
+package com.gempukku.swccgo.cards.set5.dark;
+
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.game.PhysicalCardImpl;
+import com.gempukku.swccgo.logic.decisions.DecisionResultInvalidException;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Real-path coverage for #241: Surprise Effect relocate must respect legal deploy targets
+ * (MayNotDeployToTarget and immunity to the Effect title).
+ */
+public class Card_5_156_Tests {
+
+    protected VirtualTableScenario GetMayNotDeployScenario() throws DecisionResultInvalidException {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("yavin_v", "211_32");
+                    put("war_room", "1_139");
+                }},
+                new HashMap<>() {{
+                    put("surprise", "5_156");
+                    put("presence", "1_227");
+                    put("cantina", "1_290");
+                    put("marketplace", "12_176");
+                }},
+                10,
+                10,
+                StartingSetup.LSStartingLocation("211_32"),
+                StartingSetup.DSStartingLocation("1_290"),
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    protected VirtualTableScenario GetRevolutionImmunityScenario() throws DecisionResultInvalidException {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("boss_nass", "14_49");
+                    put("revolution", "1_62");
+                }},
+                new HashMap<>() {{
+                    put("surprise", "5_156");
+                    put("cantina", "1_290");
+                    put("marketplace", "12_176");
+                }},
+                10,
+                10,
+                StartingSetup.LSStartingLocation("14_49"),
+                StartingSetup.DSStartingLocation("1_290"),
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    protected VirtualTableScenario GetExpandTheEmpireImmunityScenario() throws DecisionResultInvalidException {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("turbolift", "209_27");
+                }},
+                new HashMap<>() {{
+                    put("surprise", "5_156");
+                    put("expand", "1_215");
+                    put("marketplace", "12_176");
+                    put("desert", "6_169");
+                }},
+                10,
+                10,
+                StartingSetup.LSStartingLocation("209_27"),
+                StartingSetup.DSStartingLocation("12_176"),
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    private void prepareSurpriseRelocate(VirtualTableScenario scn, PhysicalCardImpl host, PhysicalCardImpl effect,
+                                         PhysicalCardImpl surprise, PhysicalCardImpl... extraLocations) throws DecisionResultInvalidException {
+        scn.StartGame();
+        for (PhysicalCardImpl loc : extraLocations) {
+            scn.MoveLocationToTable(loc);
+        }
+        scn.AttachCardsTo(host, effect);
+        scn.MoveCardsToHand(surprise);
+        assertEquals(Zone.ATTACHED, effect.getZone());
+        assertEquals(host, effect.getAttachedTo());
+
+        // Cheat Force before turn skip so reserve deck still has cards; SkipToDSTurn also activates.
+        scn.DSActivateForceCheat(6);
+        scn.SkipToDSTurn(Phase.DEPLOY);
+
+        assertTrue("Surprise should be playable with Force available", scn.DSCardActionAvailable(surprise));
+        scn.DSPlayCard(surprise);
+        scn.DSChooseCard(effect);
+    }
+
+    @Test
+    public void SurpriseCannotRelocatePresenceOfTheForceToYavinSiteBlockedByMayNotDeployToTarget() throws DecisionResultInvalidException {
+        var scn = GetMayNotDeployScenario();
+        var warRoom = scn.GetLSCard("war_room");
+        var cantina = scn.GetDSCard("cantina");
+        var presence = scn.GetDSCard("presence");
+        var surprise = scn.GetDSCard("surprise");
+        var marketplace = scn.GetDSCard("marketplace");
+
+        prepareSurpriseRelocate(scn, cantina, presence, surprise, warRoom, marketplace);
+
+        assertFalse("Surprise must not offer Yavin War Room as relocate target", scn.DSHasCardChoiceAvailable(warRoom));
+        assertTrue("Surprise must allow relocate to marketplace", scn.DSHasCardChoiceAvailable(marketplace));
+
+        scn.DSChooseCard(marketplace);
+        scn.PassAllResponses();
+        assertEquals("Legal relocate must succeed", marketplace, presence.getAttachedTo());
+    }
+
+    @Test
+    public void SurpriseCannotRelocateRevolutionToBossNassChambersImmuneToRevolution() throws DecisionResultInvalidException {
+        var scn = GetRevolutionImmunityScenario();
+        var bossNass = scn.GetLSCard("boss_nass");
+        var revolution = scn.GetLSCard("revolution");
+        var cantina = scn.GetDSCard("cantina");
+        var surprise = scn.GetDSCard("surprise");
+        var marketplace = scn.GetDSCard("marketplace");
+
+        prepareSurpriseRelocate(scn, cantina, revolution, surprise, marketplace);
+
+        assertFalse("Surprise must not relocate Revolution onto Boss Nass Chambers", scn.DSHasCardChoiceAvailable(bossNass));
+        assertTrue("Surprise may relocate Revolution onto marketplace", scn.DSHasCardChoiceAvailable(marketplace));
+    }
+
+    @Test
+    public void SurpriseCannotRelocateExpandTheEmpireToScarifTurboliftComplexImmuneToExpandTheEmpire() throws DecisionResultInvalidException {
+        var scn = GetExpandTheEmpireImmunityScenario();
+        var turbolift = scn.GetLSCard("turbolift");
+        var marketplace = scn.GetDSCard("marketplace");
+        var desert = scn.GetDSCard("desert");
+        var expand = scn.GetDSCard("expand");
+        var surprise = scn.GetDSCard("surprise");
+
+        prepareSurpriseRelocate(scn, marketplace, expand, surprise, desert);
+
+        assertFalse("Surprise must not relocate Expand The Empire onto Turbolift Complex", scn.DSHasCardChoiceAvailable(turbolift));
+        assertTrue("Surprise may relocate Expand The Empire onto Tatooine Desert", scn.DSHasCardChoiceAvailable(desert));
+    }
+}


### PR DESCRIPTION
## Summary
Surprise (and Effect relocation generally) could relocate an Effect onto a location that was not a legal deploy target for that Effect ? e.g. Presence Of The Force onto a Yavin 4 site while Yavin 4 (V) blocked DS Effects on related locations. Rules confirmed this is incorrect (Appendix B ?I Have A Bad Feeling About This? style: the relocate primary target must be a legal deploy target).

Also locks immunity: a location immune to an Effect title is an illegal deploy target and therefore an illegal Surprise/relocate target (Expand The Empire ? Scarif: Turbolift Complex; Revolution ? Naboo: Boss Nass' Chambers).

## What changed
- `MayNotDeployToTargetModifier` now affects in-play cards as well (previously `not(in_play)` meant relocate of an already-attached Effect ignored deploy-to-target restrictions).
- `AbstractEffect.getValidRelocateEffectTargetFilter` adds `notProhibitedFromDeployingTo` alongside existing `canBeTargetedBy` (immunity).
- `Filters.canRelocateEffectTo(PhysicalCard)` leaf explicitly checks `isProhibitedFromDeployingTo` and `canBeTargetedBy` (Filter overloads still call this leaf ? no circular recursion).

## Design
- Shared Effect-relocate eligibility path used by Surprise; no per-interrupt rewrites.
- Circular-filter care: only the `PhysicalCard` leaf was extended; `canRelocateEffectTo(Filter)` / `effectCanBeRelocatedTo` remain thin wrappers over that leaf.
- Immunity: encode via `canBeTargetedBy` (ImmuneToTitle) on relocate, same as deploy-to-attached.

## Tests
Class: `Card_5_156_Tests` (3 tests)
- `SurpriseCannotRelocatePresenceOfTheForceToYavinSiteBlockedByMayNotDeployToTarget` ? illegal under Yavin 4 (V); legal relocate to marketplace succeeds
- `SurpriseCannotRelocateRevolutionToBossNassChambersImmuneToRevolution` ? Decipher immunity
- `SurpriseCannotRelocateExpandTheEmpireToScarifTurboliftComplexImmuneToExpandTheEmpire` ? Expand The Empire immunity

Closes #241

Independent of other open PRs (skips #46/#38 cumulative work).

## Known gaps
- Yavin 4 (V) is used as the MayNotDeployToTarget source (incidental Virtual); Decipher immunity cases cover Theed Palace Boss Nass' Chambers and Scarif Turbolift Complex.
