### PR TITLE
Fix #997: Chewbacca Used Pile for hit cards lost mid-battle

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/light/Card2_003.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set2/light/Card2_003.java
@@ -27,6 +27,7 @@ import com.gempukku.swccgo.logic.timing.EffectResult;
 import com.gempukku.swccgo.logic.timing.PassthruEffect;
 import com.gempukku.swccgo.logic.timing.results.AboutToLoseCardFromTableResult;
 
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -82,6 +83,7 @@ public class Card2_003 extends AbstractAlienRebel {
                         }
                     }
             );
+            return Collections.singletonList(action);
         }
         return null;
     }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/light/Card_2_003_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set2/light/Card_2_003_Tests.java
@@ -13,7 +13,6 @@ import com.gempukku.swccgo.common.Uniqueness;
 import com.gempukku.swccgo.common.Zone;
 import com.gempukku.swccgo.framework.StartingSetup;
 import com.gempukku.swccgo.framework.VirtualTableScenario;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -151,7 +150,7 @@ public class Card_2_003_Tests {
         assertEquals(Zone.TOP_OF_USED_PILE, c3p0.getZone());
     }
 
-    @Test @Ignore
+    @Test
     public void ChewbaccaSendsDroidHitAndLostInBattleToUsedPile() {
         var scn = GetScenario();
 
@@ -234,7 +233,7 @@ public class Card_2_003_Tests {
         assertEquals(Zone.TOP_OF_USED_PILE, c3p0.getZone());
     }
 
-    @Test @Ignore
+    @Test
     public void ChewbaccaSendsDroidHitAndExcludedInBattleToUsedPile() {
         var scn = GetScenario();
 
@@ -280,10 +279,7 @@ public class Card_2_003_Tests {
         scn.LSPass();
 
         assertTrue(c3p0.isHit());
-        assertTrue(scn.DSDecisionAvailable("ABOUT_TO_BE_LOST_FROM_TABLE"));
-        scn.DSPass(); //ABOUT_TO_BE_LOST_FROM_TABLE - Optional responses
-
-            //automatic send to used pile action should be carried out here
+        // Chewie required Used-instead-of-Lost resolves during about-to-be-lost
         scn.PassAllResponses();
 
         assertTrue(scn.AwaitingLSWeaponsSegmentActions());


### PR DESCRIPTION
## Summary
Fixes Chewbacca (A New Hope `2_003`) so hit vehicles, starships, and droids at the same site go to Used Pile instead of Lost Pile when about to be lost, except in an all-cards situation.

Root cause: `getGameTextRequiredAfterTriggers` built the required Used-Pile redirect action but returned `null`, so only the forfeit path (`ForfeitedToUsedPileModifier`) worked. Non-forfeit loses mid-battle (e.g. Dr. Evazan operate, You Are Beaten exclude-then-lose) skipped the redirect.

## AR
Current book: [Advanced Rulebook (2023)](https://res.starwarsccg.org/rules/SWCCG_2023_AdvancedRulebook.pdf). Same wording in [AR v3.28 (2022)](https://res.starwarsccg.org/wp/wp-content/uploads/2022/SWCCG_2022_AdvancedRulebook.pdf).

Chewie errata: hit vehicles/starships/droids at the same site that are **hit and about to be lost** go to Used Pile instead. That is not limited to the damage-segment forfeit.

**Forfeit is one way to be lost, not the only way** ([AR, Forfeit / Damage Segment](https://res.starwarsccg.org/rules/SWCCG_2023_AdvancedRulebook.pdf)):

> A forfeited card is always 'lost,' but a lost card is not always 'forfeited.' You may forfeit a card only if it has a forfeit value, is currently participating in battle during the damage segment, and only if it is either 'hit' or is being forfeited to satisfy attrition and/or battle damage affecting you.

So a hit droid lost mid-battle by Dr. Evazan operate (or lost after You Are Beaten excludes it) is still about to be lost, even though it is not being forfeited.

**Hit cards are later forfeited in the damage segment, but they can leave table earlier** ([AR, Damage Segment - Weapon 'Hits'](https://res.starwarsccg.org/rules/SWCCG_2023_AdvancedRulebook.pdf)):

> Cards hit during the weapons segment must be forfeited (lost) during the damage segment. However, this only means that their forfeiture is mandatory, not that they must be forfeited first.

**All-cards leave-table cannot be prevented unless the card specifically allows it** ([AR, All Cards/All Characters](https://res.starwarsccg.org/wp/wp-content/uploads/2022/SWCCG_2022_AdvancedRulebook.pdf)):

> Any game text or rule that causes "all cards" (or "all characters", etc.) to be lost, missing, captured, or otherwise leave the table will affect cards on both sides (even inactive cards), unless specifically told otherwise.
>
> Also, the effect on any target of an "all cards" situation cannot be prevented (such as Force Field trying to stop Concussion Grenade, Jerus Jannick trying to protect a leader from a Thermal Detonator, or Droid Shutdown to protect a droid from a seeker; none of the above can be used) unless it is specifically permitted (such as I Thought They Smelled Bad On The Outside protecting a character from Ice Storm).

Chewie's "Used Pile instead of Lost Pile" is a prevention of going lost. Passengers aboard a vehicle that leaves table are an all-cards situation, so Chewie cannot save them. That matches `ChewbaccaDoesNotSendHitDroidToUsedPileWhenLostViaAllCardsSituation`.

## What changed
- `Card2_003`: return the about-to-be-lost Used redirect (still uses `TriggerConditions.isAboutToBeLost`, which already excludes all-cards situations).
- `Card_2_003_Tests`: enable previously `@Ignore`d hit+lost / hit+excluded coverage.
- WED-1016 Techie Droid (`3_024`): not changed in the first commit; later unified onto the same about-to-leave-table hook.

## Tests
`Card_2_003_Tests` — 5/5
- `ChewbaccaStatsAndKeywordsAreCorrect`
- `ChewbaccaSendsHitDroidForfeitedToUsedPile`
- `ChewbaccaSendsDroidHitAndLostInBattleToUsedPile`
- `ChewbaccaSendsDroidHitAndExcludedInBattleToUsedPile`
- `ChewbaccaDoesNotSendHitDroidToUsedPileWhenLostViaAllCardsSituation`

Closes #997.