### PR TITLE
Fix draw-X-choose-Y when max battle destinies already reduced (#973)

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/GameConditions.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/GameConditions.java
@@ -5303,12 +5303,12 @@ public class GameConditions {
      * @param game the game
      * @return true or false
      */
-    public static boolean canDrawDestinyAndChoose(SwccgGame game, int drawX) {
+    public static boolean canDrawDestinyAndChoose(SwccgGame game, int chooseY) {
         DrawDestinyState drawDestinyState = game.getGameState().getTopDrawDestinyState();
         if (drawDestinyState == null)
             return false;
 
-        return drawDestinyState.getDrawDestinyEffect().canDrawAndChoose(game, drawX);
+        return drawDestinyState.getDrawDestinyEffect().canDrawAndChoose(game, chooseY);
     }
 
     /**

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set14/dark/Card14_116.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set14/dark/Card14_116.java
@@ -62,7 +62,7 @@ public class Card14_116 extends AbstractStarfighter {
                 && GameConditions.isInBattleAt(game, self, Filters.system)
                 && GameConditions.isInBattleWith(game, self, Filters.and(Filters.other(self), Filters.droid_starfighter))
                 && GameConditions.isOncePerBattle(game, self, playerId, gameTextSourceCardId)
-                && GameConditions.canDrawDestinyAndChoose(game, 2)) {
+                && GameConditions.canDrawDestinyAndChoose(game, 1)) {
 
             final OptionalGameTextTriggerAction action = new OptionalGameTextTriggerAction(self, gameTextSourceCardId);
             action.setText("Draw two and choose one");

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set14/light/Card14_044.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set14/light/Card14_044.java
@@ -44,7 +44,7 @@ public class Card14_044 extends AbstractUsedInterrupt {
     protected List<PlayInterruptAction> getGameTextOptionalAfterActions(final String playerId, SwccgGame game, EffectResult effectResult, final PhysicalCard self) {
         // Check condition(s)
         if (TriggerConditions.isAboutToDrawWeaponDestiny(game, effectResult, playerId, Filters.Proton_Torpedoes)
-                && GameConditions.canDrawDestinyAndChoose(game, 3)) {
+                && GameConditions.canDrawDestinyAndChoose(game, 1)) {
 
             final PlayInterruptAction action = new PlayInterruptAction(game, self);
             action.setText("Draw three and choose one");

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/light/Card5_048.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set5/light/Card5_048.java
@@ -73,7 +73,7 @@ public class Card5_048 extends AbstractLostInterrupt {
                                                         if (playerId2.equals(playerId)
                                                                 && TriggerConditions.isAboutToDrawBattleDestiny(game, effectResult, playerId)
                                                                 && GameConditions.isOncePerBattle(game, self, playerId, gameTextSourceCardId)
-                                                                && GameConditions.canDrawDestinyAndChoose(game, 2)) {
+                                                                && GameConditions.canDrawDestinyAndChoose(game, 1)) {
 
                                                             final OptionalGameTextTriggerAction action2 = new OptionalGameTextTriggerAction(self, playerId, gameTextSourceCardId);
                                                             action2.setText("Draw two and choose one");
@@ -120,7 +120,7 @@ public class Card5_048 extends AbstractLostInterrupt {
                                                         if (playerId2.equals(playerId)
                                                                 && TriggerConditions.isAboutToDrawBattleDestiny(game, effectResult, playerId)
                                                                 && GameConditions.isOncePerBattle(game, self, playerId, gameTextSourceCardId)
-                                                                && GameConditions.canDrawDestinyAndChoose(game, 3)) {
+                                                                && GameConditions.canDrawDestinyAndChoose(game, 2)) {
 
                                                             final OptionalGameTextTriggerAction action2 = new OptionalGameTextTriggerAction(self, playerId, gameTextSourceCardId);
                                                             action2.setText("Draw three and choose two");

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set9/light/Card9_015.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set9/light/Card9_015.java
@@ -64,7 +64,7 @@ public class Card9_015 extends AbstractRebel {
                 && TriggerConditions.isAboutToDrawWeaponDestiny(game, effectResult, playerId, Filters.ion_cannon)
                 && GameConditions.isOncePerTurn(game, self, playerId, gameTextSourceCardId, gameTextActionId)
                 && GameConditions.isDuringWeaponFiringAtTarget(game, Filters.weaponBeingFiredBy(starshipPiloting), Filters.any)
-                && GameConditions.canDrawDestinyAndChoose(game, 2)
+                && GameConditions.canDrawDestinyAndChoose(game, 1)
                 ) {
             final OptionalGameTextTriggerAction action = new OptionalGameTextTriggerAction(self, gameTextSourceCardId, gameTextActionId);
             action.setText("Draw two and choose one");

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyAndChooseInsteadEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyAndChooseInsteadEffect.java
@@ -29,7 +29,7 @@ public class DrawDestinyAndChooseInsteadEffect extends AbstractSuccessfulEffect 
         DrawDestinyState drawDestinyState = gameState.getTopDrawDestinyState();
         if (drawDestinyState != null) {
             DrawDestinyEffect drawDestinyEffect = drawDestinyState.getDrawDestinyEffect();
-            if (drawDestinyEffect.canDrawAndChoose(game, _drawX)) {
+            if (drawDestinyEffect.canDrawAndChoose(game, _chooseY)) {
 
                 gameState.sendMessage(drawDestinyEffect.getPlayerDrawingDestiny() + " will draw " + _drawX + " "
                         + " " + drawDestinyEffect.getDestinyType().getHumanReadable() + " and choose " + _chooseY);

--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/DrawDestinyEffect.java
@@ -420,12 +420,13 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
     }
 
     /**
-     * Determines if a "draw X and choose Y" can be performed
+     * Determines if a "draw X and choose Y" can be performed.
+     * Gates on choose-Y (destinies that count toward the draw limit), not draw-X.
      * @param game the game
-     * @param drawX the X value
+     * @param chooseY the Y value (number of destinies chosen / counted against the limit)
      * @return true or false
      */
-    public boolean canDrawAndChoose(SwccgGame game, int drawX) {
+    public boolean canDrawAndChoose(SwccgGame game, int chooseY) {
         if (isDrawAndChoose())
             return false;
 
@@ -447,7 +448,7 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
             maxAllowedToDraw = Math.min(maxAllowedToDraw, modifiersQuerying.getNumDestinyDrawsToAttritionOnly(gameState, _performingPlayerId, true, false));
         }
 
-        return (_numDrawnSoFarAgainstLimit + _numSkippedSoFar + drawX) <= maxAllowedToDraw;
+        return (_numDrawnSoFarAgainstLimit + _numSkippedSoFar + chooseY) <= maxAllowedToDraw;
     }
 
     /**
@@ -575,8 +576,11 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
             maxAllowedToDraw = Math.min(maxAllowedToDraw, modifiersQuerying.getNumDestinyDrawsToAttritionOnly(gameState, _performingPlayerId, true, false));
         }
 
-        // If the number of destiny drawn so far against the limit has reached the limit, then no more destiny can be drawn
-        if ((_numDrawnSoFarAgainstLimit + _numSkippedSoFar) >= maxAllowedToDraw) {
+        // If the number of destiny drawn so far against the limit has reached the limit, then no more destiny can be drawn.
+        // During draw-X-choose-Y, allow finishing the remaining draws within X (extras are peeks; only Y counts toward the limit).
+        boolean stillDrawingWithinDrawX = isDrawAndChoose()
+                && (_numDrawnSoFarWithinDrawX + _numSkippedSoFarWithinDrawX) < _drawX;
+        if (!stillDrawingWithinDrawX && (_numDrawnSoFarAgainstLimit + _numSkippedSoFar) >= maxAllowedToDraw) {
             gameState.sendMessage("Limit of " + maxAllowedToDraw + " " + _destinyType.getHumanReadable() + " drawn for " + _performingPlayerId + " has been reached. No more " + _destinyType.getHumanReadable() + " can be drawn");
             _noMoreDestinyToDraw = true;
         }
@@ -923,12 +927,17 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
                                                 _drawnDestinyValueModification = 0;
                                                 _modifierSourceTitleMap.clear();
                                                 // Decrement number drawn so far against limit if substituted after drawn
-                                                _numDrawnSoFarAgainstLimit--;
+                                                // (only if that draw counted against the limit under draw-X-choose-Y rules)
+                                                if (!isDrawAndChoose() || _numDrawnSoFarWithinDrawX <= _chooseY) {
+                                                    _numDrawnSoFarAgainstLimit--;
+                                                }
                                             }
                                             else if (isDestinyToBeRedrawn()) {
                                                 // Decrement number drawn so far (and against limit if canceled and redraw)
                                                 _numDrawnSoFar--;
-                                                _numDrawnSoFarAgainstLimit--;
+                                                if (!isDrawAndChoose() || _numDrawnSoFarWithinDrawX <= _chooseY) {
+                                                    _numDrawnSoFarAgainstLimit--;
+                                                }
                                                 if (isDrawAndChoose()) {
                                                     _numDrawnSoFarWithinDrawX--;
                                                 }
@@ -1159,9 +1168,12 @@ public abstract class DrawDestinyEffect extends AbstractSubActionEffect {
                             gameState.destinyDrawn(_drawnDestinyCard, destinyText);
                             gameState.removeCardsFromZone(Collections.singleton(_drawnDestinyCard));
                             gameState.addCardToTopOfZone(_drawnDestinyCard, Zone.UNRESOLVED_DESTINY_DRAW, _performingPlayerId);
-                            // Increment number drawn (and against limit)
+                            // Increment number drawn (and against limit).
+                            // For draw-X-choose-Y only the first chooseY draws count against the destiny limit.
                             _numDrawnSoFar++;
-                            _numDrawnSoFarAgainstLimit++;
+                            if (!isDrawAndChoose() || _numDrawnSoFarWithinDrawX <= _chooseY) {
+                                _numDrawnSoFarAgainstLimit++;
+                            }
 
                             // Ask the player to choose the destiny value (if multiple exist)
                             if (_drawnDestinyCard.getBlueprint().getDestiny() != null && !_drawnDestinyCard.getBlueprint().getDestiny().equals(_drawnDestinyCard.getBlueprint().getAlternateDestiny())) {

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set14/dark/Card_14_116_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set14/dark/Card_14_116_Tests.java
@@ -1,0 +1,198 @@
+package com.gempukku.swccgo.cards.set14.dark;
+
+import com.gempukku.swccgo.common.CardSubtype;
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Keyword;
+import com.gempukku.swccgo.common.ModelType;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.cards.GameConditions;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.game.AbstractActionProxy;
+import com.gempukku.swccgo.game.PhysicalCard;
+import com.gempukku.swccgo.game.SwccgGame;
+import com.gempukku.swccgo.logic.TriggerConditions;
+import com.gempukku.swccgo.logic.actions.OptionalGameTextTriggerAction;
+import com.gempukku.swccgo.logic.actions.TriggerAction;
+import com.gempukku.swccgo.logic.timing.EffectResult;
+import java.util.Collections;
+import java.util.List;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import com.gempukku.swccgo.logic.decisions.AwaitingDecision;
+import com.gempukku.swccgo.logic.modifiers.DrawsBattleDestinyIfUnableToOtherwiseModifier;
+import com.gempukku.swccgo.logic.modifiers.MayNotDrawMoreThanBattleDestinyModifier;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Card_14_116_Tests {
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("xwing", "1_146");
+                }},
+                new HashMap<>() {{
+                    put("dfs1015", "14_116");
+                    put("dfs1308", "14_117");
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSSpaceSystem,
+                StartingSetup.DefaultDSSpaceSystem,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    private static String decisionText(VirtualTableScenario scn, String player) {
+        AwaitingDecision ad = scn.GetAwaitingDecision(player);
+        return ad == null ? "<none>" : ad.getText();
+    }
+
+    @Test
+    public void DFS1015StatsAndKeywordsAreCorrect() {
+        var scn = GetScenario();
+        var card = scn.GetDSCard("dfs1015").getBlueprint();
+
+        assertEquals("DFS-1015", card.getTitle());
+        assertEquals(Uniqueness.UNIQUE, card.getUniqueness());
+        assertEquals(Side.DARK, card.getSide());
+        assertTrue(card.isCardType(CardType.STARSHIP));
+        assertEquals(CardSubtype.STARFIGHTER, card.getCardSubtype());
+        assertEquals(2, card.getDestiny(), scn.epsilon);
+        assertEquals(1, card.getDeployCost(), scn.epsilon);
+        assertEquals(2, card.getPower(), scn.epsilon);
+        assertEquals(2, card.getManeuver(), scn.epsilon);
+        assertEquals(3, card.getForfeit(), scn.epsilon);
+        assertTrue(card.hasKeyword(Keyword.DFS_SQUADRON));
+        assertTrue(card.hasKeyword(Keyword.NO_HYPERDRIVE));
+        assertTrue(card.getModelTypes().contains(ModelType.DROID_STARFIGHTER));
+        assertEquals(1, card.getIconCount(Icon.THEED_PALACE));
+        assertEquals(1, card.getIconCount(Icon.EPISODE_I));
+        assertEquals(1, card.getIconCount(Icon.TRADE_FEDERATION));
+        assertEquals(1, card.getIconCount(Icon.PILOT));
+        assertEquals(1, card.getIconCount(Icon.PRESENCE));
+        assertEquals(1, card.getIconCount(Icon.STARSHIP));
+        assertEquals(ExpansionSet.THEED_PALACE, card.getExpansionSet());
+        assertEquals(Rarity.U, card.getRarity());
+    }
+
+    @Test
+    public void DFS1015DrawTwoChooseOneOfferedWhenMaxBattleDestiniesIsOne() {
+        // Real-path for #973: with max battle destinies already reduced to 1,
+        // draw-2-choose-1 must still be offered (gate on choose-Y, not draw-X).
+        var scn = GetScenario();
+
+        var xwing = scn.GetLSCard("xwing");
+        var dfs1015 = scn.GetDSCard("dfs1015");
+        var dfs1308 = scn.GetDSCard("dfs1308");
+        var system = scn.GetDSStartingLocation();
+
+        scn.StartGame();
+
+        scn.MoveCardsToLocation(system, dfs1015, dfs1308, xwing);
+        scn.PrepareDSDestiny(5);
+
+        scn.ApplyAdHocModifier(new DrawsBattleDestinyIfUnableToOtherwiseModifier(dfs1015, 1));
+        scn.ApplyAdHocModifier(new MayNotDrawMoreThanBattleDestinyModifier(dfs1015, 1, scn.DS));
+
+        scn.SkipToPhase(Phase.BATTLE);
+        scn.DSInitiateBattle(system);
+
+        scn.DSPass();
+        scn.LSPass();
+
+        scn.LSPass();
+        scn.DSPass();
+
+        assertEquals(1, scn.GetDSBattleDestinyLimit());
+        assertEquals(1, scn.GetDSBattleDestinyCount());
+
+        String current = scn.GetCurrentPlayer();
+        assertTrue("Expected battle destiny prompt for " + current
+                        + "; DS=[" + decisionText(scn, scn.DS) + "] LS=[" + decisionText(scn, scn.LS) + "]",
+                scn.DecisionAvailable(current, "battle destiny"));
+        scn.PlayerChooseYes(current);
+
+        if (scn.LSAnyDecisionsAvailable()) scn.LSPass();
+        if (scn.DSAnyDecisionsAvailable() && scn.DSDecisionAvailable("COST_TO_DRAW")) scn.DSPass();
+        if (scn.LSAnyDecisionsAvailable()) scn.LSPass();
+
+        assertTrue("DFS-1015 draw-two-choose-one should be offered when max destinies is 1; DS=["
+                        + decisionText(scn, scn.DS) + "]",
+                scn.DSCardActionAvailable(dfs1015, "Draw two and choose one"));
+
+        // Accept and complete under max=1 (must not be blocked mid-draw).
+        scn.DSUseCardAction(dfs1015, "Draw two and choose one");
+        scn.PassAllResponses();
+        assertTrue("Battle should continue after draw-2-choose-1 under max=1",
+                scn.DSAnyDecisionsAvailable() || scn.LSAnyDecisionsAvailable());
+    }
+
+    @Test
+    public void DrawXChooseYChooseGreaterThanMaxNotOfferedWhenMaxBattleDestiniesIsOne() {
+        // choose-Y > max must not be offered (VHD: draw-10-choose-3 blocked when max is 2, etc.)
+        var scn = GetScenario();
+
+        var xwing = scn.GetLSCard("xwing");
+        var dfs1015 = scn.GetDSCard("dfs1015");
+        var dfs1308 = scn.GetDSCard("dfs1308");
+        var system = scn.GetDSStartingLocation();
+
+        scn.StartGame();
+        scn.MoveCardsToLocation(system, dfs1015, dfs1308, xwing);
+
+        scn.ApplyAdHocModifier(new DrawsBattleDestinyIfUnableToOtherwiseModifier(dfs1015, 1));
+        scn.ApplyAdHocModifier(new MayNotDrawMoreThanBattleDestinyModifier(dfs1015, 1, scn.DS));
+
+        // Synthetic draw-X-choose-Y with chooseY=2 (> max 1), gated by canDrawDestinyAndChoose
+        scn.ApplyAdHocAction(new AbstractActionProxy() {
+            @Override
+            public List<TriggerAction> getOptionalAfterTriggers(String playerId, SwccgGame game, EffectResult effectResult) {
+                if (playerId.equals(scn.DS)
+                        && TriggerConditions.isAboutToDrawBattleDestiny(game, effectResult, playerId)
+                        && GameConditions.canDrawDestinyAndChoose(game, 2)) {
+                    final var action = new OptionalGameTextTriggerAction(dfs1015, dfs1015.getCardId());
+                    action.setText("Draw three and choose two");
+                    return Collections.singletonList(action);
+                }
+                return null;
+            }
+        });
+
+        scn.SkipToPhase(Phase.BATTLE);
+        scn.DSInitiateBattle(system);
+        scn.DSPass();
+        scn.LSPass();
+        scn.LSPass();
+        scn.DSPass();
+
+        assertEquals(1, scn.GetDSBattleDestinyLimit());
+
+        String current = scn.GetCurrentPlayer();
+        assertTrue(scn.DecisionAvailable(current, "battle destiny"));
+        scn.PlayerChooseYes(current);
+
+        if (scn.LSAnyDecisionsAvailable()) scn.LSPass();
+        if (scn.DSAnyDecisionsAvailable() && scn.DSDecisionAvailable("COST_TO_DRAW")) scn.DSPass();
+        if (scn.LSAnyDecisionsAvailable()) scn.LSPass();
+
+        // choose-Y=1 (DFS-1015) still offered; choose-Y=2 must not be
+        assertTrue(scn.DSCardActionAvailable(dfs1015, "Draw two and choose one"));
+        assertFalse("choose-Y=2 must not be offered when max battle destinies is 1; DS=["
+                        + decisionText(scn, scn.DS) + "]",
+                scn.DSCardActionAvailable(dfs1015, "Draw three and choose two")
+                        || scn.DSActionAvailable("Draw three and choose two"));
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_048_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set5/light/Card_5_048_Tests.java
@@ -1,0 +1,52 @@
+package com.gempukku.swccgo.cards.set5.light;
+
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Gambler's Luck call sites pass choose-Y into canDrawDestinyAndChoose (#973).
+ * Real-path max-destinies scenarios are covered in Card_14_116_Tests.
+ */
+public class Card_5_048_Tests {
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("luck", "5_048");
+                }},
+                new HashMap<>() {{
+                }},
+                10,
+                10,
+                StartingSetup.DefaultLSGroundLocation,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void GamblersLuckStatsAndKeywordsAreCorrect() {
+        var scn = GetScenario();
+        var card = scn.GetLSCard("luck").getBlueprint();
+        assertEquals("Gambler's Luck", card.getTitle());
+        assertEquals(Uniqueness.UNIQUE, card.getUniqueness());
+        assertEquals(Side.LIGHT, card.getSide());
+        assertEquals(4, card.getDestiny(), scn.epsilon);
+        assertEquals(1, card.getIconCount(Icon.CLOUD_CITY));
+        assertEquals(ExpansionSet.CLOUD_CITY, card.getExpansionSet());
+        assertEquals(Rarity.R, card.getRarity());
+    }
+}


### PR DESCRIPTION
## Summary
When max battle destinies is already reduced (e.g. to 1), draw-X-choose-Y text such as DFS-1015's "draw two and choose one" was incorrectly blocked because `canDrawAndChoose` compared **draw-X** against the max instead of **choose-Y**.

## Fix
- `DrawDestinyEffect.canDrawAndChoose` / `GameConditions.canDrawDestinyAndChoose` now gate on **choose-Y** (destinies that count toward the limit).
- Mid-draw limit handling allows finishing the remaining draws within X; only the first choose-Y draws increment `_numDrawnSoFarAgainstLimit`.
- Decipher call sites updated to pass choose-Y: DFS-1015, Take This!, Gambler's Luck, Gray Squadron Y-wing Pilot.
- `DrawDestinyAndChooseInsteadEffect` validates with choose-Y.

## Tests
- `Card_14_116_Tests` (3): DFS-1015 stats; draw-2-choose-1 offered when max=1; choose-Y=2 not offered when max=1.
- `Card_5_048_Tests` (1): Gambler's Luck stats (call-site choose-Y update).

## Independent
Independent PR vs `master`. Does not include #291 / #998 work.

## Known gaps
- **Reviewed / deferred (Alpha2):** against-limit if more battle destinies remain in the same `DrawDestinyEffect` after a draw-and-choose. Primary real-path check (DFS-1015 draw-2-choose-1 with max/count=2, then the second normal destiny in the same effect) already completes correctly under this PR's choose-Y against-limit accounting (`numDrawn=2`). Not expanding this PR with extra coverage. Residual follow-up only if exotic mid-draw-X cancel/substitute/skip accounting proves wrong.
- Replay used Virtual DFS / B2 as incidental setup; tests use Decipher DFS-1015 + ad-hoc max/min destiny modifiers.

Closes #973
