### PR TITLE
Fix Sabacc clone/wild value UX: auto-continue once set (#58)

### DIFF
--- a/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/PlaySabaccEffect.java
+++ b/src/gemp-swccg-logic/src/main/java/com/gempukku/swccgo/logic/effects/PlaySabaccEffect.java
@@ -366,7 +366,7 @@ public class PlaySabaccEffect extends AbstractSubActionEffect {
 
                                             final SubAction playerChooseCardValuesAction = new SubAction(chooseCardValuesAction);
                                             playerChooseCardValuesAction.appendEffect(
-                                                    new ChooseSabaccValuesEffect(playerChooseCardValuesAction, _playerId, playersCardsWithVariableValue, false));
+                                                    new ChooseSabaccValuesEffect(playerChooseCardValuesAction, _playerId, playersCardsWithVariableValue));
                                             chooseCardValuesAction.stackSubAction(playerChooseCardValuesAction);
                                         }
                                     }
@@ -394,7 +394,7 @@ public class PlaySabaccEffect extends AbstractSubActionEffect {
 
                                             final SubAction opponentChooseCardValuesAction = new SubAction(chooseCardValuesAction);
                                             opponentChooseCardValuesAction.appendEffect(
-                                                    new ChooseSabaccValuesEffect(opponentChooseCardValuesAction, _opponent, opponentsCardsWithVariableValue, false));
+                                                    new ChooseSabaccValuesEffect(opponentChooseCardValuesAction, _opponent, opponentsCardsWithVariableValue));
                                             chooseCardValuesAction.stackSubAction(opponentChooseCardValuesAction);
                                         }
                                     }
@@ -621,8 +621,10 @@ public class PlaySabaccEffect extends AbstractSubActionEffect {
          * @param playerId the sabacc hand owner
          * @param cardsWithVariableValue the sabacc cards with variable values
          */
-        public ChooseSabaccValuesEffect(SubAction subAction, String playerId, Collection<PhysicalCard> cardsWithVariableValue, boolean consideredComplete) {
-            super(subAction, playerId, playerId, consideredComplete ? 0 : 1, 1, false, Filters.in(cardsWithVariableValue));
+        public ChooseSabaccValuesEffect(SubAction subAction, String playerId, Collection<PhysicalCard> cardsWithVariableValue) {
+            // Only prompt for cards that still need a value. Once a value is set, do not re-offer that card
+            // (avoids Done-button confusion and bot infinite reassignment loops).
+            super(subAction, playerId, playerId, 1, 1, false, Filters.in(cardsStillNeedingSabaccValue(cardsWithVariableValue)));
             _subAction = subAction;
             _currentPlayerId = playerId;
             _cardsWithVariableValue = cardsWithVariableValue;
@@ -630,7 +632,11 @@ public class PlaySabaccEffect extends AbstractSubActionEffect {
 
         @Override
         public String getChoiceText(int numCardsToChoose) {
-            return "Choose card to set sabacc value";
+            int remaining = cardsStillNeedingSabaccValue(_cardsWithVariableValue).size();
+            if (remaining <= 1) {
+                return "Choose clone/wild card to set sabacc value (continues automatically after assignment)";
+            }
+            return "Choose clone/wild card to set sabacc value (" + remaining + " remaining)";
         }
 
         @Override
@@ -660,8 +666,7 @@ public class PlaySabaccEffect extends AbstractSubActionEffect {
                                                                     selectedCard.setSabaccValue(result);
 
                                                                     // Choose next card
-                                                                    _subAction.appendEffect(
-                                                                            new ChooseSabaccValuesEffect(_subAction, _currentPlayerId, _cardsWithVariableValue, isAllCardsHaveSabaccValueSet()));
+                                                                    appendChooseNextSabaccValueIfNeeded(_subAction, _currentPlayerId, _cardsWithVariableValue);
                                                                 }
                                                             }
                                                     ));
@@ -676,8 +681,7 @@ public class PlaySabaccEffect extends AbstractSubActionEffect {
                                                             selectedCard.setSabaccValue(game.getModifiersQuerying().getDestiny(game.getGameState(), selectedCard));
 
                                                             // Choose next card
-                                                            _subAction.appendEffect(
-                                                                    new ChooseSabaccValuesEffect(_subAction, _currentPlayerId, _cardsWithVariableValue, isAllCardsHaveSabaccValueSet()));
+                                                            appendChooseNextSabaccValueIfNeeded(_subAction, _currentPlayerId, _cardsWithVariableValue);
 
                                                         }
                                                     }
@@ -698,8 +702,7 @@ public class PlaySabaccEffect extends AbstractSubActionEffect {
                                             selectedCard.setSabaccValue(result);
 
                                             // Choose next card
-                                            _subAction.appendEffect(
-                                                    new ChooseSabaccValuesEffect(_subAction, _currentPlayerId, _cardsWithVariableValue, isAllCardsHaveSabaccValueSet()));
+                                            appendChooseNextSabaccValueIfNeeded(_subAction, _currentPlayerId, _cardsWithVariableValue);
                                         }
                                     }
                             ));
@@ -717,8 +720,7 @@ public class PlaySabaccEffect extends AbstractSubActionEffect {
                                                 selectedCard.setSabaccValue(optionalCloneValue);
 
                                                 // Choose next card
-                                                _subAction.appendEffect(
-                                                        new ChooseSabaccValuesEffect(_subAction, _currentPlayerId, _cardsWithVariableValue, isAllCardsHaveSabaccValueSet()));
+                                                appendChooseNextSabaccValueIfNeeded(_subAction, _currentPlayerId, _cardsWithVariableValue);
                                             }
                                             @Override
                                             protected void no() {
@@ -733,8 +735,7 @@ public class PlaySabaccEffect extends AbstractSubActionEffect {
                                                                 selectedCard.setSabaccCardCloned(selectedNonClone);
 
                                                                 // Choose next card
-                                                                _subAction.appendEffect(
-                                                                        new ChooseSabaccValuesEffect(_subAction, _currentPlayerId, _cardsWithVariableValue, isAllCardsHaveSabaccValueSet()));
+                                                                appendChooseNextSabaccValueIfNeeded(_subAction, _currentPlayerId, _cardsWithVariableValue);
                                                             }
                                                             @Override
                                                             public String getChoiceText(int numCardsToChoose) {
@@ -758,8 +759,7 @@ public class PlaySabaccEffect extends AbstractSubActionEffect {
                                         selectedCard.setSabaccCardCloned(selectedNonClone);
 
                                         // Choose next card
-                                        _subAction.appendEffect(
-                                                new ChooseSabaccValuesEffect(_subAction, _currentPlayerId, _cardsWithVariableValue, isAllCardsHaveSabaccValueSet()));
+                                        appendChooseNextSabaccValueIfNeeded(_subAction, _currentPlayerId, _cardsWithVariableValue);
                                     }
                                     @Override
                                     public String getChoiceText(int numCardsToChoose) {
@@ -778,8 +778,7 @@ public class PlaySabaccEffect extends AbstractSubActionEffect {
                                     selectedCard.setSabaccValue(game.getModifiersQuerying().getDestiny(game.getGameState(), selectedCard));
 
                                     // Choose next card
-                                    _subAction.appendEffect(
-                                            new ChooseSabaccValuesEffect(_subAction, _currentPlayerId, _cardsWithVariableValue, isAllCardsHaveSabaccValueSet()));
+                                    appendChooseNextSabaccValueIfNeeded(_subAction, _currentPlayerId, _cardsWithVariableValue);
 
                                 }
                             }
@@ -790,16 +789,29 @@ public class PlaySabaccEffect extends AbstractSubActionEffect {
         }
 
         /**
-         * Determines if all cards have a sabacc value set.
-         * @return true or false
+         * Continues prompting only while clone/wild (variable) cards still need a sabacc value.
+         * When every card has a value, play continues automatically — no Done click required.
          */
-        private boolean isAllCardsHaveSabaccValueSet() {
-            for (PhysicalCard card : _cardsWithVariableValue) {
-                if (card.getSabaccValue() == -1)
-                    return false;
+        private void appendChooseNextSabaccValueIfNeeded(SubAction subAction, String playerId, Collection<PhysicalCard> cardsWithVariableValue) {
+            if (!cardsStillNeedingSabaccValue(cardsWithVariableValue).isEmpty()) {
+                subAction.appendEffect(
+                        new ChooseSabaccValuesEffect(subAction, playerId, cardsWithVariableValue));
             }
-            return true;
         }
+
+        /**
+         * Cards among the variable sabacc cards that still need a value assigned.
+         */
+        private static java.util.List<PhysicalCard> cardsStillNeedingSabaccValue(Collection<PhysicalCard> cardsWithVariableValue) {
+            java.util.List<PhysicalCard> unset = new java.util.ArrayList<PhysicalCard>();
+            for (PhysicalCard card : cardsWithVariableValue) {
+                if (card.getSabaccValue() == -1) {
+                    unset.add(card);
+                }
+            }
+            return unset;
+        }
+
     }
 
     /**

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/rules/sabacc/SabaccTests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/rules/sabacc/SabaccTests.java
@@ -37,12 +37,13 @@ public class SabaccTests {
         );
     }
 
-    //unable to reproduce: https://github.com/PlayersCommittee/gemp-swccg-public/issues/58
+    // https://github.com/PlayersCommittee/gemp-swccg-public/issues/58 — clone/wild values auto-continue once set
     @Test
     public void SabaccCloneCardTarget() {
         //verifies:
         //clone card lets user choose a card to duplicate destiny value
         //clone card correctly duplicates target card's sabacc destiny value
+        //after assigning the clone value, play auto-continues (no Done required)
         //able to complete sabacc game after resolving clone card value
 
         var scn = GetScenario();
@@ -109,9 +110,8 @@ public class SabaccTests {
         assertTrue(scn.DSChoiceAvailable("no")); //Do you want to draw another sabacc card?
         scn.DSChoose("no");
 
-        //choosing DSPass here fails because minimum requirement (setting value of clone cards) has not been met
-        //(no way to verify "Done" option is unavailable?)
-        //scn.DSPass(); //if uncommented, fails here because "Done" is not available
+        // Before the clone value is set, play cannot continue past value assignment
+        // (no Done/reassign loop — unset clone/wild cards must be assigned first).
 
         assertEquals(7,scn.GetDSSabaccTotal()); //5 + 3 + -1 clone
 
@@ -123,8 +123,8 @@ public class SabaccTests {
 
         assertEquals(11,scn.GetDSSabaccTotal()); //5 + 3 + cloned 3
         assertEquals(8,scn.GetLSSabaccTotal()); //5 + 3
-        //(no way to verify "Done" option is available?)
-        scn.DSPass(); //choose 'Done'
+        // After the last unset clone/wild value is assigned, sabacc continues automatically
+        // (no mandatory Done click; prevents bot infinite reassignment).
 
         scn.DSPass(); //SABACC_TOTAL_CALCULATED - Optional responses
         scn.LSPass();


### PR DESCRIPTION
## Summary
Fixes [#58](https://github.com/PlayersCommittee/gemp-swccg-public/issues/58): after assigning each Sabacc clone/wild card value, play continues automatically instead of requiring a hard-to-notice **Done** click (and re-prompting for reassignment).

That Done loop was easy for humans to miss and could leave bots infinitely reassigning values.

## Approach
Preferred path from issue discussion: once a clone/wild value is set, do not re-offer that card; when every variable card has a value, auto-continue.

- `ChooseSabaccValuesEffect` only presents cards that still need a sabacc value (`getSabaccValue() == -1`)
- After each assignment, re-prompt only if unset cards remain; otherwise continue without a Done step
- Clearer prompt text (`clone/wild` + remaining count / auto-continue note)
- Scoped change in `PlaySabaccEffect` only — not a full Sabacc rewrite

## Test plan
- [x] `SabaccTests.SabaccCloneCardTarget` updated for auto-continue (no Done pass) and passing locally
- [ ] Trooper Sabacc with clone cards: assign each value once → totals resolve without Done spam
- [ ] Bot path: assigning values completes without infinite reassignment

Closes #58