### PR TITLE
Fix #886: unique permanent-pilot personas not location-present

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/dark/Card1_264.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/dark/Card1_264.java
@@ -89,7 +89,7 @@ public class Card1_264 extends AbstractLostInterrupt {
         // Check condition(s)
         if (TriggerConditions.wonBattle(game, effectResult, playerId)
                 && GameConditions.canUseForceToPlayInterrupt(game, playerId, self, 1)
-                && GameConditions.isDuringBattleWithParticipant(game, Filters.and(Filters.Dark_Jedi, Filters.presentInBattle))
+                && GameConditions.isDuringBattleWithParticipant(game, Filters.personaPresentInBattle(Filters.Dark_Jedi))
                 && GameConditions.canTarget(game, self, targetingReason, filter)) {
 
             final PlayInterruptAction action = new PlayInterruptAction(game, self);

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_091.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_091.java
@@ -44,7 +44,7 @@ public class Card1_091 extends AbstractUsedInterrupt {
         // Check condition(s)
         if (TriggerConditions.battleInitiatedAt(game, effectResult, playerId, Filters.canTargetCard(self))
                 && GameConditions.hasLessPowerInBattleThanOpponent(game, playerId)) {
-            final int damageMultiplier = GameConditions.isDuringBattleWithParticipant(game, Filters.and(Filters.Han, Filters.presentInBattle, Filters.canBeTargetedBy(self))) ? 3 : 2;
+            final int damageMultiplier = GameConditions.isDuringBattleWithParticipant(game, Filters.and(Filters.personaPresentInBattle(Filters.Han), Filters.canBeTargetedBy(self))) ? 3 : 2;
 
             final PlayInterruptAction action = new PlayInterruptAction(game, self);
             action.setText(damageMultiplier == 2 ? "Double opponent's battle damage" : "Triple opponent's battle damage");
@@ -60,7 +60,7 @@ public class Card1_091 extends AbstractUsedInterrupt {
                             action.addAnimationGroup(targetedBattleLocation);
                             if (damageMultiplier == 3) {
                                 action.appendTargeting(
-                                        new TargetCardOnTableEffect(action, playerId, "Choose Han", Filters.and(Filters.Han, Filters.presentInBattle)) {
+                                        new TargetCardOnTableEffect(action, playerId, "Choose Han", Filters.personaPresentInBattle(Filters.Han)) {
                                             @Override
                                             protected boolean getUseShortcut() {
                                                 return true;

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set101/light/Card101_003.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set101/light/Card101_003.java
@@ -73,8 +73,9 @@ public class Card101_003 extends AbstractLostInterrupt {
                                                         new MoveCardUsingLandspeedEffect(action, playerId, finalTarget, true, Filters.battleLocation));
                                                 action.appendEffect(
                                                         new AddUntilEndOfBattleModifierEffect(action,
-                                                                new PowerModifier(self, Filters.Luke, new CantSpotCondition(self, Filters.and(Filters.Vader, Filters.or(Filters.presentAt(Filters.battleLocation),
-                                                                        Filters.at(Filters.adjacentSiteTo(self, Filters.battleLocation))))), 2), null));
+                                                                new PowerModifier(self, Filters.Luke, new CantSpotCondition(self, Filters.or(
+                                                                        Filters.personaPresentAt(Filters.Vader, Filters.battleLocation),
+                                                                        Filters.personaAt(Filters.Vader, Filters.adjacentSiteTo(self, Filters.battleLocation)))), 2), null));
                                             }
                                         }
                                 );

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set11/dark/Card11_071.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set11/dark/Card11_071.java
@@ -63,7 +63,7 @@ public class Card11_071 extends AbstractNormalEffect {
         if (TriggerConditions.isTableChanged(game, effectResult)) {
             PhysicalCard amidala = Filters.findFirstActive(game, self, Filters.Amidala);
             if (amidala != null) {
-                if (GameConditions.isPresentWith(game, self, amidala, Filters.Maul)
+                if (GameConditions.canSpot(game, self, Filters.personaPresentAt(Filters.Maul, Filters.sameLocation(amidala)))
                     && !GameConditions.isWith(game, self, amidala, Filters.and(Filters.opponents(self), Filters.Jedi))) {
 
                     final RequiredGameTextTriggerAction action = new RequiredGameTextTriggerAction(self, gameTextSourceCardId);

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set4/dark/Card4_121.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set4/dark/Card4_121.java
@@ -40,8 +40,10 @@ public class Card4_121 extends AbstractNormalEffect {
     @Override
     protected Filter getGameTextValidDeployTargetFilter(SwccgGame game, PhysicalCard self, PlayCardOptionId playCardOptionId, boolean asReact) {
         return Filters.and(Filters.Imperial, Filters.abilityLessThan(5),
-                Filters.presentWith(self, Filters.or(Filters.Vader, Filters.Emperor,
-                        Filters.and(Filters.your(self), Filters.or(Filters.admiral, Filters.general, Filters.moff)))));
+                Filters.or(
+                        Filters.at(Filters.sameLocationAs(self, Filters.personaPresentAt(Filters.Vader, Filters.location))),
+                        Filters.presentWith(self, Filters.or(Filters.Emperor,
+                                Filters.and(Filters.your(self), Filters.or(Filters.admiral, Filters.general, Filters.moff))))));
     }
 
     @Override

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/dark/Card5_141.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/dark/Card5_141.java
@@ -43,7 +43,7 @@ public class Card5_141 extends AbstractLostInterrupt {
 
     @Override
     protected List<PlayInterruptAction> getGameTextTopLevelActions(final String playerId, final SwccgGame game, final PhysicalCard self) {
-        Filter filter = Filters.and(Filters.Vader, Filters.hasAnyImmunityToAttrition, Filters.presentInBattle);
+        Filter filter = Filters.and(Filters.personaPresentInBattle(Filters.Vader), Filters.hasAnyImmunityToAttrition);
 
         // Check condition(s)
         if (GameConditions.isDuringBattleAt(game, Filters.site)

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set6/dark/Card6_154.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set6/dark/Card6_154.java
@@ -47,8 +47,10 @@ public class Card6_154 extends AbstractUsedInterrupt {
     protected List<PlayInterruptAction> getGameTextTopLevelActions(final String playerId, SwccgGame game, final PhysicalCard self) {
         // Check condition(s)
         if (GameConditions.isDuringBattle(game)) {
-            Filter filter = Filters.and(Filters.or(Filters.Boba_Fett, Filters.grantedMayBeTargetedBy(self), Filters.and(Filters.your(self),
-                    Filters.character, Filters.hasAttached(Filters.Mandalorian_Armor))), Filters.presentInBattle);
+            Filter filter = Filters.or(
+                    Filters.personaPresentInBattle(Filters.Boba_Fett),
+                    Filters.and(Filters.or(Filters.grantedMayBeTargetedBy(self), Filters.and(Filters.your(self),
+                            Filters.character, Filters.hasAttached(Filters.Mandalorian_Armor))), Filters.presentInBattle));
             if (GameConditions.canSpot(game, self, filter)) {
                 Filter opponentsCharacter = Filters.and(Filters.opponents(self), Filters.character, Filters.presentInBattle);
                 final Set<TargetingReason> targetingReasonSet = new HashSet<TargetingReason>();

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set6/dark/Card6_154.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set6/dark/Card6_154.java
@@ -49,8 +49,9 @@ public class Card6_154 extends AbstractUsedInterrupt {
         if (GameConditions.isDuringBattle(game)) {
             Filter filter = Filters.or(
                     Filters.personaPresentInBattle(Filters.Boba_Fett),
-                    Filters.and(Filters.or(Filters.grantedMayBeTargetedBy(self), Filters.and(Filters.your(self),
-                            Filters.character, Filters.hasAttached(Filters.Mandalorian_Armor))), Filters.presentInBattle));
+                    Filters.and(Filters.character, Filters.presentInBattle, Filters.or(
+                            Filters.grantedMayBeTargetedBy(self),
+                            Filters.and(Filters.your(self), Filters.hasAttached(Filters.Mandalorian_Armor)))));
             if (GameConditions.canSpot(game, self, filter)) {
                 Filter opponentsCharacter = Filters.and(Filters.opponents(self), Filters.character, Filters.presentInBattle);
                 final Set<TargetingReason> targetingReasonSet = new HashSet<TargetingReason>();

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set8/light/Card8_062.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set8/light/Card8_062.java
@@ -48,7 +48,7 @@ public class Card8_062 extends AbstractUsedInterrupt {
         // Check condition(s)
         if (GameConditions.isDuringYourTurn(game, self)) {
             final PhysicalCard site = Filters.findFirstFromTopLocationsOnTable(game, Filters.and(Filters.battleground_site,
-                    Filters.and(Filters.wherePresent(self, Filters.and(Filters.Han, Filters.not(Filters.undercover_spy))), Filters.wherePresent(self, Filters.and(Filters.Leia, Filters.not(Filters.undercover_spy))))));
+                    Filters.and(Filters.wherePresent(self, Filters.and(Filters.personaPresentAt(Filters.Han, Filters.battleground_site), Filters.not(Filters.undercover_spy))), Filters.wherePresent(self, Filters.and(Filters.personaPresentAt(Filters.Leia, Filters.battleground_site), Filters.not(Filters.undercover_spy))))));
             if (site != null) {
 
                 final PlayInterruptAction action1 = new PlayInterruptAction(game, self);

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set9/dark/Card9_134.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set9/dark/Card9_134.java
@@ -59,8 +59,8 @@ public class Card9_134 extends AbstractNormalEffect {
         if (targetsLeiaInsteadOfLuke) {
             // Check condition(s)
             if (TriggerConditions.isStartOfYourTurn(game, effectResult, self)
-                    && GameConditions.canSpot(game, self, Filters.and(Filters.Vader, Filters.presentAt(Filters.battleground_site)))
-                    && !GameConditions.canSpot(game, self, SpotOverride.INCLUDE_CAPTIVE, Filters.and(Filters.Leia, Filters.or(Filters.captive, Filters.presentAt(Filters.battleground_site))))
+                    && GameConditions.canSpot(game, self, Filters.personaPresentAt(Filters.Vader, Filters.battleground_site))
+                    && !GameConditions.canSpot(game, self, SpotOverride.INCLUDE_CAPTIVE, Filters.or(Filters.and(Filters.Leia, Filters.captive), Filters.personaPresentAt(Filters.Leia, Filters.battleground_site)))
                     && !GameConditions.isOutOfPlay(game, Filters.Leia)) {
 
                 final RequiredGameTextTriggerAction action = new RequiredGameTextTriggerAction(self, gameTextSourceCardId);
@@ -75,8 +75,8 @@ public class Card9_134 extends AbstractNormalEffect {
         else if (targetsKananInsteadOfLuke) {
             // Check condition(s)
             if (TriggerConditions.isStartOfYourTurn(game, effectResult, self)
-                    && GameConditions.canSpot(game, self, Filters.and(Filters.Vader, Filters.presentAt(Filters.battleground_site)))
-                    && !GameConditions.canSpot(game, self, SpotOverride.INCLUDE_CAPTIVE, Filters.and(Filters.Kanan, Filters.or(Filters.captive, Filters.presentAt(Filters.battleground_site))))
+                    && GameConditions.canSpot(game, self, Filters.personaPresentAt(Filters.Vader, Filters.battleground_site))
+                    && !GameConditions.canSpot(game, self, SpotOverride.INCLUDE_CAPTIVE, Filters.or(Filters.and(Filters.Kanan, Filters.captive), Filters.personaPresentAt(Filters.Kanan, Filters.battleground_site)))
                     && !GameConditions.isOutOfPlay(game, Filters.Kanan)) {
 
                 final RequiredGameTextTriggerAction action = new RequiredGameTextTriggerAction(self, gameTextSourceCardId);
@@ -91,8 +91,8 @@ public class Card9_134 extends AbstractNormalEffect {
         else {
             // Check condition(s)
             if (TriggerConditions.isStartOfYourTurn(game, effectResult, self)
-                    && GameConditions.canSpot(game, self, Filters.and(Filters.Vader, Filters.presentAt(Filters.battleground_site)))
-                    && !GameConditions.canSpot(game, self, SpotOverride.INCLUDE_CAPTIVE, Filters.and(Filters.Luke, Filters.or(Filters.captive, Filters.presentAt(Filters.battleground_site))))
+                    && GameConditions.canSpot(game, self, Filters.personaPresentAt(Filters.Vader, Filters.battleground_site))
+                    && !GameConditions.canSpot(game, self, SpotOverride.INCLUDE_CAPTIVE, Filters.or(Filters.and(Filters.Luke, Filters.captive), Filters.personaPresentAt(Filters.Luke, Filters.battleground_site)))
                     && !GameConditions.isOutOfPlay(game, Filters.Luke)) {
 
                 final RequiredGameTextTriggerAction action = new RequiredGameTextTriggerAction(self, gameTextSourceCardId);

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set9/light/Card9_048.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set9/light/Card9_048.java
@@ -61,9 +61,9 @@ public class Card9_048 extends AbstractUsedInterrupt {
                 && GameConditions.canDrawDestiny(game, playerId)) {
             final AboutToLeaveTableResult aboutToLeaveTableResult = (AboutToLeaveTableResult) effectResult;
             PhysicalCard cardToBeLost = aboutToLeaveTableResult.getCardAboutToLeaveTable();
-            final Filter vaderFilter = Filters.and(Filters.Vader, Filters.present(cardToBeLost));
+            final Filter vaderFilter = Filters.personaPresentAt(Filters.Vader, Filters.sameLocation(cardToBeLost));
             if (GameConditions.canTarget(game, self, vaderFilter)) {
-                final Filter emperorFilter = Filters.and(Filters.Emperor, Filters.present(cardToBeLost));
+                final Filter emperorFilter = Filters.personaPresentAt(Filters.Emperor, Filters.sameLocation(cardToBeLost));
 
                 final PlayInterruptAction action = new PlayInterruptAction(game, self);
                 action.setImmuneTo(Title.Sense);

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
@@ -11097,10 +11097,12 @@ public class Filters {
      */
     public static Filter personaPresentInBattle(final Filterable personaFilter) {
         final Filter persona = Filters.and(personaFilter);
-        return Filters.or(
-                Filters.and(persona, Filters.character, Filters.presentInBattle),
-                Filters.and(Filters.hasPermanentPilot(persona), Filters.open_vehicle, Filters.presentInBattle)
-        );
+        // Characters with the persona that are present in battle, or permanent pilots with that
+        // persona aboard open vehicles (not starships / enclosed vehicles).
+        return Filters.and(Filters.presentInBattle, Filters.or(
+                Filters.and(persona, Filters.character),
+                Filters.and(Filters.hasPermanentPilot(persona), Filters.open_vehicle)
+        ));
     }
 
     /**
@@ -11114,10 +11116,10 @@ public class Filters {
      */
     public static Filter personaPresentAt(final Filterable personaFilter, final Filter locationFilter) {
         final Filter persona = Filters.and(personaFilter);
-        return Filters.or(
-                Filters.and(persona, Filters.character, Filters.presentAt(locationFilter)),
-                Filters.and(Filters.hasPermanentPilot(persona), Filters.open_vehicle, Filters.presentAt(locationFilter))
-        );
+        return Filters.and(Filters.presentAt(locationFilter), Filters.or(
+                Filters.and(persona, Filters.character),
+                Filters.and(Filters.hasPermanentPilot(persona), Filters.open_vehicle)
+        ));
     }
 
     /**
@@ -11131,10 +11133,10 @@ public class Filters {
      */
     public static Filter personaAt(final Filterable personaFilter, final Filter locationFilter) {
         final Filter persona = Filters.and(personaFilter);
-        return Filters.or(
-                Filters.and(persona, Filters.character, Filters.at(locationFilter)),
-                Filters.and(Filters.hasPermanentPilot(persona), Filters.open_vehicle, Filters.at(locationFilter))
-        );
+        return Filters.and(Filters.at(locationFilter), Filters.or(
+                Filters.and(persona, Filters.character),
+                Filters.and(Filters.hasPermanentPilot(persona), Filters.open_vehicle)
+        ));
     }
 
     /**

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
@@ -11087,6 +11087,57 @@ public class Filters {
     }
 
     /**
+     * Filter that accepts cards representing a persona that is "present" during battle
+     * (present at the battle location). Unique permanent-pilot personas aboard starships
+     * or enclosed vehicles are present aboard the craft, not at the location, so those
+     * combo cards do not match. Permanent pilots aboard open vehicles remain location-present.
+     *
+     * @param personaFilter filter matching the persona (e.g. Filters.Boba_Fett)
+     * @return Filter
+     */
+    public static Filter personaPresentInBattle(final Filterable personaFilter) {
+        final Filter persona = Filters.and(personaFilter);
+        return Filters.or(
+                Filters.and(persona, Filters.character, Filters.presentInBattle),
+                Filters.and(Filters.hasPermanentPilot(persona), Filters.open_vehicle, Filters.presentInBattle)
+        );
+    }
+
+    /**
+     * Filter that accepts cards representing a persona that is "present" at locations
+     * accepted by the specified filter. Unique permanent-pilot personas aboard starships
+     * or enclosed vehicles are present aboard the craft, not at the location.
+     *
+     * @param personaFilter filter matching the persona (e.g. Filters.Vader)
+     * @param locationFilter locations to check presence at
+     * @return Filter
+     */
+    public static Filter personaPresentAt(final Filterable personaFilter, final Filter locationFilter) {
+        final Filter persona = Filters.and(personaFilter);
+        return Filters.or(
+                Filters.and(persona, Filters.character, Filters.presentAt(locationFilter)),
+                Filters.and(Filters.hasPermanentPilot(persona), Filters.open_vehicle, Filters.presentAt(locationFilter))
+        );
+    }
+
+    /**
+     * Filter that accepts cards representing a persona that is "at" locations accepted by
+     * the specified filter. Unique permanent-pilot personas aboard starships or enclosed
+     * vehicles are aboard the craft, not at the location for persona-"at" checks.
+     *
+     * @param personaFilter filter matching the persona (e.g. Filters.Vader)
+     * @param locationFilter locations to check
+     * @return Filter
+     */
+    public static Filter personaAt(final Filterable personaFilter, final Filter locationFilter) {
+        final Filter persona = Filters.and(personaFilter);
+        return Filters.or(
+                Filters.and(persona, Filters.character, Filters.at(locationFilter)),
+                Filters.and(Filters.hasPermanentPilot(persona), Filters.open_vehicle, Filters.at(locationFilter))
+        );
+    }
+
+    /**
      * Filter that accepts cards that are in battle with the specified card.
      *
      * @param card the card

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/dark/Card_1_264_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/dark/Card_1_264_Tests.java
@@ -1,0 +1,61 @@
+package com.gempukku.swccgo.cards.set1.dark;
+
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Physical Choke battle-won option needs a present Dark Jedi. Dark_Jedi already requires character,
+ * and is wired through personaPresentInBattle. These tests cover the Rebel Trooper mode still working
+ * and document that DSAS alone does not unlock the top-level Rebel Trooper path incorrectly.
+ */
+public class Card_1_264_Tests {
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("rebelTrooper", "1_28"); // Rebel Trooper (approx; may adjust)
+                }},
+                new HashMap<>() {{
+                    put("choke", "1_264"); // Physical Choke
+                    put("dsas", "7_303"); // Death Star Assault Squadron
+                    put("db", "1_291"); // Tatooine: Docking Bay 94
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void PhysicalChokeRebelTrooperModeStillAvailableWithDSASOnTable() {
+        var scn = GetScenario();
+
+        var choke = scn.GetDSCard("choke");
+        var dsas = scn.GetDSCard("dsas");
+        var db = scn.GetDSCard("db");
+        var trooper = scn.GetLSCard("rebelTrooper");
+
+        scn.StartGame();
+        scn.MoveCardsToDSHand(choke);
+        scn.MoveLocationToTable(db);
+        scn.MoveCardsToLocation(db, dsas, trooper);
+
+        scn.SkipToPhase(Phase.CONTROL);
+
+        assertTrue(scn.DSCardPlayAvailable(choke, "Choke a Rebel Trooper"));
+        // battle-won Dark Jedi mode is not a top-level action; DSAS must not invent one
+        assertFalse(scn.DSCardPlayAvailable(choke, "Choke an opponent's character"));
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_091_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_091_Tests.java
@@ -1,0 +1,84 @@
+package com.gempukku.swccgo.cards.set1.light;
+
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Card_1_091_Tests {
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("badFeeling", "1_91"); // I've Got A Bad Feeling About This
+                    put("falcon", "13_21"); // Han, Chewie, And The Falcon
+                    put("han", "1_11"); // Han Solo
+                    put("db", "1_129"); // Tatooine: Docking Bay 94
+                }},
+                new HashMap<>() {{
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void BadFeelingDoublesNotTriplesWithOnlyFalconInBattle() {
+        var scn = GetScenario();
+
+        var badFeeling = scn.GetLSCard("badFeeling");
+        var falcon = scn.GetLSCard("falcon");
+        var db = scn.GetLSCard("db");
+        var ds1 = scn.GetDSFiller(1);
+        var ds2 = scn.GetDSFiller(2);
+        var ds3 = scn.GetDSFiller(3);
+        var ds4 = scn.GetDSFiller(4);
+        var ds5 = scn.GetDSFiller(5);
+
+        scn.StartGame();
+        scn.MoveCardsToLSHand(badFeeling);
+        scn.MoveLocationToTable(db);
+        scn.MoveCardsToLocation(db, falcon, ds1, ds2, ds3, ds4, ds5);
+
+        scn.SkipToLSTurn(Phase.BATTLE);
+        scn.LSInitiateBattle(db);
+
+        assertTrue(scn.LSCardPlayAvailable(badFeeling, "Double opponent's battle damage"));
+        assertFalse(scn.LSCardPlayAvailable(badFeeling, "Triple opponent's battle damage"));
+    }
+
+    @Test
+    public void BadFeelingTriplesWithCharacterHanPresentInBattle() {
+        var scn = GetScenario();
+
+        var badFeeling = scn.GetLSCard("badFeeling");
+        var han = scn.GetLSCard("han");
+        var db = scn.GetLSCard("db");
+        var ds1 = scn.GetDSFiller(1);
+        var ds2 = scn.GetDSFiller(2);
+        var ds3 = scn.GetDSFiller(3);
+        var ds4 = scn.GetDSFiller(4);
+        var ds5 = scn.GetDSFiller(5);
+
+        scn.StartGame();
+        scn.MoveCardsToLSHand(badFeeling);
+        scn.MoveLocationToTable(db);
+        scn.MoveCardsToLocation(db, han, ds1, ds2, ds3, ds4, ds5);
+
+        scn.SkipToLSTurn(Phase.BATTLE);
+        scn.LSInitiateBattle(db);
+
+        assertTrue(scn.LSCardPlayAvailable(badFeeling, "Triple opponent's battle damage"));
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set101/light/Card_101_003_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set101/light/Card_101_003_Tests.java
@@ -57,11 +57,11 @@ public class Card_101_003_Tests {
         scn.DSUseCardAction(db, "Initiate battle");
         scn.PassForceUseResponses();
 
-        assertTrue(scn.LSCardPlayAvailable(runLukeRun));
-        scn.LSPlayCard(runLukeRun);
-        scn.PassAllResponses();
+        assertTrue(scn.LSCardPlayAvailable(runLukeRun, "Move Luke"));
+        scn.LSPlayCardAndPassResponses(runLukeRun, "Move Luke", luke);
 
         assertTrue(scn.CardsAtLocation(db, luke));
+        assertTrue(scn.IsActiveBattle());
         // Luke printed power 3; Run Luke, Run! +2 should remain despite DSAS Vader permanent pilot
         assertEquals(5, scn.GetPower(luke));
     }

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set101/light/Card_101_003_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set101/light/Card_101_003_Tests.java
@@ -1,0 +1,68 @@
+package com.gempukku.swccgo.cards.set101.light;
+
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class Card_101_003_Tests {
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("luke", "1_019");
+                    put("runLukeRun", "101_3");
+                    put("cantina", "1_128"); // Tatooine: Cantina
+                }},
+                new HashMap<>() {{
+                    put("dsas", "7_303"); // Death Star Assault Squadron
+                    put("db", "1_291"); // Tatooine: Docking Bay 94
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void RunLukeRunKeepsPowerBonusWhenDeathStarAssaultSquadronAtBattleSite() {
+        var scn = GetScenario();
+
+        var luke = scn.GetLSCard("luke");
+        var runLukeRun = scn.GetLSCard("runLukeRun");
+        var cantina = scn.GetLSCard("cantina");
+        var trooper = scn.GetLSFiller(1);
+        var dsas = scn.GetDSCard("dsas");
+        var db = scn.GetDSCard("db");
+
+        scn.StartGame();
+        scn.MoveCardsToLSHand(runLukeRun);
+        scn.MoveLocationToTable(cantina);
+        scn.MoveLocationToTable(db);
+        scn.MoveCardsToLocation(cantina, luke);
+        scn.MoveCardsToLocation(db, dsas, trooper);
+
+        scn.SkipToPhase(Phase.BATTLE);
+        assertTrue(scn.DSCanInitiateBattle(db));
+        scn.DSUseCardAction(db, "Initiate battle");
+        scn.PassForceUseResponses();
+
+        assertTrue(scn.LSCardPlayAvailable(runLukeRun));
+        scn.LSPlayCard(runLukeRun);
+        scn.PassAllResponses();
+
+        assertTrue(scn.CardsAtLocation(db, luke));
+        // Luke printed power 3; Run Luke, Run! +2 should remain despite DSAS Vader permanent pilot
+        assertEquals(5, scn.GetPower(luke));
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_141_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/dark/Card_5_141_Tests.java
@@ -1,0 +1,75 @@
+package com.gempukku.swccgo.cards.set5.dark;
+
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Card_5_141_Tests {
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                }},
+                new HashMap<>() {{
+                    put("focused", "5_141"); // Focused Attack
+                    put("dsas", "7_303"); // Death Star Assault Squadron
+                    put("vader", "1_168"); // Darth Vader
+                    put("db", "1_291"); // Tatooine: Docking Bay 94
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void FocusedAttackCannotPlayWithOnlyDSASInBattle() {
+        var scn = GetScenario();
+
+        var trooper = scn.GetLSFiller(1);
+        var focused = scn.GetDSCard("focused");
+        var dsas = scn.GetDSCard("dsas");
+        var db = scn.GetDSCard("db");
+
+        scn.StartGame();
+        scn.MoveCardsToDSHand(focused);
+        scn.MoveLocationToTable(db);
+        scn.MoveCardsToLocation(db, dsas, trooper);
+
+        scn.SkipToPhase(Phase.BATTLE);
+        scn.DSInitiateBattle(db);
+
+        assertFalse(scn.DSCardPlayAvailable(focused));
+    }
+
+    @Test
+    public void FocusedAttackCanPlayWithCharacterVaderInBattle() {
+        var scn = GetScenario();
+
+        var trooper = scn.GetLSFiller(1);
+        var focused = scn.GetDSCard("focused");
+        var vader = scn.GetDSCard("vader");
+        var db = scn.GetDSCard("db");
+
+        scn.StartGame();
+        scn.MoveCardsToDSHand(focused);
+        scn.MoveLocationToTable(db);
+        scn.MoveCardsToLocation(db, vader, trooper);
+
+        scn.SkipToPhase(Phase.BATTLE);
+        scn.DSInitiateBattle(db);
+
+        assertTrue(scn.DSCardPlayAvailable(focused));
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set6/dark/Card_6_154_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set6/dark/Card_6_154_Tests.java
@@ -1,0 +1,77 @@
+package com.gempukku.swccgo.cards.set6.dark;
+
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Card_6_154_Tests {
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                }},
+                new HashMap<>() {{
+                    put("hiddenWeapons", "6_154");
+                    put("slaveI", "109_8"); // Boba Fett In Slave I
+                    put("boba", "5_091"); // Boba Fett (character)
+                    put("db", "1_291"); // Tatooine: Docking Bay 94
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void HiddenWeaponsCannotPlayWithBobaFettInSlaveIAtDockingBay() {
+        var scn = GetScenario();
+
+        var trooper = scn.GetLSFiller(1);
+        var hiddenWeapons = scn.GetDSCard("hiddenWeapons");
+        var slaveI = scn.GetDSCard("slaveI");
+        var db = scn.GetDSCard("db");
+
+        scn.StartGame();
+        scn.MoveCardsToDSHand(hiddenWeapons);
+        scn.MoveLocationToTable(db);
+        scn.MoveCardsToLocation(db, slaveI, trooper);
+
+        scn.SkipToPhase(Phase.BATTLE);
+        scn.DSInitiateBattle(db);
+
+        assertTrue(scn.AwaitingDSWeaponsSegmentActions());
+        assertFalse(scn.DSCardPlayAvailable(hiddenWeapons));
+    }
+
+    @Test
+    public void HiddenWeaponsCanPlayWithCharacterBobaFettPresent() {
+        var scn = GetScenario();
+
+        var trooper = scn.GetLSFiller(1);
+        var hiddenWeapons = scn.GetDSCard("hiddenWeapons");
+        var boba = scn.GetDSCard("boba");
+        var db = scn.GetDSCard("db");
+
+        scn.StartGame();
+        scn.MoveCardsToDSHand(hiddenWeapons);
+        scn.MoveLocationToTable(db);
+        scn.MoveCardsToLocation(db, boba, trooper);
+
+        scn.SkipToPhase(Phase.BATTLE);
+        scn.DSInitiateBattle(db);
+
+        assertTrue(scn.AwaitingDSWeaponsSegmentActions());
+        assertTrue(scn.DSCardPlayAvailable(hiddenWeapons));
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set8/light/Card_8_062_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set8/light/Card_8_062_Tests.java
@@ -1,0 +1,73 @@
+package com.gempukku.swccgo.cards.set8.light;
+
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Card_8_062_Tests {
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("absolutely", "8_62"); // This Is Absolutely Right
+                    put("falcon", "13_21"); // Han, Chewie, And The Falcon
+                    put("han", "1_11"); // Han Solo
+                    put("leia", "1_17"); // Leia Organa
+                    put("platform", "8_76"); // Endor: Landing Platform (Docking Bay)
+                }},
+                new HashMap<>() {{
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void AbsolutelyRightCannotPlayWithOnlyFalconAtBattleground() {
+        var scn = GetScenario();
+
+        var absolutely = scn.GetLSCard("absolutely");
+        var falcon = scn.GetLSCard("falcon");
+        var leia = scn.GetLSCard("leia");
+        var platform = scn.GetLSCard("platform");
+
+        scn.StartGame();
+        scn.MoveCardsToLSHand(absolutely);
+        scn.MoveLocationToTable(platform);
+        scn.MoveCardsToLocation(platform, falcon, leia);
+
+        scn.SkipToLSTurn();
+
+        assertFalse(scn.LSCardPlayAvailable(absolutely, "Make Force drains +1 this turn"));
+    }
+
+    @Test
+    public void AbsolutelyRightCanPlayWithCharacterHanAndLeiaPresent() {
+        var scn = GetScenario();
+
+        var absolutely = scn.GetLSCard("absolutely");
+        var han = scn.GetLSCard("han");
+        var leia = scn.GetLSCard("leia");
+        var platform = scn.GetLSCard("platform");
+
+        scn.StartGame();
+        scn.MoveCardsToLSHand(absolutely);
+        scn.MoveLocationToTable(platform);
+        scn.MoveCardsToLocation(platform, han, leia);
+
+        scn.SkipToLSTurn();
+
+        assertTrue(scn.LSCardPlayAvailable(absolutely, "Make Force drains +1 this turn"));
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set9/dark/Card_9_134_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set9/dark/Card_9_134_Tests.java
@@ -1,0 +1,68 @@
+package com.gempukku.swccgo.cards.set9.dark;
+
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Card_9_134_Tests {
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                }},
+                new HashMap<>() {{
+                    put("dsas", "7_303"); // Death Star Assault Squadron
+                    put("vader", "1_168"); // Darth Vader
+                    put("db", "1_291"); // Tatooine: Docking Bay 94
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.BHBMObjective,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void YourDestinyDoesNotLoseForceWhenOnlyDSASAtBattleground() {
+        var scn = GetScenario();
+
+        var dsas = scn.GetDSCard("dsas");
+        var db = scn.GetDSCard("db");
+
+        scn.StartGame();
+        scn.MoveLocationToTable(db);
+        scn.MoveCardsToLocation(db, dsas);
+
+        scn.SkipToDSTurn();
+        scn.PassAllResponses();
+
+        assertFalse(scn.AwaitingLSForceLossPayment());
+    }
+
+    @Test
+    public void YourDestinyLosesForceWhenCharacterVaderPresentAtBattleground() {
+        var scn = GetScenario();
+
+        var vader = scn.GetDSCard("vader");
+        var db = scn.GetDSCard("db");
+
+        scn.StartGame();
+        scn.MoveLocationToTable(db);
+        scn.MoveCardsToLocation(db, vader);
+
+        scn.SkipToDSTurn();
+        scn.PassAllResponses();
+
+        assertTrue(scn.AwaitingLSForceLossPayment());
+        scn.LSPayRemainingForceLossFromReserveDeck();
+    }
+}


### PR DESCRIPTION
## Summary
Unique permanent-pilot personas (Boba Fett In Slave I, Death Star Assault Squadron, Han/Chewie Falcon, etc.) are present aboard the craft, not at the location. Cards that AND a persona filter with `presentInBattle` / `presentAt` / `present` / `presentWith` incorrectly treated the combo ship as the persona being location-present.

Shared helpers `personaPresentInBattle` / `personaPresentAt` / `personaAt` match characters with the persona (and permanent pilots only aboard open vehicles). This PR wires the reported cards plus the prioritized Decipher sisters onto those helpers.

## Approach
Shared **personaPresent-style filters** in `Filters` (not card-local character-AND hacks alone). Open-vehicle permanent pilots remain location-present; starships and enclosed vehicles do not.

## Cards updated this PR
- Hidden Weapons (`6_154`)
- Run Luke, Run! (`101_3`)
- Your Destiny (`9_134`)
- Physical Choke (`1_264`)
- Focused Attack (`5_141`)
- I've Got A Bad Feeling About This (`1_91`)
- This Is Absolutely Right (`8_62`)
- I Will Find Them Quickly, Master (`11_71`)
- Anakin Skywalker (`9_48`)
- Field Promotion (`4_121`)

Skipped mass Virtual-only rewrites. Left for rules (not just filter wiring): Maul Strikes "in battle" vs "present with" duel branch, and other presentWith/in-battle edge cases.

## Tip
`3684ae2a356fba74de569b683ea50af143eef347`

## Tests (overlay 17004)
Prioritized suites — **12 run / 0 fail / 0 skip**
- `Card_6_154_Tests` — 2
- `Card_101_003_Tests` — 1
- `Card_9_134_Tests` — 2 (DSAS vs character Vader / Your Destiny)
- `Card_5_141_Tests` — 2 (Focused Attack + DSAS)
- `Card_1_091_Tests` — 2 (Falcon vs character Han / Bad Feeling)
- `Card_8_062_Tests` — 2 (Falcon vs Han+Leia / Absolutely Right)
- `Card_1_264_Tests` — 1 (Physical Choke Rebel Trooper path; Dark_Jedi already character-gated)

## Overlay
Overlay **17004** only.

Closes #886

Skipped #943 (device active/inactive).