### PR TITLE
Fix #297: reacted already-battled cards become INACTIVE in 2nd battle

### DIFF
--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/BattleState.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/game/state/BattleState.java
@@ -280,6 +280,30 @@ public class BattleState implements Snapshotable<BattleState> {
             }
         }
 
+        // Cards that arrive mid-battle but cannot participate (e.g. already battled elsewhere this turn
+        // via a react) never enter currentParticipants, so the exclude modifier above never applied.
+        // Apply ExcludedFromBattleModifier so getCardState returns INACTIVE for the rest of the battle.
+        // Do not mark them inactive before they arrive — react itself must still be legal.
+        Collection<PhysicalCard> presentButIneligible;
+        if (_isLocalTrouble) {
+            presentButIneligible = Filters.filterActive(game, null, Filters.and(
+                    Filters.initiallyParticipatesInBattle(_location),
+                    Filters.in(_localTroubleParticipants),
+                    Filters.not(Filters.in(currentParticipants)),
+                    Filters.not(Filters.in(getAllCardsParticipating()))));
+        }
+        else {
+            presentButIneligible = Filters.filterActive(game, null, Filters.and(
+                    Filters.initiallyParticipatesInBattle(_location),
+                    Filters.not(Filters.in(currentParticipants)),
+                    Filters.not(Filters.in(getAllCardsParticipating()))));
+        }
+        for (PhysicalCard card : presentButIneligible) {
+            if (!modifiersQuerying.isExcludedFromBattle(gameState, card)) {
+                modifiersEnvironment.addUntilEndOfBattleModifier(new ExcludedFromBattleModifier(null, Filters.sameCardId(card)));
+            }
+        }
+
         for (PhysicalCard previousParticipant : previousParticipants) {
             // Remove cards no longer in the battle
             if (!_darkCardsParticipants.contains(previousParticipant) && !_lightCardsParticipants.contains(previousParticipant)) {

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set3/dark/Card_3_138_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set3/dark/Card_3_138_Tests.java
@@ -10,7 +10,6 @@ import com.gempukku.swccgo.common.Side;
 import com.gempukku.swccgo.common.Uniqueness;
 import com.gempukku.swccgo.framework.StartingSetup;
 import com.gempukku.swccgo.framework.VirtualTableScenario;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -240,7 +239,7 @@ public class Card_3_138_Tests {
         assertFalse(scn.DSHasCardChoiceAvailable(trooper2)); //test1
     }
 
-    @Test @Ignore
+    @Test
     public void TrampleCannotTargetExcludedCharacterDuringBattle_MultipleBattles() {
         //test1: during battle, excluded character (due to participating in a different battle this turn)
         // is considered inactive and cannot be targeted by trample
@@ -291,7 +290,7 @@ public class Card_3_138_Tests {
         assertFalse(scn.DSHasCardChoiceAvailable(wolfman)); //test1
     }
 
-    @Test @Ignore
+    @Test
     public void TrampleExcludedWalkerCannotTargetCharacterDuringBattle_MultipleBattles() {
         //shows issue: https://github.com/PlayersCommittee/gemp-swccg-public/issues/297
         //test1: during battle, excluded walker (due to participating in a different battle this turn)


### PR DESCRIPTION
## Summary
Cards that move as a react into a second battle correctly may not participate, but stayed ACTIVE instead of becoming INACTIVE. `updateParticipants` only considered `canParticipateInBattleAt` candidates, so already-battled arrivals never received `ExcludedFromBattleModifier` and could still enable Trample, fire weapons, and apply gametext.

This applies the exclude modifier for present-but-ineligible cards at the battle location after the normal participant update, so they are inactive for the rest of the battle. React itself remains legal because the card is not marked inactive before it arrives.

Closes #297. Closes #554.

Does not claim #57 (Clash / exclude while already participating is a different path).

## Tip
`bb412a970332a99adea5b5ed361ead1295b2cb65`

## Test plan
- [x] `TrampleCannotTargetExcludedCharacterDuringBattle_Barrier` — Imperial Barrier exclude still inactive / not Trample-targetable
- [x] `TrampleCannotTargetExcludedCharacterDuringBattle_MultipleBattles` — reacted already-battled character is inactive / not Trample-targetable
- [x] `TrampleExcludedWalkerCannotTargetCharacterDuringBattle_MultipleBattles` — reacted already-battled AT-ST is inactive / cannot enable Trample
- [x] `Card_3_138_Tests` full class: 7 run / 0 fail / 0 skipped
- [x] Overlay **17004** rebuilt and healthy