### PR TITLE
Fix all-cards escort loss hanging captives not in lost set (#981)

### DIFF
--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/LoseCardsFromTableEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/LoseCardsFromTableEffect.java
@@ -1,4 +1,4 @@
-package com.gempukku.swccgo.logic.effects;
+﻿package com.gempukku.swccgo.logic.effects;
 
 import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.game.PhysicalCard;
@@ -127,10 +127,24 @@ public class LoseCardsFromTableEffect extends AbstractSubActionEffect {
         protected void cardsSelected(Collection<PhysicalCard> selectedCards) {
             for (PhysicalCard selectedCard : selectedCards) {
 
+                // Always release captives that are not themselves being lost. Previously all-cards situations
+                // passed releaseCaptives=false, which left escorts' captives hanging when the captive was not
+                // in the lost set (Cantina Brawl / Concussion Grenade vs escort only). Captives that are also
+                // in the remaining lose set are pulled into this simultaneous lose so they leave without Escape/Rally
+                // (Explosive Charge, Program Trap, Binders multi-captive partial hit).
+                Collection<PhysicalCard> cardsToLoseNow = new ArrayList<PhysicalCard>(selectedCards);
+                for (PhysicalCard card : selectedCards) {
+                    for (PhysicalCard attached : _game.getGameState().getAttachedCards(card, true)) {
+                        if (attached.isCaptive() && _remainingCards.contains(attached) && !cardsToLoseNow.contains(attached)) {
+                            cardsToLoseNow.add(attached);
+                        }
+                    }
+                }
+
                 // SubAction to carry out losing card from table
                 SubAction loseCardsSubAction = new SubAction(_subAction);
                 loseCardsSubAction.appendEffect(
-                        new LoseCardsFromTableSimultaneouslyEffect(loseCardsSubAction, selectedCards, _toBottomOfPile, _allCardsSituation, !_allCardsSituation) {
+                        new LoseCardsFromTableSimultaneouslyEffect(loseCardsSubAction, cardsToLoseNow, _toBottomOfPile, _allCardsSituation, true) {
                             @Override
                             protected boolean asEaten() {
                                 return _that.asEaten();
@@ -139,7 +153,7 @@ public class LoseCardsFromTableEffect extends AbstractSubActionEffect {
                 // Stack sub-action
                 _subAction.stackSubAction(loseCardsSubAction);
 
-                _remainingCards.remove(selectedCard);
+                _remainingCards.removeAll(cardsToLoseNow);
                 if (!_remainingCards.isEmpty()) {
 
                     _subAction.appendEffect(

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/LoseCardsFromTableEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/LoseCardsFromTableEffect.java
@@ -1,4 +1,4 @@
-﻿package com.gempukku.swccgo.logic.effects;
+package com.gempukku.swccgo.logic.effects;
 
 import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.game.PhysicalCard;

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/choose/ChooseCardsToLoseFromTableEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/choose/ChooseCardsToLoseFromTableEffect.java
@@ -160,14 +160,25 @@ public class ChooseCardsToLoseFromTableEffect extends AbstractSubActionEffect {
         protected void cardsSelected(Collection<PhysicalCard> selectedCards) {
             for (PhysicalCard selectedCard : selectedCards) {
 
+                // Pull captives that are also scheduled to be lost into this simultaneous lose so they
+                // leave without Escape/Rally; other captives release via releaseCaptives=true.
+                Collection<PhysicalCard> cardsToLoseNow = new ArrayList<PhysicalCard>(selectedCards);
+                for (PhysicalCard card : selectedCards) {
+                    for (PhysicalCard attached : _game.getGameState().getAttachedCards(card, true)) {
+                        if (attached.isCaptive() && _remainingCards.contains(attached) && !cardsToLoseNow.contains(attached)) {
+                            cardsToLoseNow.add(attached);
+                        }
+                    }
+                }
+
                 // SubAction to carry out losing card from table
                 SubAction loseCardsSubAction = new SubAction(_subAction);
                 loseCardsSubAction.appendEffect(
-                        new LoseCardsFromTableSimultaneouslyEffect(loseCardsSubAction, selectedCards, false, _allCardsSituation, true));
+                        new LoseCardsFromTableSimultaneouslyEffect(loseCardsSubAction, cardsToLoseNow, false, _allCardsSituation, true));
                 // Stack sub-action
                 _subAction.stackSubAction(loseCardsSubAction);
 
-                _remainingCards.remove(selectedCard);
+                _remainingCards.removeAll(cardsToLoseNow);
                 if (!_remainingCards.isEmpty()) {
 
                     _subAction.appendEffect(

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_073_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_073_Tests.java
@@ -4,6 +4,7 @@ import com.gempukku.swccgo.common.Phase;
 import com.gempukku.swccgo.common.Zone;
 import com.gempukku.swccgo.framework.StartingSetup;
 import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.game.PhysicalCardImpl;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -21,17 +22,18 @@ public class Card_1_073_Tests {
         return new VirtualTableScenario(
                 new HashMap<>() {{
                     put("brawl", "1_073"); // Cantina Brawl
-                    put("luke", "1_019"); // Luke Skywalker — ability 4
-                    put("luke_jedi", "9_024"); // Luke Skywalker, Jedi Knight — destiny 6
+                    put("luke", "1_019"); // Luke Skywalker ? ability 4
+                    put("luke_jedi", "9_024"); // Luke Skywalker, Jedi Knight ? destiny 6
                     put("grenade", "3_073"); // Concussion Grenade
-                    put("biggs", "1_003"); // Biggs — destiny 2 warrior
+                    put("biggs", "1_003"); // Biggs ? destiny 2 warrior
+                    put("cantina", "1_128"); // Tatooine: Cantina
                 }},
                 new HashMap<>() {{
-                    put("vader", "1_168"); // Darth Vader — ability 6, destiny 1
+                    put("vader", "1_168"); // Darth Vader ? ability 6, destiny 1
                 }},
                 10,
                 10,
-                StartingSetup.LSStartingLocation("1_128"), // Tatooine: Cantina
+                StartingSetup.DefaultLSGroundLocation,
                 StartingSetup.DefaultDSGroundLocation,
                 StartingSetup.NoLSStartingInterrupts,
                 StartingSetup.NoDSStartingInterrupts,
@@ -41,53 +43,103 @@ public class Card_1_073_Tests {
         );
     }
 
+    private void playCantinaBrawl(VirtualTableScenario scn, PhysicalCardImpl brawl, PhysicalCardImpl cantina) {
+        assertTrue(scn.LSCardPlayAvailable(brawl));
+        scn.LSPlayCard(brawl);
+        if (scn.LSDecisionAvailable("Choose Cantina")) {
+            scn.LSChooseCard(cantina);
+        }
+        scn.PassCardAndForceUseResponses();
+        scn.PassAllResponses();
+    }
+
+    private void chooseLostPileOrderPreferring(VirtualTableScenario scn, PhysicalCardImpl preferFirst) {
+        while (scn.LSDecisionAvailable("Choose card to be lost")) {
+            if (preferFirst != null && scn.LSHasCardChoiceAvailable(preferFirst)) {
+                scn.LSChooseCard(preferFirst);
+            } else {
+                // Any remaining choice ? preferFirst already taken
+                break;
+            }
+            scn.PassAllResponses();
+            preferFirst = null;
+        }
+        while (scn.DSDecisionAvailable("Choose card to be lost")) {
+            if (preferFirst != null && scn.DSHasCardChoiceAvailable(preferFirst)) {
+                scn.DSChooseCard(preferFirst);
+            } else {
+                break;
+            }
+            scn.PassAllResponses();
+            preferFirst = null;
+        }
+    }
+
+    private void releaseCaptiveWith(VirtualTableScenario scn, PhysicalCardImpl captive, boolean rally) {
+        if (scn.LSDecisionAvailable("Choose character to release")) {
+            scn.LSChooseCard(captive);
+        } else if (scn.DSDecisionAvailable("Choose character to release")) {
+            scn.DSChooseCard(captive);
+        }
+        boolean releaseReady = scn.LSReleaseDecisionAvailable() || scn.DSDecisionAvailable("Choose release option for ");
+        if (!releaseReady) {
+            var dec = scn.GetCurrentDecision();
+            String msg = dec == null ? "no decision" : dec.getText();
+            throw new AssertionError("Expected Escape/Rally prompt, got: " + msg + "; captive=" + captive.isCaptive() + " zone=" + captive.getZone());
+        }
+        if (scn.LSReleaseDecisionAvailable()) {
+            if (rally) { scn.LSChooseRally(); } else { scn.LSChooseEscape(); }
+        } else {
+            if (rally) { scn.DSChoose("Rally"); } else { scn.DSChoose("Escape"); }
+        }
+        scn.PassAllResponses();
+    }
+
     @Test
     public void CantinaBrawlEscortOnlyLostCaptiveMayRally() {
-        // Cantina Brawl destinies match Vader ability (6) only — Luke (ability 4) Escape/Rallys.
+        // Cantina Brawl destinies match Vader ability (6) only ? Luke (ability 4) Escape/Rallys.
         var scn = GetScenario();
 
         var brawl = scn.GetLSCard("brawl");
         var luke = scn.GetLSCard("luke");
-        var cantina = scn.GetLSStartingLocation();
+        var cantina = scn.GetLSCard("cantina");
         var vader = scn.GetDSCard("vader");
 
         scn.StartGame();
+        scn.MoveLocationToTable(cantina);
         scn.MoveCardsToHand(brawl);
         scn.MoveCardsToLocation(cantina, vader, luke);
         scn.CaptureCardWith(vader, luke);
 
         assertTrue(luke.isCaptive());
-                scn.SkipToLSTurn(Phase.CONTROL);
+
+        scn.SkipToLSTurn(Phase.CONTROL);
         scn.LSActivateForceCheat(2);
         scn.PrepareLSDestiny(6);
         scn.PrepareDSDestiny(1);
 
-        assertTrue(scn.LSPlayLostInterruptAvailable(brawl));
-        scn.LSPlayLostInterrupt(brawl);
-        scn.PassCardAndForceUseResponses();
-        // destinies resolve; Vader is the only matching ability character to lose
-        scn.PassAllResponses();
+        playCantinaBrawl(scn, brawl, cantina);
+        chooseLostPileOrderPreferring(scn, vader);
+        // Release happens before escort is placed in Lost Pile
+        releaseCaptiveWith(scn, luke, true);
 
         assertInZone(Zone.LOST_PILE, vader);
-        assertTrue(scn.LSReleaseDecisionAvailable());
-        scn.LSChooseRally();
-        scn.PassAllResponses();
-
         assertFalse(luke.isCaptive());
         assertAtLocation(cantina, luke);
     }
 
     @Test
     public void CantinaBrawlEscortAndCaptiveBothLostNoUsedEscape() {
-        // Destinies 6 and 4 match Vader ability and Luke ability — captive lost with escort, no Used Escape.
+        // Destinies 6 and 4 match Vader ability and Luke ability ? captive lost with escort, no Used Escape.
         var scn = GetScenario();
 
         var brawl = scn.GetLSCard("brawl");
         var luke = scn.GetLSCard("luke");
-        var cantina = scn.GetLSStartingLocation();
+        var cantina = scn.GetLSCard("cantina");
         var vader = scn.GetDSCard("vader");
 
         scn.StartGame();
+        scn.MoveLocationToTable(cantina);
         scn.MoveCardsToHand(brawl);
         scn.MoveCardsToLocation(cantina, vader, luke);
         scn.CaptureCardWith(vader, luke);
@@ -97,14 +149,10 @@ public class Card_1_073_Tests {
         scn.PrepareLSDestiny(6);
         scn.PrepareDSDestiny(4);
 
-        scn.LSPlayLostInterrupt(brawl);
-        scn.PassCardAndForceUseResponses();
-        // Prefer escort first so the pull-in path is exercised
-        if (scn.LSDecisionAvailable("Choose card to be lost")) {
-            scn.LSChooseCard(vader);
-        }
-        scn.PassAllResponses();
+        playCantinaBrawl(scn, brawl, cantina);
+        chooseLostPileOrderPreferring(scn, vader);
 
+        assertFalse(scn.LSDecisionAvailable("Choose character to release"));
         assertFalse(scn.LSReleaseDecisionAvailable());
         assertInZone(Zone.LOST_PILE, vader);
         assertInZone(Zone.LOST_PILE, luke);
@@ -113,16 +161,17 @@ public class Card_1_073_Tests {
 
     @Test
     public void ConcussionGrenadeMatchingEscortDestinyOnlyReleasesCaptive() {
-        // Grenade destiny 1 matches Vader (destiny 1) only — Luke Jedi (destiny 6) Escape/Rallys.
+        // Grenade destiny 1 matches Vader (destiny 1) only ? Luke Jedi (destiny 6) Escape/Rallys.
         var scn = GetScenario();
 
         var luke = scn.GetLSCard("luke_jedi");
         var grenade = scn.GetLSCard("grenade");
         var biggs = scn.GetLSCard("biggs");
-        var cantina = scn.GetLSStartingLocation();
+        var cantina = scn.GetLSCard("cantina");
         var vader = scn.GetDSCard("vader");
 
         scn.StartGame();
+        scn.MoveLocationToTable(cantina);
         scn.MoveCardsToLocation(cantina, vader, luke, biggs);
         scn.AttachCardsTo(biggs, grenade);
         scn.CaptureCardWith(vader, luke);
@@ -130,18 +179,21 @@ public class Card_1_073_Tests {
         assertTrue(luke.isCaptive());
 
         scn.SkipToLSTurn(Phase.BATTLE);
+        scn.LSActivateForceCheat(1);
         scn.PrepareLSDestiny(1);
 
-        assertTrue(scn.LSCardActionAvailable(grenade));
-        scn.LSUseCardAction(grenade);
+        scn.LSInitiateBattle(cantina);
+        scn.PassBattleStartResponses();
+        assertTrue(scn.AwaitingLSWeaponsSegmentActions());
+        assertTrue(scn.LSCardActionAvailable(grenade, "Fire"));
+        scn.LSUseCardAction(grenade, "Fire");
         scn.LSChooseCard(cantina);
         scn.PassAllResponses();
+        chooseLostPileOrderPreferring(scn, vader);
+        // Release happens before escort is placed in Lost Pile
+        releaseCaptiveWith(scn, luke, false);
 
         assertInZone(Zone.LOST_PILE, vader);
-        assertTrue(scn.LSReleaseDecisionAvailable());
-        scn.LSChooseEscape();
-        scn.PassAllResponses();
-
         assertFalse(luke.isCaptive());
         assertInZone(Zone.USED_PILE, luke);
     }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_073_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_073_Tests.java
@@ -1,0 +1,148 @@
+package com.gempukku.swccgo.cards.set1.light;
+
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static com.gempukku.swccgo.framework.Assertions.assertAtLocation;
+import static com.gempukku.swccgo.framework.Assertions.assertInZone;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * VHD coverage for all-cards escort loss releasing captives not in the lost set (#981 / #645 / #325).
+ */
+public class Card_1_073_Tests {
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("brawl", "1_073"); // Cantina Brawl
+                    put("luke", "1_019"); // Luke Skywalker — ability 4
+                    put("luke_jedi", "9_024"); // Luke Skywalker, Jedi Knight — destiny 6
+                    put("grenade", "3_073"); // Concussion Grenade
+                    put("biggs", "1_003"); // Biggs — destiny 2 warrior
+                }},
+                new HashMap<>() {{
+                    put("vader", "1_168"); // Darth Vader — ability 6, destiny 1
+                }},
+                10,
+                10,
+                StartingSetup.LSStartingLocation("1_128"), // Tatooine: Cantina
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void CantinaBrawlEscortOnlyLostCaptiveMayRally() {
+        // Cantina Brawl destinies match Vader ability (6) only — Luke (ability 4) Escape/Rallys.
+        var scn = GetScenario();
+
+        var brawl = scn.GetLSCard("brawl");
+        var luke = scn.GetLSCard("luke");
+        var cantina = scn.GetLSStartingLocation();
+        var vader = scn.GetDSCard("vader");
+
+        scn.StartGame();
+        scn.MoveCardsToHand(brawl);
+        scn.MoveCardsToLocation(cantina, vader, luke);
+        scn.CaptureCardWith(vader, luke);
+
+        assertTrue(luke.isCaptive());
+                scn.SkipToLSTurn(Phase.CONTROL);
+        scn.LSActivateForceCheat(2);
+        scn.PrepareLSDestiny(6);
+        scn.PrepareDSDestiny(1);
+
+        assertTrue(scn.LSPlayLostInterruptAvailable(brawl));
+        scn.LSPlayLostInterrupt(brawl);
+        scn.PassCardAndForceUseResponses();
+        // destinies resolve; Vader is the only matching ability character to lose
+        scn.PassAllResponses();
+
+        assertInZone(Zone.LOST_PILE, vader);
+        assertTrue(scn.LSReleaseDecisionAvailable());
+        scn.LSChooseRally();
+        scn.PassAllResponses();
+
+        assertFalse(luke.isCaptive());
+        assertAtLocation(cantina, luke);
+    }
+
+    @Test
+    public void CantinaBrawlEscortAndCaptiveBothLostNoUsedEscape() {
+        // Destinies 6 and 4 match Vader ability and Luke ability — captive lost with escort, no Used Escape.
+        var scn = GetScenario();
+
+        var brawl = scn.GetLSCard("brawl");
+        var luke = scn.GetLSCard("luke");
+        var cantina = scn.GetLSStartingLocation();
+        var vader = scn.GetDSCard("vader");
+
+        scn.StartGame();
+        scn.MoveCardsToHand(brawl);
+        scn.MoveCardsToLocation(cantina, vader, luke);
+        scn.CaptureCardWith(vader, luke);
+
+        scn.SkipToLSTurn(Phase.CONTROL);
+        scn.LSActivateForceCheat(2);
+        scn.PrepareLSDestiny(6);
+        scn.PrepareDSDestiny(4);
+
+        scn.LSPlayLostInterrupt(brawl);
+        scn.PassCardAndForceUseResponses();
+        // Prefer escort first so the pull-in path is exercised
+        if (scn.LSDecisionAvailable("Choose card to be lost")) {
+            scn.LSChooseCard(vader);
+        }
+        scn.PassAllResponses();
+
+        assertFalse(scn.LSReleaseDecisionAvailable());
+        assertInZone(Zone.LOST_PILE, vader);
+        assertInZone(Zone.LOST_PILE, luke);
+        assertFalse(luke.isCaptive());
+    }
+
+    @Test
+    public void ConcussionGrenadeMatchingEscortDestinyOnlyReleasesCaptive() {
+        // Grenade destiny 1 matches Vader (destiny 1) only — Luke Jedi (destiny 6) Escape/Rallys.
+        var scn = GetScenario();
+
+        var luke = scn.GetLSCard("luke_jedi");
+        var grenade = scn.GetLSCard("grenade");
+        var biggs = scn.GetLSCard("biggs");
+        var cantina = scn.GetLSStartingLocation();
+        var vader = scn.GetDSCard("vader");
+
+        scn.StartGame();
+        scn.MoveCardsToLocation(cantina, vader, luke, biggs);
+        scn.AttachCardsTo(biggs, grenade);
+        scn.CaptureCardWith(vader, luke);
+
+        assertTrue(luke.isCaptive());
+
+        scn.SkipToLSTurn(Phase.BATTLE);
+        scn.PrepareLSDestiny(1);
+
+        assertTrue(scn.LSCardActionAvailable(grenade));
+        scn.LSUseCardAction(grenade);
+        scn.LSChooseCard(cantina);
+        scn.PassAllResponses();
+
+        assertInZone(Zone.LOST_PILE, vader);
+        assertTrue(scn.LSReleaseDecisionAvailable());
+        scn.LSChooseEscape();
+        scn.PassAllResponses();
+
+        assertFalse(luke.isCaptive());
+        assertInZone(Zone.USED_PILE, luke);
+    }
+}


### PR DESCRIPTION
## Summary
All-cards losses (Cantina Brawl, Concussion Grenade, etc.) that remove an escort but do **not** include the captive in the lost set were leaving the captive hanging (still attached / no Escape or Rally). Root cause: `LoseCardsFromTableEffect` passed `releaseCaptives = !allCardsSituation`, so all-cards paths never released captives.

Per AR, if the escort leaves and the captive is **not** part of the same all-cards leave set, the captive must Escape or Rally. If the captive **is** in that set (Explosive Charge, Program Trap, Binders multi-captive partial hit), they leave without Used Escape.

## What changed
- `LoseCardsFromTableEffect`: always pass `releaseCaptives = true`; when an escort is chosen for Lost Pile ordering, also pull any of its captives that are still in the remaining lose set into the same simultaneous lose (so they do not Escape/Rally).
- `ChooseCardsToLoseFromTableEffect`: same captive pull-in for Lost Pile ordering consistency (it already passed `releaseCaptives = true`).

No broad captive-engine rewrite.

## Tests
`Card_1_073_Tests` — **3 run / 0 fail / 0 skip** (tip `81deae425f18204c0a5ac7df67762cc0d6b3cf0f`)
- `CantinaBrawlEscortOnlyLostCaptiveMayRally` — destinies match escort ability only → captive Rallys
- `CantinaBrawlEscortAndCaptiveBothLostNoUsedEscape` — destinies match both → captive Lost, no Used Escape
- `ConcussionGrenadeMatchingEscortDestinyOnlyReleasesCaptive` — grenade destiny matches escort only → captive Escapes to Used Pile

## Closes
Closes #981. Same root as #645 and #325 — also closes those.

Does not claim #57 (different path).

## Tip
`81deae425f18204c0a5ac7df67762cc0d6b3cf0f`

## Overlay
Overlay **17004** rebuilt and healthy with this tip.