### PR TITLE
Fix Yerka Mig deploy aboard and move-like-a-character shuttle (#1012, #1013)

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/PlayCardToLocationAction.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/actions/PlayCardToLocationAction.java
@@ -1,7 +1,10 @@
 package com.gempukku.swccgo.cards.actions;
 
 import com.gempukku.swccgo.cards.effects.PayDeployCostEffect;
+import com.gempukku.swccgo.common.TargetId;
+import com.gempukku.swccgo.common.TargetingReason;
 import com.gempukku.swccgo.filters.Filter;
+import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.game.PhysicalCard;
 import com.gempukku.swccgo.game.PlayCardOption;
 import com.gempukku.swccgo.game.ReactActionOption;
@@ -11,6 +14,7 @@ import com.gempukku.swccgo.logic.GameUtils;
 import com.gempukku.swccgo.logic.actions.AbstractPlayCardAction;
 import com.gempukku.swccgo.logic.effects.DeploySingleCardEffect;
 import com.gempukku.swccgo.logic.effects.PayExtraCostToDeployCardEffect;
+import com.gempukku.swccgo.logic.effects.TargetCardOnTableEffect;
 import com.gempukku.swccgo.logic.effects.choose.ChooseCardOnTableEffect;
 import com.gempukku.swccgo.logic.effects.choose.ChoosePlayerEffect;
 import com.gempukku.swccgo.logic.timing.Effect;
@@ -65,14 +69,29 @@ public class PlayCardToLocationAction extends AbstractPlayCardAction {
             _text = _text + " as a 'react'";
         }
 
-        appendTargeting(
-                new ChooseCardOnTableEffect(_that, getPerformingPlayer(), "Choose location where to " + _text.toLowerCase() + " " + GameUtils.getCardLink(cardToDeploy), deployTargetFilter) {
-                    @Override
-                    protected void cardSelected(PhysicalCard target) {
-                        _target = target;
+        // Moves-like-a-character cards (e.g. Yerka Mig) can deploy to sites or aboard ships/vehicles.
+        // When attaching, DeploySingleCardEffect requires TO_BE_DEPLOYED_ON targeting (Effects are cancelable).
+        if (cardToDeploy.getBlueprint().isMovesLikeCharacter()) {
+            appendTargeting(
+                    new TargetCardOnTableEffect(_that, getPerformingPlayer(), "Choose where to " + _text.toLowerCase() + " " + GameUtils.getCardLink(cardToDeploy), TargetingReason.TO_BE_DEPLOYED_ON, deployTargetFilter) {
+                        @Override
+                        protected void cardTargeted(int targetGroupId, PhysicalCard target) {
+                            _target = target;
+                            _cardToPlay.setTargetedCard(TargetId.DEPLOY_TARGET, targetGroupId, target, deployTargetFilter);
+                        }
                     }
-                }
-        );
+            );
+        }
+        else {
+            appendTargeting(
+                    new ChooseCardOnTableEffect(_that, getPerformingPlayer(), "Choose location where to " + _text.toLowerCase() + " " + GameUtils.getCardLink(cardToDeploy), deployTargetFilter) {
+                        @Override
+                        protected void cardSelected(PhysicalCard target) {
+                            _target = target;
+                        }
+                    }
+            );
+        }
     }
 
     @Override
@@ -151,7 +170,16 @@ public class PlayCardToLocationAction extends AbstractPlayCardAction {
             if (!_cardPlayed) {
                 _cardPlayed = true;
 
-                _playCardEffect = new DeploySingleCardEffect(_that, _cardToPlay, _target, !_cardToPlay.getOwner().equals(_playedToZoneOwner), null, _reactActionOption, _playCardOption.getId(), _reshuffle);
+                // Cards that deploy/move like a character (e.g. Yerka Mig) may target starships/vehicles
+                // for passenger capacity while still using a location play-card option. Attach as
+                // passenger instead of placing at the location (which left them in the void).
+                if (_cardToPlay.getBlueprint().isMovesLikeCharacter()
+                        && Filters.or(Filters.starship, Filters.vehicle).accepts(game, _target)) {
+                    _playCardEffect = new DeploySingleCardEffect(_that, _cardToPlay, _target, false, _reactActionOption, _playCardOption.getId(), _reshuffle);
+                }
+                else {
+                    _playCardEffect = new DeploySingleCardEffect(_that, _cardToPlay, _target, !_cardToPlay.getOwner().equals(_playedToZoneOwner), null, _reactActionOption, _playCardOption.getId(), _reshuffle);
+                }
                 return _playCardEffect;
             }
         }

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_069.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set1/light/Card1_069.java
@@ -52,8 +52,6 @@ public class Card1_069 extends AbstractUtinniEffect {
             deploysLikeACharacter = Filters.and(deploysLikeACharacter, Filters.not(Filters.locationAndCardsAtLocation(Filters.Dagobah_location)));
         }
         return deploysLikeACharacter;
-
-        //TODO when deploying aboard, need to attach to ship/vehicle - possibly using attachCardInPassengerCapacitySlot?
     }
 
     @Override

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/filters/Filters.java
@@ -7148,7 +7148,7 @@ public class Filters {
                 PhysicalCard attachedTo = cardToMove.getAttachedTo();
                 if ((atLocation == null && attachedTo == null)
                         || (cardToMove.getBlueprint().getCardCategory() != CardCategory.CHARACTER
-                        && !Filters.movesLikeCharacter().accepts(gameState, modifiersQuerying, physicalCard)
+                        && !cardToMove.getBlueprint().isMovesLikeCharacter()
                         && cardToMove.getBlueprint().getCardCategory() != CardCategory.VEHICLE)) {
                     return false;
                 }

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DeploySingleCardEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DeploySingleCardEffect.java
@@ -112,7 +112,8 @@ public class DeploySingleCardEffect extends AbstractSubActionEffect implements P
         }
         _playedToZone = Zone.ATTACHED;
         _attachTo = attachTo;
-        if (cardToPlay.getBlueprint().getCardCategory() != CardCategory.CHARACTER) {
+        if (cardToPlay.getBlueprint().getCardCategory() != CardCategory.CHARACTER
+                && !cardToPlay.getBlueprint().isMovesLikeCharacter()) {
             throw new UnsupportedOperationException(GameUtils.getFullName(cardToPlay) + " should not specify if being played as pilot");
         }
         _attachAsPilot = attachAsPilot;

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/Piloting.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/Piloting.java
@@ -266,11 +266,13 @@ public interface Piloting extends BaseQuery, Icons, Locations, Prohibited {
         if (starshipOrVehicle.getBlueprint().getCardCategory() != CardCategory.STARSHIP && starshipOrVehicle.getBlueprint().getCardCategory() != CardCategory.VEHICLE)
             return false;
 
-        // A character, starship, vehicle, weapon or device is "aboard" (or "on") a starship or vehicle if it is:
+        // A character, starship, vehicle, weapon, device, or moves-like-a-character card is "aboard" (or "on") a starship or vehicle if it is:
         // (1) Present at any site related to that starship or vehicle.
         // (2) At the bridge, cockpit or cargo bay of that starship or vehicle.
         CardCategory cardCategory = physicalCard.getBlueprint().getCardCategory();
-        if (cardCategory!=CardCategory.CHARACTER && cardCategory!=CardCategory.STARSHIP && cardCategory!=CardCategory.VEHICLE && cardCategory!=CardCategory.WEAPON && cardCategory!=CardCategory.DEVICE)
+        // Moves-like-a-character cards (e.g. Yerka Mig, All My Urchins) can be aboard as passengers
+        if (cardCategory!=CardCategory.CHARACTER && cardCategory!=CardCategory.STARSHIP && cardCategory!=CardCategory.VEHICLE && cardCategory!=CardCategory.WEAPON && cardCategory!=CardCategory.DEVICE
+                && !physicalCard.getBlueprint().isMovesLikeCharacter())
             return false;
 
 

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_069_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_069_Tests.java
@@ -485,6 +485,52 @@ public class Card_1_069_Tests {
 		assertTrue(scn.IsAboardAsPassenger(corvette, urchins));
 	}
 
+
+	@Test
+	public void YerkaMigCanTransferBetweenDockedStarshipsAsPassenger() {
+		// #1013: real ship-dock transfer path for moves-like-a-character (passenger capacity may be occupied)
+		var scn = GetScenario();
+
+		var yerka = scn.GetLSCard("yerka");
+		var corvette = scn.GetLSCard("corvette");
+		var ywing = scn.GetLSCard("ywing");
+		var rebelTrooper = scn.GetLSFiller(1);
+		var system = scn.GetLSStartingLocation();
+
+		var trooper = scn.GetDSFiller(1);
+
+		scn.StartGame();
+
+		scn.MoveCardsToLSHand(yerka);
+		// Keep Utinni target off Yerka so Mig is not immediately cancelled
+		var landing = scn.GetDSCard("landing");
+		scn.MoveLocationToTable(landing);
+		scn.MoveCardsToLocation(landing, trooper);
+		scn.MoveCardsToLocation(system, corvette, ywing);
+		// Fill Y-wing pilot-or-passenger slot; Yerka still transfers (does not count toward capacity)
+		scn.BoardAsPassenger(ywing, rebelTrooper);
+
+		scn.SkipToLSTurn(Phase.DEPLOY);
+		scn.LSDeployCard(yerka);
+		scn.LSChooseCard(corvette);
+		scn.LSChooseCard(trooper);
+		scn.PassAllResponses();
+		assertTrue(scn.IsAboardAsPassenger(corvette, yerka));
+
+		scn.SkipToPhase(Phase.MOVE);
+		assertTrue(scn.LSCardActionAvailable(corvette, "dock"));
+		scn.LSUseCardAction(corvette, "dock");
+		scn.LSChooseCard(ywing);
+		scn.PassAllResponses();
+
+		assertTrue(scn.LSCardActionAvailable(yerka, "Transfer"));
+		scn.LSUseCardAction(yerka, "Transfer");
+		scn.PassAllResponses();
+
+		assertTrue(scn.IsAttachedTo(ywing, yerka));
+		assertTrue(scn.IsAboardAsPassenger(ywing, yerka));
+	}
+
     //add tests for:
 	// requires targetable opponent's character to play
 

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_069_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set1/light/Card_1_069_Tests.java
@@ -10,7 +10,6 @@ import com.gempukku.swccgo.common.Uniqueness;
 import com.gempukku.swccgo.common.Zone;
 import com.gempukku.swccgo.framework.StartingSetup;
 import com.gempukku.swccgo.framework.VirtualTableScenario;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -33,6 +32,9 @@ public class Card_1_069_Tests {
 					put("hut","4_089"); //Dagobah: Yoda's Hut
                     put("hoth","3_055");
                     put("skiff","6_088");
+					put("corvette","1_140"); //Corellian Corvette (capital, passenger capacity)
+					put("tatooine","1_127"); //Tatooine system
+					put("urchins","5_017"); //All My Urchins
 				}},
 				new HashMap<>() {{
 					put("landing","11_092"); //Tatooine: Desert Landing Site
@@ -171,7 +173,7 @@ public class Card_1_069_Tests {
 		assertFalse(scn.LSHasCardChoiceAvailable(hut)); //test1
 	}
 
-	@Test @Ignore
+	@Test
 	public void YerkaMigCanDeployAboardStarship() {
 		//test1: can deploy aboard starship with passenger capacity (1+ available)
 		//test2: can deploy aboard starship with passenger capacity (0 available)
@@ -221,7 +223,7 @@ public class Card_1_069_Tests {
 		assertTrue(scn.IsAboardAsPassenger(ywing2, yerka)); //test5
 	}
 
-	@Test @Ignore
+	@Test
 	public void YerkaMigMovesWithStarship() {
 		//test1: when aboard a starship that moves, Yerka stays attached and moves with the ship
 		var scn = GetScenario();
@@ -365,6 +367,123 @@ public class Card_1_069_Tests {
         assertEquals(Zone.TOP_OF_LOST_PILE,skiff.getZone()); //test2
         assertTrue(scn.CardsAtLocation(site, yerka, rebelTrooper)); //test3
     }
+
+
+	@Test
+	public void YerkaMigCanDeployAboardVehicle() {
+		//test1: can deploy aboard vehicle with passenger capacity
+		//test2: after deploying, is aboard as a passenger
+		var scn = GetScenario();
+
+		var yerka = scn.GetLSCard("yerka");
+		var skiff = scn.GetLSCard("skiff");
+		var site = scn.GetDSStartingLocation();
+
+		var trooper = scn.GetDSFiller(1);
+
+		scn.StartGame();
+
+		scn.MoveCardsToLSHand(yerka);
+		scn.MoveCardsToLocation(site, skiff);
+		var landing = scn.GetDSCard("landing");
+		scn.MoveLocationToTable(landing);
+		scn.MoveCardsToLocation(landing, trooper);
+
+		scn.SkipToLSTurn(Phase.DEPLOY);
+		scn.LSDeployCard(yerka);
+		assertTrue(scn.LSHasCardChoiceAvailable(skiff)); //test1
+		scn.LSChooseCard(skiff);
+		scn.LSChooseCard(trooper);
+		scn.PassAllResponses();
+
+		assertTrue(scn.AwaitingDSDeployPhaseActions());
+		assertTrue(scn.IsAttachedTo(skiff, yerka)); //test2
+		assertTrue(scn.IsAboardAsPassenger(skiff, yerka)); //test2
+	}
+
+	@Test
+	public void YerkaMigCanShuttleToCapitalWithPassengerCapacity() {
+		// #1013: move-like-a-character cards should get shuttle actions when destination has passenger capacity
+		// (even if that capacity is currently occupied)
+		var scn = GetScenario();
+
+		var yerka = scn.GetLSCard("yerka");
+		var corvette = scn.GetLSCard("corvette");
+		var tatooine = scn.GetLSCard("tatooine");
+		var rebelTrooper = scn.GetLSFiller(1);
+		var rebelTrooper2 = scn.GetLSFiller(2);
+		var rebelTrooper3 = scn.GetLSFiller(3);
+		var rebelTrooper4 = scn.GetLSFiller(4);
+		var site = scn.GetDSStartingLocation(); // Tatooine: Marketplace (exterior)
+
+		var trooper = scn.GetDSFiller(1);
+
+		scn.StartGame();
+
+		scn.MoveCardsToLSHand(yerka);
+		scn.MoveLocationToTable(tatooine);
+		// Keep Utinni target off Yerka deploy site so Yerka is not immediately cancelled
+		var landing = scn.GetDSCard("landing");
+		scn.MoveLocationToTable(landing);
+		scn.MoveCardsToLocation(landing, trooper);
+		scn.MoveCardsToLocation(tatooine, corvette);
+		// Fill all 4 passenger slots so capacity is occupied but still exists
+		scn.BoardAsPassenger(corvette, rebelTrooper, rebelTrooper2, rebelTrooper3, rebelTrooper4);
+
+		scn.SkipToLSTurn(Phase.DEPLOY);
+		scn.LSDeployCard(yerka);
+		scn.LSChooseCard(site);
+		scn.LSChooseCard(trooper);
+		scn.PassAllResponses();
+		assertTrue(scn.CardsAtLocation(site, yerka));
+
+		scn.SkipToPhase(Phase.MOVE);
+		assertTrue(scn.LSCardActionAvailable(yerka, "Shuttle"));
+		scn.LSUseCardAction(yerka, "Shuttle");
+		scn.LSChooseCard(corvette);
+		scn.PassAllResponses();
+
+		assertTrue(scn.AwaitingDSMovePhaseActions());
+		assertTrue(scn.IsAttachedTo(corvette, yerka));
+		assertTrue(scn.IsAboardAsPassenger(corvette, yerka));
+	}
+
+	@Test
+	public void AllMyUrchinsCanShuttleToCapitalWithPassengerCapacity() {
+		// #1013 coverage for non-Utinni move-like-a-character card
+		var scn = GetScenario();
+
+		var urchins = scn.GetLSCard("urchins");
+		var corvette = scn.GetLSCard("corvette");
+		var tatooine = scn.GetLSCard("tatooine");
+		var site = scn.GetDSStartingLocation();
+		var rebel = scn.GetLSFiller(1);
+
+		var trooper = scn.GetDSFiller(1);
+
+		scn.StartGame();
+
+		scn.MoveCardsToLSHand(urchins);
+		scn.MoveLocationToTable(tatooine);
+		scn.MoveCardsToLocation(site, rebel, trooper);
+		scn.MoveCardsToLocation(tatooine, corvette);
+
+		scn.SkipToLSTurn(Phase.DEPLOY);
+		assertTrue(scn.LSDeployAvailable(urchins));
+		scn.LSDeployCard(urchins);
+		scn.LSChooseCard(site);
+		scn.PassAllResponses();
+		assertTrue(scn.CardsAtLocation(site, urchins));
+
+		scn.SkipToPhase(Phase.MOVE);
+		assertTrue(scn.LSCardActionAvailable(urchins, "Shuttle"));
+		scn.LSUseCardAction(urchins, "Shuttle");
+		scn.LSChooseCard(corvette);
+		scn.PassAllResponses();
+
+		assertTrue(scn.AwaitingDSMovePhaseActions());
+		assertTrue(scn.IsAboardAsPassenger(corvette, urchins));
+	}
 
     //add tests for:
 	// requires targetable opponent's character to play


### PR DESCRIPTION
﻿## Summary
- Fixes **Yerka Mig (1_069)** deploy aboard starships/vehicles per AR Appendix B: deploys like a character as a passenger (does not count toward capacity). Previously Yerka could target a ship/vehicle but ended in the location void instead of attaching.
- Auto zone selection (no Baniss-style manual Deploy option): when a moves-like-a-character card chooses a starship/vehicle via the location play path, it attaches as passenger; sites still deploy to the location.
- Fixes **#1013** shuttle for cards that move like a character (Yerka Mig, All My Urchins): `canShuttleTo` incorrectly checked `isMovesLikeCharacter` on the destination instead of the card being moved, so shuttle actions never appeared.
- Fixes **#1013** ship-dock transfer: `Piloting.isAboard` excluded Effects, so moves-like-a-character passengers never appeared in the ship-dock transfer window. Now `isMovesLikeCharacter()` cards are treated as aboard when attached as passengers.

## Yerka 1_069 AR
Yerka Mig is not a character. It deploys and moves like a character, does not require presence or Force icons, and does not count toward vehicle/starship capacity. Deploy aboard is allowed when passenger capacity exists on the host.

## What changed
- `PlayCardToLocationAction`: for `isMovesLikeCharacter()`, use `TO_BE_DEPLOYED_ON` targeting and passenger `DeploySingleCardEffect` when the chosen target is a starship/vehicle.
- `DeploySingleCardEffect`: allow the character attach-as-pilot/passenger constructor for `isMovesLikeCharacter()` cards (Effects are not `CHARACTER`).
- `Filters.canShuttleTo`: check `cardToMove.isMovesLikeCharacter()` instead of the destination.
- `Piloting.isAboard`: include `isMovesLikeCharacter()` so Yerka/Urchins enter the ship-dock transfer action list.
- `Card1_069`: remove obsolete deploy-aboard TODO.

## #1013 shuttle / transfer
- Shuttle covered by VHD for Yerka and All My Urchins (destination with passenger capacity even if occupied).
- Ship-dock transfer covered by real-path VHD: dock Corvette with Y-wing (occupied passenger slot) and Transfer Yerka as passenger.

## Tests
Class: `Card_1_069_Tests` — **12** methods, all passing
- `YerkaMigStatsAndKeywordsAreCorrect`
- `YerkaMigCanDeployToSite`
- `YerkaMigCannotDeployToSystem`
- `YerkaMigCannotDeployToDagobahSite`
- `YerkaMigCanDeployAboardStarship`
- `YerkaMigMovesWithStarship`
- `YerkaMigCanEmbarkOnVehicle`
- `YerkaMigCanJumpOffVehicle`
- `YerkaMigCanDeployAboardVehicle`
- `YerkaMigCanShuttleToCapitalWithPassengerCapacity`
- `AllMyUrchinsCanShuttleToCapitalWithPassengerCapacity`
- `YerkaMigCanTransferBetweenDockedStarshipsAsPassenger`

Tip: `4385a7b9663078bcbdd8e160601df452c9c9b9e8`

## Independence
Independent PR vs `master`. Closes #1012 and #1013.
