### PR TITLE
Fix Weapon Of A Sith destiny on Weapon Levitation steal (#972)

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set13/dark/Card13_095.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set13/dark/Card13_095.java
@@ -6,7 +6,6 @@ import com.gempukku.swccgo.common.Icon;
 import com.gempukku.swccgo.common.PlayCardZoneOption;
 import com.gempukku.swccgo.common.Rarity;
 import com.gempukku.swccgo.common.Side;
-import com.gempukku.swccgo.common.TargetingReason;
 import com.gempukku.swccgo.common.Title;
 import com.gempukku.swccgo.filters.Filters;
 import com.gempukku.swccgo.game.PhysicalCard;
@@ -47,9 +46,13 @@ public class Card13_095 extends AbstractDefensiveShield {
             final PhysicalCard sourceCard = aboutToStealCardResult.getSourceCard();
             final PhysicalCard weaponToBeStolen = aboutToStealCardResult.getCardToBeStolen();
             final PhysicalCard targetCharacter = weaponToBeStolen.getAttachedTo();
+            // Destiny is required whenever opponent steals with a non-[Episode I] card.
+            // Do not gate on canBeTargetedBy(...TO_BE_PLACED_OUT_OF_PLAY): that check can
+            // fail for edge cases (e.g. grabber/stacked sources) and would skip the destiny
+            // requirement entirely. Out-of-play placement is only a failure consequence.
             if (targetCharacter != null
-                    && !game.getModifiersQuerying().hasIcon(game.getGameState(), sourceCard, Icon.EPISODE_I)
-                    && Filters.canBeTargetedBy(self, TargetingReason.TO_BE_PLACED_OUT_OF_PLAY).accepts(game, sourceCard)) {
+                    && sourceCard != null
+                    && !game.getModifiersQuerying().hasIcon(game.getGameState(), sourceCard, Icon.EPISODE_I)) {
 
                 final RequiredGameTextTriggerAction action = new RequiredGameTextTriggerAction(self, gameTextSourceCardId);
                 action.setText("Make " + opponent + " draw destiny");

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set13/dark/Card_13_095_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set13/dark/Card_13_095_Tests.java
@@ -1,0 +1,262 @@
+package com.gempukku.swccgo.cards.set13.dark;
+
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * VHD for Weapon Of A Sith — issue #972.
+ * Weapon Levitation steal of a character weapon must require WOAS destiny.
+ */
+public class Card_13_095_Tests {
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("levitation", "6_79"); // Weapon Levitation (Jabba's Palace)
+                    put("obiwan", "1_21"); // Obi-Wan Kenobi ability 6
+                }},
+                new HashMap<>() {{
+                    put("woas", "13_95"); // Weapon Of A Sith
+                    put("vader", "1_168"); // Darth Vader ability 6
+                    put("saber", "1_324"); // Vader's Lightsaber
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    /** Leave the BATTLE_INITIATED response window open for LS (Weapon Levitation). */
+    private void openBattleInitiatedWindowForLS(VirtualTableScenario scn, boolean darkInitiates) {
+        var site = scn.GetLSStartingLocation();
+        if (darkInitiates) {
+            scn.SkipToDSTurn(Phase.BATTLE);
+            assertTrue(scn.DSCanInitiateBattle(site));
+            scn.DSUseCardAction(site, "Initiate battle");
+        } else {
+            scn.SkipToLSTurn(Phase.BATTLE);
+            assertTrue(scn.LSCanInitiateBattle(site));
+            scn.LSUseCardAction(site, "Initiate battle");
+        }
+        scn.PassForceUseResponses();
+        for (int i = 0; i < 10; i++) {
+            if (scn.LSGetDecision() != null) {
+                return;
+            }
+            if (scn.DSGetDecision() != null) {
+                scn.DSPass();
+            } else {
+                break;
+            }
+        }
+    }
+
+    /** Advance until a destiny-related decision appears (WOAS gate). */
+    private boolean advanceUntilDestinyDecision(VirtualTableScenario scn) {
+        for (int i = 0; i < 40; i++) {
+            var decision = scn.GetCurrentDecision();
+            if (decision == null) {
+                return false;
+            }
+            String lower = decision.getText().toLowerCase();
+            if (lower.contains("destiny") || lower.contains("weapon of a sith") || lower.contains("make light")) {
+                return true;
+            }
+            if (lower.contains("optional") || lower.contains("playing") || lower.contains("force")) {
+                scn.PassResponses();
+            } else if (lower.contains("required")) {
+                scn.PlayerDecided(scn.GetDecidingPlayer(), "0");
+            } else {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    private void finishPendingResponses(VirtualTableScenario scn) {
+        for (int i = 0; i < 50; i++) {
+            var decision = scn.GetCurrentDecision();
+            if (decision == null) {
+                break;
+            }
+            String text = decision.getText().toLowerCase();
+            if (text.contains("optional") || text.contains("destiny") || text.contains("just drew")
+                    || text.contains("just completed") || text.contains("required")
+                    || text.contains("about to") || text.contains("playing") || text.contains("force")) {
+                scn.PassResponses();
+            } else {
+                break;
+            }
+        }
+    }
+
+    @Test
+    public void WeaponOfASithStatsAndKeywordsAreCorrect() {
+        var scn = GetScenario();
+        var card = scn.GetDSCard("woas").getBlueprint();
+        assertEquals("Weapon Of A Sith", card.getTitle());
+        assertEquals(Uniqueness.UNIQUE, card.getUniqueness());
+        assertEquals(Side.DARK, card.getSide());
+        scn.BlueprintCardTypeCheck(card, new ArrayList<>() {{
+            add(CardType.DEFENSIVE_SHIELD);
+        }});
+        scn.BlueprintIconCheck(card, new ArrayList<>() {{
+            add(Icon.REFLECTIONS_III);
+            add(Icon.DEFENSIVE_SHIELD);
+            add(Icon.EPISODE_I);
+        }});
+        assertEquals(ExpansionSet.REFLECTIONS_III, card.getExpansionSet());
+        assertEquals(Rarity.PM, card.getRarity());
+    }
+
+    @Test
+    public void WeaponOfASithWeaponLevitationStealRequiresDestinyAndFailsWhenDestinyTooLow() {
+        var scn = GetScenario();
+
+        var levitation = scn.GetLSCard("levitation");
+        var obiwan = scn.GetLSCard("obiwan");
+        scn.MoveCardsToHand(levitation);
+
+        var site = scn.GetLSStartingLocation();
+        var woas = scn.GetDSCard("woas");
+        var vader = scn.GetDSCard("vader");
+        var saber = scn.GetDSCard("saber");
+
+        scn.StartGame();
+        scn.MoveCardsToDSSideOfTable(woas);
+        scn.MoveCardsToLocation(site, obiwan, vader);
+        scn.AttachCardsTo(vader, saber);
+        assertEquals(vader, saber.getAttachedTo());
+
+        openBattleInitiatedWindowForLS(scn, false);
+        assertTrue(scn.LSPlayLostInterruptAvailable(levitation));
+        scn.LSPlayLostInterrupt(levitation);
+        scn.LSChooseCard(saber);
+        scn.LSChooseCard(obiwan);
+
+        scn.PrepareLSDestiny(0); // 0 + 1 = 1 not > Vader ability 6
+        assertTrue("WOAS must require destiny before Weapon Levitation steals",
+                advanceUntilDestinyDecision(scn));
+        finishPendingResponses(scn);
+
+        assertEquals(vader, saber.getAttachedTo());
+        assertEquals(Zone.OUT_OF_PLAY, levitation.getZone());
+    }
+
+    @Test
+    public void WeaponOfASithWeaponLevitationStealSucceedsWhenDestinyHighEnough() {
+        var scn = GetScenario();
+
+        var levitation = scn.GetLSCard("levitation");
+        var obiwan = scn.GetLSCard("obiwan");
+        scn.MoveCardsToHand(levitation);
+
+        var site = scn.GetLSStartingLocation();
+        var woas = scn.GetDSCard("woas");
+        var vader = scn.GetDSCard("vader");
+        var saber = scn.GetDSCard("saber");
+
+        scn.StartGame();
+        scn.MoveCardsToDSSideOfTable(woas);
+        scn.MoveCardsToLocation(site, obiwan, vader);
+        scn.AttachCardsTo(vader, saber);
+
+        openBattleInitiatedWindowForLS(scn, false);
+        assertTrue(scn.LSPlayLostInterruptAvailable(levitation));
+        scn.LSPlayLostInterrupt(levitation);
+        scn.LSChooseCard(saber);
+        scn.LSChooseCard(obiwan);
+
+        scn.PrepareLSDestiny(7); // 7 + 1 = 8 > ability 6
+        assertTrue("WOAS must require destiny before Weapon Levitation steals",
+                advanceUntilDestinyDecision(scn));
+        finishPendingResponses(scn);
+
+        assertEquals(obiwan, saber.getAttachedTo());
+        assertEquals(scn.LS, saber.getOwner());
+        assertNotEquals(Zone.OUT_OF_PLAY, levitation.getZone());
+    }
+
+    @Test
+    public void WeaponOfASithWeaponLevitationOnDarkTurnBattleRequiresDestinyFailurePath() {
+        var scn = GetScenario();
+
+        var levitation = scn.GetLSCard("levitation");
+        var obiwan = scn.GetLSCard("obiwan");
+        scn.MoveCardsToHand(levitation);
+
+        var site = scn.GetLSStartingLocation();
+        var woas = scn.GetDSCard("woas");
+        var vader = scn.GetDSCard("vader");
+        var saber = scn.GetDSCard("saber");
+
+        scn.StartGame();
+        scn.MoveCardsToDSSideOfTable(woas);
+        scn.MoveCardsToLocation(site, obiwan, vader);
+        scn.AttachCardsTo(vader, saber);
+
+        // Replay-shaped: DS turn battle; LS responds with Weapon Levitation
+        openBattleInitiatedWindowForLS(scn, true);
+        assertTrue(scn.LSPlayLostInterruptAvailable(levitation));
+        scn.LSPlayLostInterrupt(levitation);
+        scn.LSChooseCard(saber);
+        scn.LSChooseCard(obiwan);
+
+        scn.PrepareLSDestiny(0);
+        assertTrue("WOAS must require destiny on DS-turn Weapon Levitation path",
+                advanceUntilDestinyDecision(scn));
+        finishPendingResponses(scn);
+
+        assertEquals(vader, saber.getAttachedTo());
+        assertEquals(Zone.OUT_OF_PLAY, levitation.getZone());
+    }
+
+    @Test
+    public void WeaponLevitationStealsWithoutWeaponOfASithWithoutDestinyGate() {
+        var scn = GetScenario();
+
+        var levitation = scn.GetLSCard("levitation");
+        var obiwan = scn.GetLSCard("obiwan");
+        scn.MoveCardsToHand(levitation);
+
+        var site = scn.GetLSStartingLocation();
+        var vader = scn.GetDSCard("vader");
+        var saber = scn.GetDSCard("saber");
+
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, obiwan, vader);
+        scn.AttachCardsTo(vader, saber);
+
+        openBattleInitiatedWindowForLS(scn, false);
+        assertTrue(scn.LSPlayLostInterruptAvailable(levitation));
+        scn.LSPlayLostInterrupt(levitation);
+        scn.LSChooseCard(saber);
+        scn.LSChooseCard(obiwan);
+        scn.PassAllResponses();
+        finishPendingResponses(scn);
+
+        assertEquals(obiwan, saber.getAttachedTo());
+        assertEquals(scn.LS, saber.getOwner());
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes **Weapon Of A Sith (13_95)** so opponent steal attempts via non-[Episode I] cards (including **Weapon Levitation**) always require the WOAS destiny draw.
- Previously the about-to-be-stolen required response was gated on `canBeTargetedBy(...TO_BE_PLACED_OUT_OF_PLAY)` for the stealing card. That gate can fail in edge cases and skip destiny entirely, allowing a free steal.
- Out-of-play placement of the stealing card remains a **failure-path** consequence (unchanged), not a prerequisite for drawing destiny.

## Weapon Of A Sith
Plays on table. For opponent to steal a weapon from target character using a non-[Episode I] card, must first draw destiny. If destiny +1 > target's ability, weapon stolen. Otherwise, attempt fails and stealing card is placed out of play.

## What changed
- `Card13_095`: remove the `canBeTargetedBy(TO_BE_PLACED_OUT_OF_PLAY)` gate from the about-to-be-stolen trigger; keep non-[Episode I] check and null-safe source card; failure path still places the stealing card out of play via existing off-table/on-table effects.

## Weapon Levitation path
- Real-path VHD: WOAS on table → battle initiated → **Weapon Levitation** (6_79) LOST steal of Vader's Lightsaber.
- Covers LS-initiated and DS-turn (replay-shaped) battle windows.
- Failure (low destiny): steal prevented, Levitation out of play, saber remains on Vader.
- Success (high destiny): saber stolen onto Obi-Wan.
- Control: without WOAS, Levitation steals with no destiny gate.

## Tests
Class: `Card_13_095_Tests` — **5** methods, all passing
- `WeaponOfASithStatsAndKeywordsAreCorrect`
- `WeaponOfASithWeaponLevitationStealRequiresDestinyAndFailsWhenDestinyTooLow`
- `WeaponOfASithWeaponLevitationStealSucceedsWhenDestinyHighEnough`
- `WeaponOfASithWeaponLevitationOnDarkTurnBattleRequiresDestinyFailurePath`
- `WeaponLevitationStealsWithoutWeaponOfASithWithoutDestinyGate`

## Independence
Independent PR vs `master`. Closes #972.

## Known gaps
- Same `canBeTargetedBy` gate still exists on light-side twins **Only Jedi Carry That Weapon** (`Card13_035` / `Card221_068`); not changed here (WOAS-only minimal fix).
- Grabber-stacked interrupt play path not separately VHD'd; hardening addresses that class of false-negative targeting without rewriting steal infrastructure.