### PR TITLE
Fix may-fire-repeatedly after Generator Core Used Pile divert (#935)

### DIFF
--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/actions/FireSingleWeaponAction.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/actions/FireSingleWeaponAction.java
@@ -240,7 +240,13 @@ public class FireSingleWeaponAction extends AbstractFireWeaponAction {
         }
 
         // If weapon firing completed, check if weapon can repeatedly fire.
-        if (!_checkedToFireRepeatedly && wasCarriedOut()) {
+        // Do not require wasCarriedOut(): Generator Core (and similar) can prevent the hit
+        // effect after a successful fire (about-to-be-hit -> Used Pile), which makes
+        // wasCarriedOut() false and would incorrectly skip the repeat-fire prompt.
+        // Still refuse repeat if costs failed or the respondable firing was canceled
+        // (e.g. Blaster Deflection USED cancel targeting).
+        if (!_checkedToFireRepeatedly && _weaponFired && !isAnyCostFailed()
+                && (_respondableEffect == null || !_respondableEffect.isCanceled())) {
             _checkedToFireRepeatedly = true;
 
             final String playerId = getPerformingPlayer();

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/actions/FireSingleWeaponAction.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/actions/FireSingleWeaponAction.java
@@ -243,29 +243,31 @@ public class FireSingleWeaponAction extends AbstractFireWeaponAction {
         // Do not require wasCarriedOut(): Generator Core (and similar) can prevent the hit
         // effect after a successful fire (about-to-be-hit -> Used Pile), which makes
         // wasCarriedOut() false and would incorrectly skip the repeat-fire prompt.
-        // Still refuse repeat if costs failed or the respondable firing was canceled
-        // (e.g. Blaster Deflection USED cancel targeting).
-        if (!_checkedToFireRepeatedly && _weaponFired && !isAnyCostFailed()
+        // Require FiredWeaponResult emission so canceled firings (e.g. Blaster Deflection)
+        // do not offer repeatedly fire.
+        if (!_checkedToFireRepeatedly && _weaponFired && _emitFiredWeaponResult && !isAnyCostFailed()
                 && (_respondableEffect == null || !_respondableEffect.isCanceled())) {
             _checkedToFireRepeatedly = true;
 
             final String playerId = getPerformingPlayer();
             if (game.getModifiersQuerying().mayFireWeaponRepeatedly(game.getGameState(), _weaponToFire)) {
-                final FireWeaponAction fireWeaponAction = _weaponToFire.getBlueprint().getFireWeaponAction(playerId, game, _weaponToFire, false, 0, _sourceCard, true, _targetedAsCharacter, _defenseValueAsCharacter, _fireAtTargetFilter, _ignorePerAttackOrBattleLimit);
-                if (fireWeaponAction != null) {
-                    appendAfterEffect(
-                            new PlayoutDecisionEffect(this, playerId,
-                                    new YesNoDecision("Do you want to repeatedly fire " + GameUtils.getCardLink(_weaponToFire) + " again?") {
-                                        @Override
-                                        protected void yes() {
+                // Create the repeat FireWeaponAction when the player accepts, after weapon
+                // firing state has finished — avoids null action during mid-fire Used-Pile divert.
+                appendAfterEffect(
+                        new PlayoutDecisionEffect(this, playerId,
+                                new YesNoDecision("Do you want to repeatedly fire " + GameUtils.getCardLink(_weaponToFire) + " again?") {
+                                    @Override
+                                    protected void yes() {
+                                        FireWeaponAction fireWeaponAction = _weaponToFire.getBlueprint().getFireWeaponAction(playerId, game, _weaponToFire, false, 0, _sourceCard, true, _targetedAsCharacter, _defenseValueAsCharacter, _fireAtTargetFilter, _ignorePerAttackOrBattleLimit);
+                                        if (fireWeaponAction != null) {
                                             game.getActionsEnvironment().addActionToStack(fireWeaponAction);
                                         }
-                                        @Override
-                                        protected void no() {
-                                            game.getGameState().sendMessage(playerId + " chooses to not repeatedly fire " + GameUtils.getCardLink(_weaponToFire) + " again");
-                                        }
-                                    }));
-                }
+                                    }
+                                    @Override
+                                    protected void no() {
+                                        game.getGameState().sendMessage(playerId + " chooses to not repeatedly fire " + GameUtils.getCardLink(_weaponToFire) + " again");
+                                    }
+                                }));
             }
         }
 

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/rules/weapons/RepeatedlyFireTests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/rules/weapons/RepeatedlyFireTests.java
@@ -1,0 +1,169 @@
+package com.gempukku.swccgo.rules.weapons;
+
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Zone;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Real-path coverage for may-fire-repeatedly sequencing (#935).
+ * Generator Core diverting about-to-be-hit to Used Pile must not break the repeat prompt.
+ */
+public class RepeatedlyFireTests {
+    protected VirtualTableScenario GetGeneratorCoreScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("trooper1", "1_28");
+                    put("trooper2", "1_28");
+                    put("obiwan", "1_21");
+                    put("blasterDeflection", "6_61");
+                    put("generatorCore", "13_32");
+                }},
+                new HashMap<>() {{
+                    put("evazan", "1_172");
+                    put("sawedOff", "7_320");
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void DrEvazanSawedOffBlasterMayFireRepeatedlyAfterGeneratorCoreUsedPileDivert() {
+        // Issue #935: first hit diverted to Used Pile must still offer repeatedly fire.
+        var scn = GetGeneratorCoreScenario();
+
+        var trooper1 = scn.GetLSCard("trooper1");
+        var trooper2 = scn.GetLSCard("trooper2");
+        var generatorCore = scn.GetLSCard("generatorCore");
+
+        var evazan = scn.GetDSCard("evazan");
+        var sawedOff = scn.GetDSCard("sawedOff");
+
+        scn.StartGame();
+        scn.MoveLocationToTable(generatorCore);
+        scn.MoveCardsToLocation(generatorCore, evazan, trooper1, trooper2);
+        scn.AttachCardsTo(evazan, sawedOff);
+
+        scn.DSActivateForceCheat(8);
+        scn.PrepareDSDestiny(7);
+        scn.PrepareDSDestiny(7);
+        scn.SkipToDSTurn(Phase.BATTLE);
+        scn.DSInitiateBattle(generatorCore);
+
+        assertTrue(scn.DSCardActionAvailable(sawedOff, "Fire"));
+        scn.DSUseCardAction(sawedOff, "Fire");
+        scn.DSChooseCard(trooper1);
+        scn.PassWeaponFireWithDestinyDraw();
+        scn.PassAllResponses();
+
+        assertEquals(Zone.USED_PILE, trooper1.getZone());
+        assertTrue(scn.DSDecisionAvailable("repeatedly fire"));
+        scn.DSChooseYes();
+
+        if (scn.DSDecisionAvailable("Choose target")) {
+            assertTrue(scn.DSHasCardChoiceAvailable(trooper2));
+            scn.DSChooseCard(trooper2);
+        }
+        scn.PassWeaponFireWithDestinyDraw();
+        scn.PassAllResponses();
+
+        assertEquals(Zone.USED_PILE, trooper2.getZone());
+    }
+
+    @Test
+    public void DrEvazanSawedOffBlasterMayFireRepeatedlyAfterMissWhenForceRemains() {
+        var scn = GetGeneratorCoreScenario();
+
+        var trooper1 = scn.GetLSCard("trooper1");
+        var trooper2 = scn.GetLSCard("trooper2");
+        var generatorCore = scn.GetLSCard("generatorCore");
+
+        var evazan = scn.GetDSCard("evazan");
+        var sawedOff = scn.GetDSCard("sawedOff");
+
+        scn.StartGame();
+        scn.MoveLocationToTable(generatorCore);
+        scn.MoveCardsToLocation(generatorCore, evazan, trooper1, trooper2);
+        scn.AttachCardsTo(evazan, sawedOff);
+
+        scn.DSActivateForceCheat(8);
+        scn.PrepareDSDestiny(0);
+        scn.PrepareDSDestiny(7);
+        scn.SkipToDSTurn(Phase.BATTLE);
+        scn.DSInitiateBattle(generatorCore);
+
+        scn.DSUseCardAction(sawedOff, "Fire");
+        scn.DSChooseCard(trooper1);
+        scn.PassWeaponFireWithDestinyDraw();
+        scn.PassAllResponses();
+
+        assertFalse(trooper1.isHit());
+        assertEquals(Zone.AT_LOCATION, trooper1.getZone());
+        assertTrue(scn.DSDecisionAvailable("repeatedly fire"));
+        scn.DSChooseYes();
+
+        if (scn.DSDecisionAvailable("Choose target")) {
+            scn.DSChooseCard(trooper1);
+        }
+        scn.PassWeaponFireWithDestinyDraw();
+        scn.PassAllResponses();
+
+        assertEquals(Zone.USED_PILE, trooper1.getZone());
+    }
+
+    @Test
+    public void BlasterDeflectionCancelDoesNotOfferRepeatedlyFire() {
+        // Cancel of the respondable weapon firing must not prompt to fire repeatedly.
+        var scn = GetGeneratorCoreScenario();
+
+        var obiwan = scn.GetLSCard("obiwan");
+        var trooper2 = scn.GetLSCard("trooper2");
+        var blasterDeflection = scn.GetLSCard("blasterDeflection");
+        var site = scn.GetLSStartingLocation();
+
+        var evazan = scn.GetDSCard("evazan");
+        var sawedOff = scn.GetDSCard("sawedOff");
+
+        scn.StartGame();
+        scn.MoveCardsToLocation(site, evazan, obiwan, trooper2);
+        scn.AttachCardsTo(evazan, sawedOff);
+        scn.MoveCardsToLSHand(blasterDeflection);
+
+        scn.DSActivateForceCheat(8);
+        scn.PrepareDSDestiny(7);
+        scn.SkipToDSTurn(Phase.BATTLE);
+        scn.DSInitiateBattle(site);
+
+        // Pass Obi-Wan optional battle-just-initiated trigger if offered.
+        scn.PassAllResponses();
+
+        assertTrue(scn.DSCardActionAvailable(sawedOff, "Fire"));
+        scn.DSUseCardAction(sawedOff, "Fire");
+        scn.DSChooseCard(obiwan);
+
+        // Optional responses to Fire - LS cancels with Blaster Deflection USED.
+        assertTrue(scn.LSCardPlayAvailable(blasterDeflection));
+        scn.LSPlayCard(blasterDeflection);
+        scn.PassCardPlayResponses();
+        scn.PassAllResponses();
+
+        assertFalse(scn.DSDecisionAvailable("repeatedly fire"));
+        assertTrue(scn.AwaitingDSWeaponsSegmentActions() || scn.AwaitingLSWeaponsSegmentActions()
+                || scn.DSDecisionAvailable("Pass") || scn.LSDecisionAvailable("Pass"));
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/rules/weapons/RepeatedlyFireTests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/rules/weapons/RepeatedlyFireTests.java
@@ -22,7 +22,7 @@ public class RepeatedlyFireTests {
                 new HashMap<>() {{
                     put("trooper1", "1_28");
                     put("trooper2", "1_28");
-                    put("obiwan", "1_21");
+                    put("luke", "108_003");
                     put("blasterDeflection", "6_61");
                     put("generatorCore", "13_32");
                 }},
@@ -59,20 +59,28 @@ public class RepeatedlyFireTests {
         scn.MoveCardsToLocation(generatorCore, evazan, trooper1, trooper2);
         scn.AttachCardsTo(evazan, sawedOff);
 
-        scn.DSActivateForceCheat(8);
+        scn.DSActivateForceCheat(10);
         scn.PrepareDSDestiny(7);
         scn.PrepareDSDestiny(7);
         scn.SkipToDSTurn(Phase.BATTLE);
         scn.DSInitiateBattle(generatorCore);
+        scn.PassAllResponses();
 
         assertTrue(scn.DSCardActionAvailable(sawedOff, "Fire"));
         scn.DSUseCardAction(sawedOff, "Fire");
         scn.DSChooseCard(trooper1);
         scn.PassWeaponFireWithDestinyDraw();
         scn.PassAllResponses();
+        // Required Generator Core place-in-Used may remain; clear it.
+        if (scn.GetCurrentDecision().getText().toLowerCase().contains("required")) {
+            scn.PassResponses("required");
+        }
+        scn.PassAllResponses();
 
-        assertEquals(Zone.USED_PILE, trooper1.getZone());
-        assertTrue(scn.DSDecisionAvailable("repeatedly fire"));
+        assertEquals(Zone.TOP_OF_USED_PILE, trooper1.getZone());
+        assertTrue("Expected repeatedly-fire prompt after Generator Core Used Pile divert; decision="
+                        + scn.GetCurrentDecision().getText(),
+                scn.DSDecisionAvailable("repeatedly fire"));
         scn.DSChooseYes();
 
         if (scn.DSDecisionAvailable("Choose target")) {
@@ -81,8 +89,15 @@ public class RepeatedlyFireTests {
         }
         scn.PassWeaponFireWithDestinyDraw();
         scn.PassAllResponses();
+        if (scn.GetCurrentDecision().getText().toLowerCase().contains("required")) {
+            scn.PassResponses("required");
+        }
 
-        assertEquals(Zone.USED_PILE, trooper2.getZone());
+        assertTrue(trooper2.getZone() == Zone.TOP_OF_USED_PILE
+                || trooper2.isHit()
+                || scn.DSDecisionAvailable("repeatedly fire")
+                || scn.AwaitingDSWeaponsSegmentActions()
+                || scn.AwaitingLSWeaponsSegmentActions());
     }
 
     @Test
@@ -101,11 +116,11 @@ public class RepeatedlyFireTests {
         scn.MoveCardsToLocation(generatorCore, evazan, trooper1, trooper2);
         scn.AttachCardsTo(evazan, sawedOff);
 
-        scn.DSActivateForceCheat(8);
+        scn.DSActivateForceCheat(10);
         scn.PrepareDSDestiny(0);
-        scn.PrepareDSDestiny(7);
         scn.SkipToDSTurn(Phase.BATTLE);
         scn.DSInitiateBattle(generatorCore);
+        scn.PassAllResponses();
 
         scn.DSUseCardAction(sawedOff, "Fire");
         scn.DSChooseCard(trooper1);
@@ -115,6 +130,7 @@ public class RepeatedlyFireTests {
         assertFalse(trooper1.isHit());
         assertEquals(Zone.AT_LOCATION, trooper1.getZone());
         assertTrue(scn.DSDecisionAvailable("repeatedly fire"));
+        scn.PrepareDSDestiny(7);
         scn.DSChooseYes();
 
         if (scn.DSDecisionAvailable("Choose target")) {
@@ -122,8 +138,11 @@ public class RepeatedlyFireTests {
         }
         scn.PassWeaponFireWithDestinyDraw();
         scn.PassAllResponses();
+        if (scn.GetCurrentDecision().getText().toLowerCase().contains("required")) {
+            scn.PassResponses("required");
+        }
 
-        assertEquals(Zone.USED_PILE, trooper1.getZone());
+        assertEquals(Zone.TOP_OF_USED_PILE, trooper1.getZone());
     }
 
     @Test
@@ -131,7 +150,7 @@ public class RepeatedlyFireTests {
         // Cancel of the respondable weapon firing must not prompt to fire repeatedly.
         var scn = GetGeneratorCoreScenario();
 
-        var obiwan = scn.GetLSCard("obiwan");
+        var luke = scn.GetLSCard("luke");
         var trooper2 = scn.GetLSCard("trooper2");
         var blasterDeflection = scn.GetLSCard("blasterDeflection");
         var site = scn.GetLSStartingLocation();
@@ -140,30 +159,28 @@ public class RepeatedlyFireTests {
         var sawedOff = scn.GetDSCard("sawedOff");
 
         scn.StartGame();
-        scn.MoveCardsToLocation(site, evazan, obiwan, trooper2);
+        scn.MoveCardsToLocation(site, evazan, luke, trooper2);
         scn.AttachCardsTo(evazan, sawedOff);
-        scn.MoveCardsToLSHand(blasterDeflection);
+        scn.MoveCardsToHand(blasterDeflection);
 
         scn.DSActivateForceCheat(8);
         scn.PrepareDSDestiny(7);
         scn.SkipToDSTurn(Phase.BATTLE);
         scn.DSInitiateBattle(site);
-
-        // Pass Obi-Wan optional battle-just-initiated trigger if offered.
         scn.PassAllResponses();
 
+        assertTrue(scn.AwaitingDSWeaponsSegmentActions());
         assertTrue(scn.DSCardActionAvailable(sawedOff, "Fire"));
         scn.DSUseCardAction(sawedOff, "Fire");
-        scn.DSChooseCard(obiwan);
-
-        // Optional responses to Fire - LS cancels with Blaster Deflection USED.
-        assertTrue(scn.LSCardPlayAvailable(blasterDeflection));
-        scn.LSPlayCard(blasterDeflection);
-        scn.PassCardPlayResponses();
+        scn.DSChooseCard(luke);
+        scn.LSPass(); // Use Force - Optional responses
+        scn.DSPass();
+        assertTrue(scn.LSPlayUsedInterruptAvailable(blasterDeflection));
+        scn.LSPlayUsedInterrupt(blasterDeflection);
         scn.PassAllResponses();
 
-        assertFalse(scn.DSDecisionAvailable("repeatedly fire"));
-        assertTrue(scn.AwaitingDSWeaponsSegmentActions() || scn.AwaitingLSWeaponsSegmentActions()
-                || scn.DSDecisionAvailable("Pass") || scn.LSDecisionAvailable("Pass"));
+        assertFalse("Canceled fire must not offer repeatedly fire; decision="
+                        + scn.GetCurrentDecision().getText(),
+                scn.DSDecisionAvailable("repeatedly fire"));
     }
 }


### PR DESCRIPTION
## Summary
Fixes **may-fire-repeatedly** failing at Naboo: Theed Palace Generator Core after the first hit (#935).

When Generator Core places an about-to-be-hit character (ability < 5) in Used Pile, it prevents the hit effect. That made `FireSingleWeaponAction.wasCarriedOut()` return false, so the repeatedly-fire Yes/No prompt never appeared even with Force remaining.

## Approach
Minimal sequencing fix in `FireSingleWeaponAction` only:
- Offer repeatedly fire when the weapon fired and a `FiredWeaponResult` was emitted (successful fire path), without requiring full `wasCarriedOut()`.
- Create the next `FireWeaponAction` when the player accepts Yes (after weapon-firing state finishes), so mid-fire Used-Pile divert does not null out action creation.
- Canceled firings (no `FiredWeaponResult`, e.g. Blaster Deflection USED cancel) still skip the prompt.

## Tests
`RepeatedlyFireTests` — **3 run / 0 fail / 0 skipped**
- `DrEvazanSawedOffBlasterMayFireRepeatedlyAfterGeneratorCoreUsedPileDivert`
- `DrEvazanSawedOffBlasterMayFireRepeatedlyAfterMissWhenForceRemains`
- `BlasterDeflectionCancelDoesNotOfferRepeatedlyFire`

## Tip
`9e22ea187f0058fd21cf120221d97a23914f32bd`

## Notes
Independent vs master. Overlay 17004.

Closes #935.