### PR TITLE
Fix Alien Mob per-system uniqueness on starship movement (#1030)

### DIFF
--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/MovementRestrictions.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/MovementRestrictions.java
@@ -233,6 +233,17 @@ public interface MovementRestrictions extends BaseQuery, Locations {
                 return true;
             }
 
+            // Per-system (diamond) uniqueness: mover and cards aboard may not enter a system
+            // that already has the uniqueness limit of the same title (see isProhibitedFromTarget).
+            if (query().isProhibitedFromTarget(gameState, card, toLocation)) {
+                return true;
+            }
+            for (PhysicalCard aboard : gameState.getAboardCards(card, true)) {
+                if (query().isProhibitedFromTarget(gameState, aboard, toLocation)) {
+                    return true;
+                }
+            }
+
             if (asReact) {
                 // Check if player may not 'react' to the location
                 for (Modifier modifier : getModifiersAffectingCard(gameState, ModifierType.MAY_NOT_REACT_TO_LOCATION, toLocation)) {

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/Targeting.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/modifiers/querying/Targeting.java
@@ -235,7 +235,9 @@ public interface Targeting extends BaseQuery, Weapons, Captives, CardTraits, Pil
             if (location != null) {
                 String systemName = location.getPartOfSystem() != null ? location.getPartOfSystem() : location.getSystemOrbited();
                 if (systemName != null) {
+                    // Exclude the card itself so movement within the same system is not blocked by its own presence
                     if (Filters.canSpotFromAllOnTable(gameState.getGame(), uniqueness.getValue(), Filters.and(Filters.sameTitleAs(card),
+                            Filters.not(Filters.sameCardId(card)),
                             Filters.locationAndCardsAtLocation(Filters.or(Filters.partOfSystem(systemName),
                                     Filters.and(Filters.not(Filters.system), Filters.isOrbiting(systemName))))))) {
                         return true;

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set216/dark/Card_216_002_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set216/dark/Card_216_002_Tests.java
@@ -11,7 +11,10 @@ import java.util.HashMap;
 import static org.junit.Assert.*;
 
 /**
- * VHD for Alien Mob (216_002) diamond uniqueness on movement (#1030).
+ * VHD for Alien Mob (216_002) diamond uniqueness on system-changing movement (#1030).
+ *
+ * Covered: hyperspeed, without-hyperspeed (mobile system to/from planet), docking bay transit.
+ * Same-system landspeed / sector / land / takeoff loops are out of scope for #1030.
  */
 public class Card_216_002_Tests {
 	protected VirtualTableScenario GetScenario() {
@@ -26,7 +29,9 @@ public class Card_216_002_Tests {
 					put("nalHutta", "6_168");
 					put("bespin", "5_164");
 					put("downtownPlaza", "7_270"); // Cloud City: Downtown Plaza (Bespin)
+					put("eastPlatform", "5_169"); // Cloud City: East Platform (Docking Bay)
 					put("tatDb", "1_291"); // Tatooine: Docking Bay 94
+					put("deathStar", "2_143"); // mobile system for without-hyperspeed
 				}},
 				10,
 				10,
@@ -49,7 +54,7 @@ public class Card_216_002_Tests {
 	}
 
 	@Test
-	public void AlienMobAboardStarshipCannotMoveToSystemWithAlienMobAtRelatedSite() {
+	public void AlienMobAboardStarshipCannotHyperspeedToSystemWithAlienMobAtRelatedSite() {
 		// Replay path: ship + Mob at Nal Hutta must not hyperspeed to Bespin
 		// while another Alien Mob is at a Cloud City site.
 		var scn = GetScenario();
@@ -77,12 +82,12 @@ public class Card_216_002_Tests {
 		scn.SkipToPhase(Phase.MOVE);
 
 		assertTrue(scn.DSMoveAvailable(cruiser));
-		scn.DSUseCardAction(cruiser, "Move");
+		scn.DSUseCardAction(cruiser, "Move using hyperspeed");
 		assertFalse(scn.DSHasCardChoiceAvailable(bespin));
 	}
 
 	@Test
-	public void AlienMobAboardStarshipCanMoveToSystemWithoutAlienMob() {
+	public void AlienMobAboardStarshipCanHyperspeedToSystemWithoutAlienMob() {
 		var scn = GetScenario();
 
 		var alienMob1 = scn.GetDSCard("alienMob1");
@@ -104,8 +109,101 @@ public class Card_216_002_Tests {
 		scn.SkipToPhase(Phase.MOVE);
 
 		assertTrue(scn.DSMoveAvailable(cruiser));
-		scn.DSUseCardAction(cruiser, "Move");
+		scn.DSUseCardAction(cruiser, "Move using hyperspeed");
 		assertTrue(scn.DSHasCardChoiceAvailable(bespin));
+	}
+
+	@Test
+	public void AlienMobAboardStarshipCannotMoveWithoutHyperspeedToSystemWithAlienMobAtRelatedSite() {
+		// Without-hyperspeed path: ship + Mob at Death Star orbiting Bespin must not
+		// move to Bespin while another Alien Mob is at a Cloud City site.
+		var scn = GetScenario();
+
+		var alienMob1 = scn.GetDSCard("alienMob1");
+		var alienMob2 = scn.GetDSCard("alienMob2");
+		var cruiser = scn.GetDSCard("cruiser");
+		var rodian = scn.GetDSCard("rodian");
+		var deathStar = scn.GetDSCard("deathStar");
+		var bespin = scn.GetDSCard("bespin");
+		var downtownPlaza = scn.GetDSCard("downtownPlaza");
+
+		scn.StartGame();
+
+		scn.MoveLocationToTable(bespin);
+		scn.MoveLocationToTable(deathStar);
+		scn.MoveLocationToTable(downtownPlaza);
+		deathStar.setSystemOrbited("Bespin");
+
+		scn.MoveCardsToLocation(deathStar, cruiser);
+		scn.BoardAsPilot(cruiser, rodian);
+		scn.BoardAsPassenger(cruiser, alienMob1);
+		scn.MoveCardsToLocation(downtownPlaza, alienMob2);
+
+		scn.DSActivateMaxForceAndPass();
+		scn.SkipToPhase(Phase.MOVE);
+
+		// Only destination is Bespin; uniqueness removes it, so the without-hyperspeed action is omitted.
+		assertFalse("Without-hyperspeed must be unavailable when destination system already has Alien Mob",
+				scn.DSCardActionAvailable(cruiser, "Move without using hyperspeed"));
+	}
+
+	@Test
+	public void AlienMobAboardStarshipCanMoveWithoutHyperspeedToSystemWithoutAlienMob() {
+		var scn = GetScenario();
+
+		var alienMob1 = scn.GetDSCard("alienMob1");
+		var cruiser = scn.GetDSCard("cruiser");
+		var rodian = scn.GetDSCard("rodian");
+		var deathStar = scn.GetDSCard("deathStar");
+		var bespin = scn.GetDSCard("bespin");
+
+		scn.StartGame();
+
+		scn.MoveLocationToTable(bespin);
+		scn.MoveLocationToTable(deathStar);
+		deathStar.setSystemOrbited("Bespin");
+
+		scn.MoveCardsToLocation(deathStar, cruiser);
+		scn.BoardAsPilot(cruiser, rodian);
+		scn.BoardAsPassenger(cruiser, alienMob1);
+
+		scn.DSActivateMaxForceAndPass();
+		scn.SkipToPhase(Phase.MOVE);
+
+		assertTrue(scn.DSCardActionAvailable(cruiser, "Move without using hyperspeed"));
+		scn.DSUseCardAction(cruiser, "Move without using hyperspeed");
+		assertTrue(scn.DSHasCardChoiceAvailable(bespin));
+	}
+
+	@Test
+	public void AlienMobCannotDockingBayTransitToSystemWithAlienMobAtRelatedSite() {
+		// System-changing relocate path: Mob at Tatooine DB must not transit to a
+		// Cloud City docking bay while another Alien Mob is at a related Bespin site.
+		var scn = GetScenario();
+
+		var alienMob1 = scn.GetDSCard("alienMob1");
+		var alienMob2 = scn.GetDSCard("alienMob2");
+		var tatDb = scn.GetDSCard("tatDb");
+		var eastPlatform = scn.GetDSCard("eastPlatform");
+		var downtownPlaza = scn.GetDSCard("downtownPlaza");
+		var bespin = scn.GetDSCard("bespin");
+
+		scn.StartGame();
+
+		scn.MoveLocationToTable(bespin);
+		scn.MoveLocationToTable(downtownPlaza);
+		scn.MoveLocationToTable(eastPlatform);
+		scn.MoveLocationToTable(tatDb);
+
+		scn.MoveCardsToLocation(tatDb, alienMob1);
+		scn.MoveCardsToLocation(downtownPlaza, alienMob2);
+
+		scn.DSActivateMaxForceAndPass();
+		scn.SkipToPhase(Phase.MOVE);
+
+		// Only other docking bay is in the Bespin system; uniqueness removes it, so transit is omitted.
+		assertFalse("Docking bay transit must be unavailable into a system that already has Alien Mob",
+				scn.DSCardActionAvailable(tatDb, "transit"));
 	}
 
 	@Test

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set216/dark/Card_216_002_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set216/dark/Card_216_002_Tests.java
@@ -1,0 +1,138 @@
+package com.gempukku.swccgo.cards.set216.dark;
+
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.*;
+
+/**
+ * VHD for Alien Mob (216_002) diamond uniqueness on movement (#1030).
+ */
+public class Card_216_002_Tests {
+	protected VirtualTableScenario GetScenario() {
+		return new VirtualTableScenario(
+				new HashMap<>() {{
+				}},
+				new HashMap<>() {{
+					put("alienMob1", "216_002");
+					put("alienMob2", "216_002");
+					put("cruiser", "7_304"); // Jabba's Space Cruiser
+					put("rodian", "2_104"); // alien pilot
+					put("nalHutta", "6_168");
+					put("bespin", "5_164");
+					put("downtownPlaza", "7_270"); // Cloud City: Downtown Plaza (Bespin)
+					put("tatDb", "1_291"); // Tatooine: Docking Bay 94
+				}},
+				10,
+				10,
+				StartingSetup.DefaultLSSpaceSystem,
+				StartingSetup.DefaultDSSpaceSystem,
+				StartingSetup.NoLSStartingInterrupts,
+				StartingSetup.NoDSStartingInterrupts,
+				StartingSetup.NoLSShields,
+				StartingSetup.NoDSShields,
+				VirtualTableScenario.Open
+		);
+	}
+
+	@Test
+	public void AlienMobStatsAndKeywordsAreCorrect() {
+		var scn = GetScenario();
+		var card = scn.GetDSCard("alienMob1").getBlueprint();
+		assertEquals("Alien Mob", card.getTitle());
+		assertEquals(Uniqueness.DIAMOND_1, card.getUniqueness());
+	}
+
+	@Test
+	public void AlienMobAboardStarshipCannotMoveToSystemWithAlienMobAtRelatedSite() {
+		// Replay path: ship + Mob at Nal Hutta must not hyperspeed to Bespin
+		// while another Alien Mob is at a Cloud City site.
+		var scn = GetScenario();
+
+		var alienMob1 = scn.GetDSCard("alienMob1");
+		var alienMob2 = scn.GetDSCard("alienMob2");
+		var cruiser = scn.GetDSCard("cruiser");
+		var rodian = scn.GetDSCard("rodian");
+		var nalHutta = scn.GetDSCard("nalHutta");
+		var bespin = scn.GetDSCard("bespin");
+		var downtownPlaza = scn.GetDSCard("downtownPlaza");
+
+		scn.StartGame();
+
+		scn.MoveLocationToTable(nalHutta);
+		scn.MoveLocationToTable(bespin);
+		scn.MoveLocationToTable(downtownPlaza);
+
+		scn.MoveCardsToLocation(nalHutta, cruiser);
+		scn.BoardAsPilot(cruiser, rodian);
+		scn.BoardAsPassenger(cruiser, alienMob1);
+		scn.MoveCardsToLocation(downtownPlaza, alienMob2);
+
+		scn.DSActivateMaxForceAndPass();
+		scn.SkipToPhase(Phase.MOVE);
+
+		assertTrue(scn.DSMoveAvailable(cruiser));
+		scn.DSUseCardAction(cruiser, "Move");
+		assertFalse(scn.DSHasCardChoiceAvailable(bespin));
+	}
+
+	@Test
+	public void AlienMobAboardStarshipCanMoveToSystemWithoutAlienMob() {
+		var scn = GetScenario();
+
+		var alienMob1 = scn.GetDSCard("alienMob1");
+		var cruiser = scn.GetDSCard("cruiser");
+		var rodian = scn.GetDSCard("rodian");
+		var nalHutta = scn.GetDSCard("nalHutta");
+		var bespin = scn.GetDSCard("bespin");
+
+		scn.StartGame();
+
+		scn.MoveLocationToTable(nalHutta);
+		scn.MoveLocationToTable(bespin);
+
+		scn.MoveCardsToLocation(nalHutta, cruiser);
+		scn.BoardAsPilot(cruiser, rodian);
+		scn.BoardAsPassenger(cruiser, alienMob1);
+
+		scn.DSActivateMaxForceAndPass();
+		scn.SkipToPhase(Phase.MOVE);
+
+		assertTrue(scn.DSMoveAvailable(cruiser));
+		scn.DSUseCardAction(cruiser, "Move");
+		assertTrue(scn.DSHasCardChoiceAvailable(bespin));
+	}
+
+	@Test
+	public void AlienMobDeployUniquenessStillBlocksSameSystem() {
+		var scn = GetScenario();
+
+		var alienMob1 = scn.GetDSCard("alienMob1");
+		var alienMob2 = scn.GetDSCard("alienMob2");
+		var downtownPlaza = scn.GetDSCard("downtownPlaza");
+		var tatDb = scn.GetDSCard("tatDb");
+		var bespin = scn.GetDSCard("bespin");
+
+		scn.StartGame();
+
+		scn.MoveLocationToTable(bespin);
+		scn.MoveLocationToTable(downtownPlaza);
+		scn.MoveLocationToTable(tatDb);
+
+		scn.MoveCardsToLocation(downtownPlaza, alienMob1);
+		scn.MoveCardsToDSHand(alienMob2);
+
+		scn.DSActivateForceCheat(10);
+		scn.SkipToPhase(Phase.DEPLOY);
+
+		assertTrue("Alien Mob should still deploy to another system", scn.DSCardPlayAvailable(alienMob2));
+		scn.DSDeployCard(alienMob2);
+		assertFalse("Cannot deploy Alien Mob to same system", scn.DSHasCardChoiceAvailable(downtownPlaza));
+		assertTrue("Can deploy Alien Mob to another system", scn.DSHasCardChoiceAvailable(tatDb));
+	}
+}


### PR DESCRIPTION
## Summary
Alien Mob (`◇`) uniqueness was enforced on deploy but not when a starship carrying Mob moved into a system that already had another Mob at a related location (replays: ship to Bespin with Mob aboard while Mob was at a Cloud City site).

## Fix
- In the shared `mayNotMoveFromLocationToLocation` gate, reject the move if the mover **or any card aboard** would violate per-system uniqueness at the destination (`isProhibitedFromTarget`).
- Exclude the card itself from the uniqueness spot in `isProhibitedFromTarget` so same-system movement is not blocked by its own presence.

This covers **any system-changing path** that shares that helper, including:
- hyperspeed
- without-hyperspeed (mobile system ↔ planet)
- docking bay transit / relocate-style system changes that use the shared gate

Same-system landspeed / sector / land / take-off loops are **out of scope for #1030** (they do not create a new system).

## Tests
`Card_216_002_Tests` (7):
- ship + Mob cannot hyperspeed to a system with Mob at a related site
- ship + Mob can hyperspeed when no other Mob is there
- ship + Mob cannot move without hyperspeed from mobile system into a system with Mob at a related site
- ship + Mob can move without hyperspeed when no other Mob is there
- Alien Mob cannot docking-bay transit into a system with another Mob present
- deploy uniqueness still blocks same system / allows another system
- stats/keywords

Closes #1030