### PR TITLE
Fix Concentrate All Fire stacking on same starfighter (#38)

### DIFF
--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set9/dark/Card9_093.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set9/dark/Card9_093.java
@@ -17,6 +17,7 @@ import com.gempukku.swccgo.logic.effects.ModifyPowerUntilEndOfBattleEffect;
 import com.gempukku.swccgo.logic.modifiers.EachWeaponDestinyModifier;
 import com.gempukku.swccgo.logic.modifiers.ImmunityToAttritionChangeModifier;
 import com.gempukku.swccgo.logic.modifiers.Modifier;
+import com.gempukku.swccgo.logic.modifiers.ModifierType;
 import com.gempukku.swccgo.logic.timing.EffectResult;
 import com.gempukku.swccgo.logic.timing.results.FiredWeaponResult;
 
@@ -43,6 +44,13 @@ public class Card9_093 extends AbstractAdmiralsOrder {
         // Check condition(s)
         if (TriggerConditions.weaponJustFiredBy(game, effectResult, Filters.weapon, Filters.and(Filters.starfighter, Filters.participatingInBattle))) {
             final PhysicalCard cardFiringWeapon = ((FiredWeaponResult) effectResult).getCardFiringWeapon();
+
+            // Once per starfighter per battle: do not re-apply +3 if this card already modified that ship's power
+            for (Modifier modifier : game.getModifiersQuerying().getModifiersAffectingCard(game.getGameState(), ModifierType.POWER, cardFiringWeapon)) {
+                if (modifier.getSource(game.getGameState()) == self) {
+                    return null;
+                }
+            }
 
             final RequiredGameTextTriggerAction action = new RequiredGameTextTriggerAction(self, gameTextSourceCardId, gameTextActionId);
             action.setText("Add 3 to power of " + GameUtils.getFullName(cardFiringWeapon));

--- a/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set9/light/Card9_003.java
+++ b/src/gemp-swccg-cards/src/main/java/com/gempukku/swccgo/cards/set9/light/Card9_003.java
@@ -17,6 +17,7 @@ import com.gempukku.swccgo.logic.effects.ModifyPowerUntilEndOfBattleEffect;
 import com.gempukku.swccgo.logic.modifiers.EachWeaponDestinyModifier;
 import com.gempukku.swccgo.logic.modifiers.ImmunityToAttritionChangeModifier;
 import com.gempukku.swccgo.logic.modifiers.Modifier;
+import com.gempukku.swccgo.logic.modifiers.ModifierType;
 import com.gempukku.swccgo.logic.timing.EffectResult;
 import com.gempukku.swccgo.logic.timing.results.FiredWeaponResult;
 
@@ -43,6 +44,13 @@ public class Card9_003 extends AbstractAdmiralsOrder {
         // Check condition(s)
         if (TriggerConditions.weaponJustFiredBy(game, effectResult, Filters.weapon, Filters.and(Filters.starfighter, Filters.participatingInBattle))) {
             final PhysicalCard cardFiringWeapon = ((FiredWeaponResult) effectResult).getCardFiringWeapon();
+
+            // Once per starfighter per battle: do not re-apply +3 if this card already modified that ship's power
+            for (Modifier modifier : game.getModifiersQuerying().getModifiersAffectingCard(game.getGameState(), ModifierType.POWER, cardFiringWeapon)) {
+                if (modifier.getSource(game.getGameState()) == self) {
+                    return null;
+                }
+            }
 
             final RequiredGameTextTriggerAction action = new RequiredGameTextTriggerAction(self, gameTextSourceCardId, gameTextActionId);
             action.setText("Add 3 to power of " + GameUtils.getFullName(cardFiringWeapon));

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set9/dark/Card_9_093_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set9/dark/Card_9_093_Tests.java
@@ -1,0 +1,124 @@
+package com.gempukku.swccgo.cards.set9.dark;
+
+import com.gempukku.swccgo.common.CardType;
+import com.gempukku.swccgo.common.ExpansionSet;
+import com.gempukku.swccgo.common.Icon;
+import com.gempukku.swccgo.common.Phase;
+import com.gempukku.swccgo.common.Rarity;
+import com.gempukku.swccgo.common.Side;
+import com.gempukku.swccgo.common.Uniqueness;
+import com.gempukku.swccgo.framework.StartingSetup;
+import com.gempukku.swccgo.framework.VirtualTableScenario;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Card_9_093_Tests {
+    protected VirtualTableScenario GetScenario() {
+        return new VirtualTableScenario(
+                new HashMap<>() {{
+                    put("bwing", "9_66");
+                    put("weapon1", "9_87");
+                    put("weapon2", "2_81");
+                    put("hoth", "3_55");
+                }},
+                new HashMap<>() {{
+                    put("fighterCover", "9_93");
+                    put("executor", "4_167");
+                }},
+                10,
+                10,
+                StartingSetup.ThereIsGoodInHimObjective,
+                StartingSetup.DefaultDSGroundLocation,
+                StartingSetup.NoLSStartingInterrupts,
+                StartingSetup.NoDSStartingInterrupts,
+                StartingSetup.NoLSShields,
+                StartingSetup.NoDSShields,
+                VirtualTableScenario.Open
+        );
+    }
+
+    @Test
+    public void FighterCoverStatsAndKeywordsAreCorrect() {
+        var scn = GetScenario();
+        var card = scn.GetDSCard("fighterCover").getBlueprint();
+
+        assertEquals("Fighter Cover", card.getTitle());
+        assertEquals(Uniqueness.UNIQUE, card.getUniqueness());
+        assertEquals(Side.DARK, card.getSide());
+        scn.BlueprintCardTypeCheck(card, new ArrayList<>() {{
+            add(CardType.ADMIRALS_ORDER);
+        }});
+        assertEquals(6, card.getDestiny(), scn.epsilon);
+        scn.BlueprintIconCheck(card, new ArrayList<>() {{
+            add(Icon.ADMIRALS_ORDER);
+            add(Icon.DEATH_STAR_II);
+        }});
+        assertEquals(ExpansionSet.DEATH_STAR_II, card.getExpansionSet());
+        assertEquals(Rarity.R, card.getRarity());
+    }
+
+    @Test
+    public void FighterCoverDoesNotAddPowerTwiceToSameStarfighterInOneBattle() {
+        // Issue #46 twin of #38: same once-per-starfighter gate as Concentrate All Fire.
+        // LS B-Wing fires two weapons under DS Fighter Cover; +3 applies once only.
+
+        var scn = GetScenario();
+
+        var fighterCover = scn.GetDSCard("fighterCover");
+        var bWing = scn.GetLSCard("bwing");
+        var weapon1 = scn.GetLSCard("weapon1");
+        var weapon2 = scn.GetLSCard("weapon2");
+        var hoth = scn.GetLSCard("hoth");
+        var executor = scn.GetDSCard("executor");
+
+        scn.StartGame();
+
+        scn.MoveCardsToDSHand(fighterCover);
+        scn.MoveLocationToTable(hoth);
+        scn.MoveCardsToLocation(hoth, bWing, executor);
+        scn.AttachCardsTo(bWing, weapon1, weapon2);
+
+        scn.SkipToDSTurn(Phase.DEPLOY);
+        assertTrue(scn.AwaitingDSDeployPhaseActions());
+        assertTrue(scn.DSDeployAvailable(fighterCover));
+        scn.DSDeployCard(fighterCover);
+
+        scn.SkipToLSTurn(Phase.BATTLE);
+        assertTrue(scn.AwaitingLSBattlePhaseActions());
+        assertTrue(scn.GetLSForcePileCount() >= 2);
+        assertTrue(scn.LSCanInitiateBattle());
+        scn.LSInitiateBattle(hoth);
+        scn.PassBattleStartResponses();
+
+        assertEquals(4, scn.GetPower(bWing));
+        assertEquals(4, scn.GetLSTotalPower());
+
+        assertTrue(scn.LSCardActionAvailable(weapon1));
+        scn.LSUseCardAction(weapon1);
+        assertTrue(scn.LSHasCardChoiceAvailable(executor));
+        scn.LSChooseCard(executor);
+        scn.PassAllResponses();
+
+        assertEquals(7, scn.GetPower(bWing));
+        assertEquals(7, scn.GetLSTotalPower());
+
+        scn.DSPass();
+
+        assertTrue(scn.LSCardActionAvailable(weapon2));
+        scn.LSUseCardAction(weapon2);
+        assertTrue(scn.LSHasCardChoiceAvailable(executor));
+        scn.LSChooseCard(executor);
+        assertFalse(scn.LSDecisionAvailable("Add 3 to power"));
+        scn.PassAllResponses();
+        assertFalse(scn.LSDecisionAvailable("Add 3 to power"));
+
+        assertEquals(7, scn.GetPower(bWing));
+        assertEquals(7, scn.GetLSTotalPower());
+    }
+}

--- a/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set9/light/Card_9_003_Tests.java
+++ b/src/gemp-swccg-server/src/test/java/com/gempukku/swccgo/cards/set9/light/Card_9_003_Tests.java
@@ -1,17 +1,14 @@
 package com.gempukku.swccgo.cards.set9.light;
 
-import com.gempukku.swccgo.common.CardSubtype;
 import com.gempukku.swccgo.common.CardType;
 import com.gempukku.swccgo.common.ExpansionSet;
 import com.gempukku.swccgo.common.Icon;
 import com.gempukku.swccgo.common.Phase;
 import com.gempukku.swccgo.common.Rarity;
 import com.gempukku.swccgo.common.Side;
-import com.gempukku.swccgo.common.Title;
 import com.gempukku.swccgo.common.Uniqueness;
 import com.gempukku.swccgo.framework.StartingSetup;
 import com.gempukku.swccgo.framework.VirtualTableScenario;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -19,7 +16,6 @@ import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 public class Card_9_003_Tests {
@@ -80,64 +76,64 @@ public class Card_9_003_Tests {
         assertEquals(Rarity.R, card.getRarity());
     }
 
-    @Test @Ignore
-    public void ConcentrateAllFirePowerBonusIsNotCumulative() {
-        //this test fails and demonstrates issue #38
-        //https://github.com/PlayersCommittee/gemp-swccg-public/issues/38
+    @Test
+    public void ConcentrateAllFireDoesNotAddPowerTwiceToSameStarfighterInOneBattle() {
+        // Issue #38: B-Wing firing multiple weapons must get +3 from Concentrate All Fire only once per battle.
 
         var scn = GetScenario();
 
         var concentrateAllFire = scn.GetLSCard("concentrateAllFire");
-        var bwing = scn.GetLSCard("bwing");
+        var bWing = scn.GetLSCard("bwing");
         var weapon1 = scn.GetLSCard("weapon1");
         var weapon2 = scn.GetLSCard("weapon2");
         var hoth = scn.GetLSCard("hoth");
-
         var executor = scn.GetDSCard("executor");
 
         scn.StartGame();
 
         scn.MoveCardsToLSHand(concentrateAllFire);
-
         scn.MoveLocationToTable(hoth);
-        scn.MoveCardsToLocation(hoth, bwing, executor);
-        scn.AttachCardsTo(bwing, weapon1, weapon2);
+        scn.MoveCardsToLocation(hoth, bWing, executor);
+        scn.AttachCardsTo(bWing, weapon1, weapon2);
 
         scn.SkipToLSTurn(Phase.DEPLOY);
         assertTrue(scn.AwaitingLSDeployPhaseActions());
-
         assertTrue(scn.LSDeployAvailable(concentrateAllFire));
         scn.LSDeployCard(concentrateAllFire);
 
         scn.SkipToPhase(Phase.BATTLE);
-
         assertTrue(scn.AwaitingLSBattlePhaseActions());
-        assertTrue(scn.GetLSForcePileCount() >= 2); //enough to initiate and fire both weapons
+        assertTrue(scn.GetLSForcePileCount() >= 2);
         assertTrue(scn.LSCanInitiateBattle());
         scn.LSInitiateBattle(hoth);
         scn.PassBattleStartResponses();
 
-        // -- base power 4
-        assertEquals(4,scn.GetLSTotalPower());
+        // B-Wing printed power 4 before any Concentrate All Fire bonus
+        assertEquals(4, scn.GetPower(bWing));
+        assertEquals(4, scn.GetLSTotalPower());
 
         assertTrue(scn.LSCardActionAvailable(weapon1));
-        scn.LSUseCardAction(weapon1); //cost: free
+        scn.LSUseCardAction(weapon1);
         assertTrue(scn.LSHasCardChoiceAvailable(executor));
         scn.LSChooseCard(executor);
         scn.PassAllResponses();
 
-        // -- concentrate all fire adds 3
-        assertEquals(7,scn.GetLSTotalPower());
+        // First weapon fire: Concentrate All Fire +3 once
+        assertEquals(7, scn.GetPower(bWing));
+        assertEquals(7, scn.GetLSTotalPower());
 
         scn.DSPass();
 
         assertTrue(scn.LSCardActionAvailable(weapon2));
-        scn.LSUseCardAction(weapon2); //cost: 1
+        scn.LSUseCardAction(weapon2);
         assertTrue(scn.LSHasCardChoiceAvailable(executor));
         scn.LSChooseCard(executor);
+        // Second fire must not re-offer / re-apply Concentrate All Fire +3 on the same B-Wing
+        assertFalse(scn.LSDecisionAvailable("Add 3 to power"));
         scn.PassAllResponses();
+        assertFalse(scn.LSDecisionAvailable("Add 3 to power"));
 
-        // -- concentrate all fire should not add further (not cumulative)
-        assertEquals(7,scn.GetLSTotalPower());
+        assertEquals(7, scn.GetPower(bWing));
+        assertEquals(7, scn.GetLSTotalPower());
     }
 }


### PR DESCRIPTION
## Summary
Closes #38.
Closes #46.

Concentrate All Fire was adding +3 power every time a starfighter fired a weapon in the same battle (B-Wings with multiple weapons). Per ruling, each starfighter should get that bonus only once per battle. Fighter Cover (Decipher twin) shares the same trigger and gate (#46).

## Approach
Minimal card-level once-per-target-per-battle gate (no cumulative-engine rewrite):
- Before applying the until-end-of-battle +3, skip if that starfighter already has a POWER modifier sourced from this Admirals Order.
- Same gate on Fighter Cover (Decipher twin with the same trigger).
- Maul Strikes / broader cumulative-rule work left soft-hold.

## Tests
`Card_9_003_Tests` — **2 run / 0 fail / 0 skip**
- `ConcentrateAllFireStatsAndKeywordsAreCorrect`
- `ConcentrateAllFireDoesNotAddPowerTwiceToSameStarfighterInOneBattle` (multi-weapon B-Wing: first fire +3, second fire not offered/not applied; power stays 7)

`Card_9_093_Tests` — **2 run / 0 fail / 0 skip**
- `FighterCoverStatsAndKeywordsAreCorrect`
- `FighterCoverDoesNotAddPowerTwiceToSameStarfighterInOneBattle` (twin path: DS Fighter Cover + LS multi-weapon B-Wing; same once-per-starfighter gate)

Combined surefire: **4 run / 0 fail / 0 skip**

## Tip
`024e75b3bbf35d9631a5cfd6401bd0bb339fe33b`
