### PR TITLE
Fix Blaster Deflection LOST retarget for non-free weapons (#859)

### DIFF
--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/actions/FireWeaponActionBuilder.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/actions/FireWeaponActionBuilder.java
@@ -389,7 +389,10 @@ public class FireWeaponActionBuilder {
                             }
                         }
                     }
-                    _targetFilterList.set(i, Filters.in(validTargets));
+                    // Keep the logical target filter (same structure as free targeting).
+                    // Replacing it with Filters.in(validTargets) snapshots only currently
+                    // affordable opponent cards, which breaks Filters.weaponMayRetargetTo
+                    // (acceptsIgnoringOwner) used by retarget interrupts like Blaster Deflection LOST.
                     isValid = (validTargets.size() >= _numTargets);
                 }
                 _targetFilterValid.add(isValid);

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set6/light/Card_6_061_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set6/light/Card_6_061_Tests.java
@@ -10,7 +10,6 @@ import com.gempukku.swccgo.common.Side;
 import com.gempukku.swccgo.common.Uniqueness;
 import com.gempukku.swccgo.framework.StartingSetup;
 import com.gempukku.swccgo.framework.VirtualTableScenario;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -122,9 +121,9 @@ public class Card_6_061_Tests {
         scn.PassAllResponses();
     }
 
-    @Test @Ignore
+    @Test
     public void BlasterDeflectionLostRetargetsNonFreeBlaster() {
-        //demonstrates bug https://github.com/PlayersCommittee/gemp-swccg-public/issues/859
+        // Regression coverage for https://github.com/PlayersCommittee/gemp-swccg-public/issues/859 (Imperial Blaster / non-free path)
 
         var scn = GetScenario();
 
@@ -155,7 +154,6 @@ public class Card_6_061_Tests {
         scn.LSPass(); //Use 1 Force - Optional responses
         scn.DSPass();
         assertTrue(scn.GetLSForcePileCount() >= 3);
-            ///FAILS HERE
         assertTrue(scn.LSPlayLostInterruptAvailable(deflection));
         scn.LSPlayLostInterrupt(deflection);
         assertTrue(scn.LSDecisionAvailable("Choose character to re-target from"));
@@ -218,7 +216,7 @@ public class Card_6_061_Tests {
         scn.PassAllResponses();
     }
 
-    @Test @Ignore
+    @Test
     public void BlasterDeflectionLostRetargetsRepeatedBlaster() {
 
         var scn = GetScenario();
@@ -247,17 +245,16 @@ public class Card_6_061_Tests {
         assertTrue(scn.DSCardActionAvailable(bobasBlaster));
         scn.DSUseCardAction(bobasBlaster);
         scn.DSChooseCard(luke);
-        //assertTrue(scn.GetLSForcePileCount() >= 3);
-            ///FAILS HERE on initial firing (because not free, but covered in other test)
-        //assertTrue(scn.LSPlayLostInterruptAvailable(deflection));
+        // Initial non-free firing LOST coverage is in BlasterDeflectionLostRetargetsNonFreeBlaster
         scn.PassAllResponses();
 
         assertTrue(scn.DSDecisionAvailable("repeatedly fire"));
         scn.DSChooseYes();
         scn.DSChooseCard(luke);
+        scn.LSPass(); // Use 1 Force (repeated fire) - Optional responses
+        scn.DSPass();
 
         assertTrue(scn.GetLSForcePileCount() >= 3);
-            ///FAILS HERE on repeated firing
         assertTrue(scn.LSPlayLostInterruptAvailable(deflection));
         scn.LSPlayLostInterrupt(deflection);
         assertTrue(scn.LSDecisionAvailable("Choose character to re-target from"));


### PR DESCRIPTION
## Summary
Blaster Deflection (6_061) LOST was not offered when retargeting a non-free blaster (e.g. Imperial Blaster), while USED worked and free blasters / EPP already worked.

Root cause: `FireWeaponActionBuilder.finishBuildPrep()` for non-free targeting replaced the logical target filter with `Filters.in(validTargets)` (a snapshot of currently affordable opponent cards). `Filters.weaponMayRetargetTo` uses `acceptsIgnoringOwner` against that stored filter so LOST can retarget to the firer's characters; a card-id snapshot of opponent targets never matches those cards, so LOST became unplayable.

## What changed
- `FireWeaponActionBuilder`: keep the logical target filter for non-free targeting (same retargetable structure as the free path). Validity / weapon-user checks still use the affordable `validTargets` set; only the snapshot replacement was removed.
- `Card_6_061_Tests`: enable and harden LOST coverage for non-free, free, repeated, and built-in (EPP) blasters.

## Tests
Class: `Card_6_061_Tests` — **6 run, 0 fail**
- `BlasterDeflectionStatsAndKeywordsAreCorrect`
- `BlasterDeflectionUsedCancelsTargeting`
- `BlasterDeflectionLostRetargetsNonFreeBlaster` (Imperial Blaster / `targetUsingForce`)
- `BlasterDeflectionLostRetargetsFreeBlaster`
- `BlasterDeflectionLostRetargetsRepeatedBlaster`
- `BlasterDeflectionLostRetargetsBuiltInBlaster` (EPP)

## Notes
- Independent PR vs master; Closes #859.
- Minimal builder change only (no wide fire-builder rewrite).
- Known gaps: other cards that call `weaponMayRetargetTo` were not exhaustively re-tested beyond this interrupt; multi-target / ability-4 edge cases called out in the test file TODOs remain future coverage.

Closes #859